### PR TITLE
feat: pre-commit hooks for monorepo linting (#21)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Pre-commit hook for ai-movie-suggester monorepo
+# Install with: make hooks
+# Runs ruff on staged Python files, eslint+prettier on staged TS/TSX files
+# Deliberately fast — no tests or type-checking (that's CI's job)
+
+# Backend: ruff on staged Python files
+PYTHON_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '^backend/.*\.py$' || true)
+if [ -n "$PYTHON_FILES" ]; then
+  echo "🐍 Running ruff on backend..."
+  cd backend
+  uv run ruff check --fix $PYTHON_FILES
+  uv run ruff format $PYTHON_FILES
+  cd ..
+  echo $PYTHON_FILES | xargs git add
+fi
+
+# Frontend: eslint + prettier on staged TS/TSX files
+TS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '^frontend/.*\.\(ts\|tsx\)$' || true)
+if [ -n "$TS_FILES" ]; then
+  echo "📦 Running eslint + prettier on frontend..."
+  cd frontend
+  npx eslint --fix $TS_FILES
+  npx prettier --write $TS_FILES
+  cd ..
+  echo $TS_FILES | xargs git add
+fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-full dev-ui build test lint clean logs health
+.PHONY: dev dev-full dev-ui build test lint clean logs health hooks
 
 # Default dev target — full stack with Ollama
 dev: dev-full
@@ -32,6 +32,11 @@ logs:
 # Check service health
 health:
 	@curl -sf http://localhost:8000/health | python3 -m json.tool 2>/dev/null || echo "Backend not reachable"
+
+# Install pre-commit hooks
+hooks:
+	git config core.hooksPath .githooks
+	@echo "Pre-commit hooks installed (.githooks/pre-commit)"
 
 # Tear down everything including volumes
 clean:


### PR DESCRIPTION
## Summary
- Plain git hook at `.githooks/pre-commit` — no extra dependencies
- Runs **ruff** (check + format) on staged Python files in `backend/`
- Runs **eslint + prettier** on staged TS/TSX files in `frontend/`
- Only processes staged files — fast, no wasted work
- Deliberately skips tests and type-checking (too slow for hooks, that's CI's job)
- Install with `make hooks` (sets `git config core.hooksPath .githooks`)

## Design decision
Chose plain git hooks over husky + pre-commit framework because:
- Monorepo with `.git` at root, frontend in subdirectory — husky can't find `.git`
- No extra npm/pip dependencies needed
- Same tools already installed for CI (ruff via uv, eslint/prettier via npx)

## Test plan
- [ ] `make hooks` installs the hook
- [ ] Committing a Python file with formatting issues: auto-fixed by ruff
- [ ] Committing a TS file with lint issues: auto-fixed by eslint/prettier
- [ ] Hook completes in under 3 seconds
- [ ] Committing files outside backend/frontend: hook skips gracefully

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)