### PR TITLE
chore: add .editorconfig for consistent formatting (#16)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[Dockerfile]
+indent_style = tab
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.json]
+indent_size = 2


### PR DESCRIPTION
## Summary
- Add `.editorconfig` with editor-agnostic formatting standards
- UTF-8, LF line endings, language-specific indentation
- Python: 4-space, JS/YAML/JSON: 2-space, Makefile/Dockerfile: tabs
- Markdown: trailing whitespace preserved (line breaks)

## Test plan
- [ ] `.editorconfig` exists and is valid
- [ ] Editor plugins pick up settings (VS Code, JetBrains, etc.)
- [ ] No conflicts with existing Makefile tab indentation

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)