### PR TITLE
feat: add test user provisioning and integration test docs (#47)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,28 @@ make test
 make lint
 ```
 
+### Integration Tests
+
+Integration tests run against a real Jellyfin instance. A disposable container is provided via Docker Compose.
+
+```bash
+# Start a disposable Jellyfin for testing
+make jellyfin-up
+
+# Run integration tests (Jellyfin must be running)
+make test-integration
+
+# Full cycle: start Jellyfin, run tests, teardown
+make test-integration-full
+
+# Stop and remove the test Jellyfin
+make jellyfin-down
+```
+
+The test suite automatically completes the Jellyfin first-run wizard and provisions test users on first run. Subsequent runs are idempotent.
+
+**Prerequisites:** Docker running, port 8096 available, `uv` installed.
+
 ## Coding Standards
 
 ### Python (Backend)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -7,9 +7,18 @@ integration tests (tests/Jellyfin.Server.Integration.Tests/AuthHelper.cs).
 import asyncio
 import os
 import warnings
+from typing import NamedTuple
 
 import httpx
 import pytest_asyncio
+
+
+class JellyfinInstance(NamedTuple):
+    """Jellyfin connection info discovered during wizard setup."""
+
+    url: str
+    admin_user: str
+
 
 # ---------------------------------------------------------------------------
 # Constants — test-only, never imported outside backend/tests/integration/
@@ -48,12 +57,13 @@ def _auth_headers(token: str | None = None) -> dict[str, str]:
 # Session-scoped fixture — polls, version-checks, completes wizard
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture(scope="session")
-async def jellyfin_url() -> str:
+async def jellyfin() -> JellyfinInstance:
     """Wait for Jellyfin readiness, verify version, complete wizard if needed.
 
-    Returns the base URL of the ready Jellyfin instance.
+    Returns a JellyfinInstance with the URL and discovered admin username.
     """
     base = JELLYFIN_TEST_URL
+    admin_user = "root"
 
     async with httpx.AsyncClient() as client:
         # Phase 1: Poll for readiness
@@ -92,6 +102,11 @@ async def jellyfin_url() -> str:
         # run in-process, not in Docker.
         resp = await client.get(f"{base}/Startup/Configuration")
         if resp.status_code == 200:
+            # Discover admin username before wizard changes state
+            resp = await client.get(f"{base}/Startup/User")
+            if resp.is_success:
+                admin_user = resp.json().get("Name", "root")
+
             resp = await client.post(
                 f"{base}/Startup/Configuration",
                 json={
@@ -102,10 +117,10 @@ async def jellyfin_url() -> str:
             )
             resp.raise_for_status()
 
-            # Read default user — may return 500 in CI, wizard still completes
+            # Set admin user — may return 500 in CI, wizard still completes
             resp = await client.post(
                 f"{base}/Startup/User",
-                json={"Name": "root", "Password": TEST_ADMIN_PASS},
+                json={"Name": admin_user, "Password": TEST_ADMIN_PASS},
             )
 
             resp = await client.post(
@@ -120,30 +135,14 @@ async def jellyfin_url() -> str:
             resp = await client.post(f"{base}/Startup/Complete")
             resp.raise_for_status()
 
-    return base
-
-
-# ---------------------------------------------------------------------------
-# Session-scoped fixture — discovers the admin username
-# ---------------------------------------------------------------------------
-@pytest_asyncio.fixture(scope="session")
-async def jellyfin_admin_user(jellyfin_url: str) -> str:
-    """Discover the admin username from Jellyfin.
-
-    Returns the default admin username (typically 'root' on fresh instances).
-    """
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(f"{jellyfin_url}/Startup/User")
-        if resp.is_success:
-            return resp.json().get("Name", "root")
-    return "root"
+    return JellyfinInstance(url=base, admin_user=admin_user)
 
 
 # ---------------------------------------------------------------------------
 # Session-scoped fixture — authenticates as admin, returns access token
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture(scope="session")
-async def admin_auth_token(jellyfin_url: str, jellyfin_admin_user: str) -> str:
+async def admin_auth_token(jellyfin: JellyfinInstance) -> str:
     """Authenticate as admin and return the access token.
 
     On a fresh instance after /Startup/Complete, the default user has an
@@ -151,8 +150,8 @@ async def admin_auth_token(jellyfin_url: str, jellyfin_admin_user: str) -> str:
     Retries handle the case where auth isn't ready immediately after wizard.
     """
     credentials = [
-        (jellyfin_admin_user, TEST_ADMIN_PASS),
-        (jellyfin_admin_user, ""),
+        (jellyfin.admin_user, TEST_ADMIN_PASS),
+        (jellyfin.admin_user, ""),
     ]
     max_attempts = 10
     last_status = 0
@@ -161,7 +160,7 @@ async def admin_auth_token(jellyfin_url: str, jellyfin_admin_user: str) -> str:
         for attempt in range(max_attempts):
             for username, password in credentials:
                 resp = await client.post(
-                    f"{jellyfin_url}/Users/AuthenticateByName",
+                    f"{jellyfin.url}/Users/AuthenticateByName",
                     json={"Username": username, "Pw": password},
                     headers=_auth_headers(),
                 )
@@ -173,7 +172,7 @@ async def admin_auth_token(jellyfin_url: str, jellyfin_admin_user: str) -> str:
 
                     if password != TEST_ADMIN_PASS:
                         resp = await client.post(
-                            f"{jellyfin_url}/Users/{user_id}/Password",
+                            f"{jellyfin.url}/Users/{user_id}/Password",
                             json={
                                 "CurrentPw": password,
                                 "NewPw": TEST_ADMIN_PASS,
@@ -193,7 +192,7 @@ async def admin_auth_token(jellyfin_url: str, jellyfin_admin_user: str) -> str:
                 await asyncio.sleep(3)
 
     msg = (
-        f"Cannot authenticate as {jellyfin_admin_user} after "
+        f"Cannot authenticate as {jellyfin.admin_user} after "
         f"{max_attempts} attempts (last status: {last_status})"
     )
     raise RuntimeError(msg)
@@ -203,7 +202,9 @@ async def admin_auth_token(jellyfin_url: str, jellyfin_admin_user: str) -> str:
 # Session-scoped fixture — provisions test users (idempotent)
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture(scope="session")
-async def test_users(jellyfin_url: str, admin_auth_token: str) -> dict[str, str]:
+async def test_users(
+    jellyfin: JellyfinInstance, admin_auth_token: str
+) -> dict[str, str]:
     """Create test users if they don't exist. Returns {username: user_id}.
 
     Idempotent — safe to run against an already-provisioned instance.
@@ -215,7 +216,7 @@ async def test_users(jellyfin_url: str, admin_auth_token: str) -> dict[str, str]
     ]
 
     async with httpx.AsyncClient() as client:
-        resp = await client.get(f"{jellyfin_url}/Users", headers=headers)
+        resp = await client.get(f"{jellyfin.url}/Users", headers=headers)
         resp.raise_for_status()
         existing = {u["Name"]: u["Id"] for u in resp.json()}
 
@@ -225,7 +226,7 @@ async def test_users(jellyfin_url: str, admin_auth_token: str) -> dict[str, str]
                 created[username] = existing[username]
                 continue
             resp = await client.post(
-                f"{jellyfin_url}/Users/New",
+                f"{jellyfin.url}/Users/New",
                 json={"Name": username, "Password": password},
                 headers=headers,
             )

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -165,7 +165,17 @@ async def admin_auth_token(jellyfin_url: str) -> str:
                 break
 
         if token is None or user_id is None:
-            msg = "Cannot authenticate as admin with any known credential combination"
+            # Debug: try to discover what users exist
+            debug_info = ""
+            try:
+                r = await client.get(f"{jellyfin_url}/Startup/FirstUser")
+                debug_info += f" FirstUser={r.status_code}:{r.text}"
+            except Exception as e:
+                debug_info += f" FirstUser=error:{e}"
+            msg = (
+                "Cannot authenticate as admin with any known credential "
+                f"combination.{debug_info}"
+            )
             raise RuntimeError(msg)
 
         token_header = {

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -6,6 +6,7 @@ integration tests (tests/Jellyfin.Server.Integration.Tests/AuthHelper.cs).
 
 import asyncio
 import os
+import warnings
 
 import httpx
 import pytest_asyncio
@@ -16,10 +17,10 @@ import pytest_asyncio
 JELLYFIN_TEST_URL = os.environ.get(
     "JELLYFIN_TEST_URL", "http://host.docker.internal:8096"
 )
+# Must match the image version in docker-compose.test.yml
 EXPECTED_JELLYFIN_VERSION = "10.11.6"
 TEST_ADMIN_PASS = "test-admin-password"
 
-# Test users — known credentials for downstream permission-scoping tests
 TEST_USER_ALICE = "test-alice"
 TEST_USER_ALICE_PASS = "test-alice-password"
 
@@ -36,9 +37,6 @@ _AUTH_HEADER = (
 POLL_INTERVAL_SECONDS = 2
 POLL_TIMEOUT_SECONDS = 60
 
-# Set during wizard completion — the actual admin username on this instance
-_discovered_admin_user: str = "root"
-
 
 def _auth_headers(token: str | None = None) -> dict[str, str]:
     """Build Jellyfin Authorization header, optionally with token."""
@@ -53,9 +51,7 @@ def _auth_headers(token: str | None = None) -> dict[str, str]:
 async def jellyfin_url() -> str:
     """Wait for Jellyfin readiness, verify version, complete wizard if needed.
 
-    Follows Jellyfin's own test pattern: read default user from
-    GET /Startup/User, then POST /Startup/Complete. Skips the unreliable
-    /Startup/Configuration, /Startup/User POST, and /Startup/RemoteAccess.
+    Returns the base URL of the ready Jellyfin instance.
     """
     base = JELLYFIN_TEST_URL
 
@@ -96,12 +92,6 @@ async def jellyfin_url() -> str:
         # run in-process, not in Docker.
         resp = await client.get(f"{base}/Startup/Configuration")
         if resp.status_code == 200:
-            # Read default user before modifying anything
-            global _discovered_admin_user  # noqa: PLW0603
-            resp = await client.get(f"{base}/Startup/User")
-            resp.raise_for_status()
-            _discovered_admin_user = resp.json().get("Name", "root")
-
             resp = await client.post(
                 f"{base}/Startup/Configuration",
                 json={
@@ -112,15 +102,11 @@ async def jellyfin_url() -> str:
             )
             resp.raise_for_status()
 
-            # Set admin user — may return 500 in CI but wizard still completes
+            # Read default user — may return 500 in CI, wizard still completes
             resp = await client.post(
                 f"{base}/Startup/User",
-                json={
-                    "Name": _discovered_admin_user,
-                    "Password": TEST_ADMIN_PASS,
-                },
+                json={"Name": "root", "Password": TEST_ADMIN_PASS},
             )
-            # Don't raise — this is known to fail in CI service containers
 
             resp = await client.post(
                 f"{base}/Startup/RemoteAccess",
@@ -138,26 +124,40 @@ async def jellyfin_url() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Session-scoped fixture — discovers the admin username
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture(scope="session")
+async def jellyfin_admin_user(jellyfin_url: str) -> str:
+    """Discover the admin username from Jellyfin.
+
+    Returns the default admin username (typically 'root' on fresh instances).
+    """
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{jellyfin_url}/Startup/User")
+        if resp.is_success:
+            return resp.json().get("Name", "root")
+    return "root"
+
+
+# ---------------------------------------------------------------------------
 # Session-scoped fixture — authenticates as admin, returns access token
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture(scope="session")
-async def admin_auth_token(jellyfin_url: str) -> str:
+async def admin_auth_token(jellyfin_url: str, jellyfin_admin_user: str) -> str:
     """Authenticate as admin and return the access token.
 
-    On a fresh instance after /Startup/Complete, the default user ("root")
-    has an empty password. We authenticate, then set the expected password
-    for downstream use.
+    On a fresh instance after /Startup/Complete, the default user has an
+    empty password. We authenticate, then set the expected password.
+    Retries handle the case where auth isn't ready immediately after wizard.
     """
+    credentials = [
+        (jellyfin_admin_user, TEST_ADMIN_PASS),
+        (jellyfin_admin_user, ""),
+    ]
+    max_attempts = 10
+    last_status = 0
+
     async with httpx.AsyncClient() as client:
-        # Authenticate with retries — Jellyfin's auth subsystem may not
-        # be ready immediately after /Startup/Complete in Docker containers.
-        admin_user = _discovered_admin_user
-        credentials = [
-            (admin_user, TEST_ADMIN_PASS),  # Wizard set password or prev run
-            (admin_user, ""),  # Fresh instance, empty password
-        ]
-        max_attempts = 10
-        last_status = 0
         for attempt in range(max_attempts):
             for username, password in credentials:
                 resp = await client.post(
@@ -171,7 +171,6 @@ async def admin_auth_token(jellyfin_url: str) -> str:
                     token: str = data["AccessToken"]
                     user_id: str = data["User"]["Id"]
 
-                    # Set expected password if authenticated with empty
                     if password != TEST_ADMIN_PASS:
                         resp = await client.post(
                             f"{jellyfin_url}/Users/{user_id}/Password",
@@ -182,12 +181,10 @@ async def admin_auth_token(jellyfin_url: str) -> str:
                             headers=_auth_headers(token),
                         )
                         if not resp.is_success:
-                            import warnings
-
                             warnings.warn(
                                 f"Could not set admin password "
                                 f"(status {resp.status_code})",
-                                stacklevel=1,
+                                stacklevel=2,
                             )
 
                     return token
@@ -195,11 +192,11 @@ async def admin_auth_token(jellyfin_url: str) -> str:
             if attempt < max_attempts - 1:
                 await asyncio.sleep(3)
 
-        msg = (
-            f"Cannot authenticate as {admin_user} after "
-            f"{max_attempts} attempts (last status: {last_status})"
-        )
-        raise RuntimeError(msg)
+    msg = (
+        f"Cannot authenticate as {jellyfin_admin_user} after "
+        f"{max_attempts} attempts (last status: {last_status})"
+    )
+    raise RuntimeError(msg)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -17,6 +17,19 @@ EXPECTED_JELLYFIN_VERSION = "10.11.6"
 TEST_ADMIN_USER = "admin"
 TEST_ADMIN_PASS = "test-admin-password"
 
+# Test users — known credentials for downstream permission-scoping tests
+TEST_USER_ALICE = "test-alice"
+TEST_USER_ALICE_PASS = "test-alice-password"
+
+TEST_USER_BOB = "test-bob"
+TEST_USER_BOB_PASS = "test-bob-password"
+
+# Jellyfin client header required for authenticated API calls
+JELLYFIN_AUTH_HEADER = (
+    'MediaBrowser Client="ai-movie-suggester-tests", '
+    'Device="pytest", DeviceId="integration-test", Version="0.0.0"'
+)
+
 POLL_INTERVAL_SECONDS = 2
 POLL_TIMEOUT_SECONDS = 60
 
@@ -107,3 +120,59 @@ async def jellyfin_url() -> str:
             resp.raise_for_status()
 
     return base
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped fixture — authenticates as admin, returns access token
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture(scope="session")
+async def admin_auth_token(jellyfin_url: str) -> str:
+    """Authenticate as the admin user and return the access token."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{jellyfin_url}/Users/AuthenticateByName",
+            json={"Username": TEST_ADMIN_USER, "Pw": TEST_ADMIN_PASS},
+            headers={"X-Emby-Authorization": JELLYFIN_AUTH_HEADER},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        token: str = data["AccessToken"]
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped fixture — provisions test users (idempotent)
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture(scope="session")
+async def test_users(jellyfin_url: str, admin_auth_token: str) -> dict[str, str]:
+    """Create test users if they don't exist. Returns {username: user_id}.
+
+    Idempotent — safe to run against an already-provisioned instance.
+    """
+    auth_headers = {
+        "X-Emby-Authorization": (f'{JELLYFIN_AUTH_HEADER}, Token="{admin_auth_token}"'),
+    }
+    users_to_create = [
+        (TEST_USER_ALICE, TEST_USER_ALICE_PASS),
+        (TEST_USER_BOB, TEST_USER_BOB_PASS),
+    ]
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(f"{jellyfin_url}/Users", headers=auth_headers)
+        resp.raise_for_status()
+        existing = {u["Name"]: u["Id"] for u in resp.json()}
+
+        created: dict[str, str] = {}
+        for username, password in users_to_create:
+            if username in existing:
+                created[username] = existing[username]
+                continue
+            resp = await client.post(
+                f"{jellyfin_url}/Users/New",
+                json={"Name": username, "Password": password},
+                headers=auth_headers,
+            )
+            resp.raise_for_status()
+            created[username] = resp.json()["Id"]
+
+    return created

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -134,7 +134,14 @@ async def admin_auth_token(jellyfin_url: str) -> str:
     creating "admin" with the expected password. Tries multiple username/
     password combinations and normalizes to expected credentials.
     """
-    auth_header = {"X-Emby-Authorization": JELLYFIN_AUTH_HEADER}
+    # Jellyfin may need a moment after wizard completion before auth works
+    await asyncio.sleep(2)
+
+    # Try both header styles — Jellyfin versions vary
+    header_styles = [
+        {"X-Emby-Authorization": JELLYFIN_AUTH_HEADER},
+        {"Authorization": JELLYFIN_AUTH_HEADER},
+    ]
 
     # Candidates: (username, password) in priority order
     candidates = [
@@ -149,33 +156,31 @@ async def admin_auth_token(jellyfin_url: str) -> str:
         user_id: str | None = None
         matched_user: str | None = None
         matched_pass: str | None = None
+        debug_attempts: list[str] = []
 
-        for username, password in candidates:
-            resp = await client.post(
-                f"{jellyfin_url}/Users/AuthenticateByName",
-                json={"Username": username, "Pw": password},
-                headers=auth_header,
-            )
-            if resp.is_success:
-                data = resp.json()
-                token = data["AccessToken"]
-                user_id = data["User"]["Id"]
-                matched_user = username
-                matched_pass = password
+        for headers in header_styles:
+            for username, password in candidates:
+                resp = await client.post(
+                    f"{jellyfin_url}/Users/AuthenticateByName",
+                    json={"Username": username, "Pw": password},
+                    headers=headers,
+                )
+                hdr = "X-Emby" if "X-Emby-Authorization" in headers else "Auth"
+                debug_attempts.append(
+                    f"{username}/{password!r} {hdr} → {resp.status_code}"
+                )
+                if resp.is_success:
+                    data = resp.json()
+                    token = data["AccessToken"]
+                    user_id = data["User"]["Id"]
+                    matched_user = username
+                    matched_pass = password
+                    break
+            if token is not None:
                 break
 
         if token is None or user_id is None:
-            # Debug: try to discover what users exist
-            debug_info = ""
-            try:
-                r = await client.get(f"{jellyfin_url}/Startup/FirstUser")
-                debug_info += f" FirstUser={r.status_code}:{r.text}"
-            except Exception as e:
-                debug_info += f" FirstUser=error:{e}"
-            msg = (
-                "Cannot authenticate as admin with any known credential "
-                f"combination.{debug_info}"
-            )
+            msg = "Cannot authenticate as admin. Attempts: " + "; ".join(debug_attempts)
             raise RuntimeError(msg)
 
         token_header = {

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -36,6 +36,9 @@ _AUTH_HEADER = (
 POLL_INTERVAL_SECONDS = 2
 POLL_TIMEOUT_SECONDS = 60
 
+# Set during wizard completion — the actual admin username on this instance
+_discovered_admin_user: str = "root"
+
 
 def _auth_headers(token: str | None = None) -> dict[str, str]:
     """Build Jellyfin Authorization header, optionally with token."""
@@ -88,9 +91,46 @@ async def jellyfin_url() -> str:
             raise AssertionError(msg)
 
         # Phase 3: Complete first-run wizard (idempotent)
-        # Pattern from Jellyfin's AuthHelper.cs: just POST /Startup/Complete.
+        # Docker service containers need the full wizard sequence for auth
+        # to work. Jellyfin's own tests use just /Startup/Complete but they
+        # run in-process, not in Docker.
         resp = await client.get(f"{base}/Startup/Configuration")
         if resp.status_code == 200:
+            # Read default user before modifying anything
+            global _discovered_admin_user  # noqa: PLW0603
+            resp = await client.get(f"{base}/Startup/User")
+            resp.raise_for_status()
+            _discovered_admin_user = resp.json().get("Name", "root")
+
+            resp = await client.post(
+                f"{base}/Startup/Configuration",
+                json={
+                    "UICulture": "en-US",
+                    "MetadataCountryCode": "US",
+                    "PreferredMetadataLanguage": "en",
+                },
+            )
+            resp.raise_for_status()
+
+            # Set admin user — may return 500 in CI but wizard still completes
+            resp = await client.post(
+                f"{base}/Startup/User",
+                json={
+                    "Name": _discovered_admin_user,
+                    "Password": TEST_ADMIN_PASS,
+                },
+            )
+            # Don't raise — this is known to fail in CI service containers
+
+            resp = await client.post(
+                f"{base}/Startup/RemoteAccess",
+                json={
+                    "EnableRemoteAccess": True,
+                    "EnableAutomaticPortMapping": False,
+                },
+            )
+            resp.raise_for_status()
+
             resp = await client.post(f"{base}/Startup/Complete")
             resp.raise_for_status()
 
@@ -109,16 +149,12 @@ async def admin_auth_token(jellyfin_url: str) -> str:
     for downstream use.
     """
     async with httpx.AsyncClient() as client:
-        # Discover the default admin username (typically "root")
-        # Try /Startup/User first (available before auth is needed)
-        resp = await client.get(f"{jellyfin_url}/Startup/User")
-        default_user = resp.json().get("Name", "root") if resp.is_success else "root"
-
         # Authenticate with retries — Jellyfin's auth subsystem may not
         # be ready immediately after /Startup/Complete in Docker containers.
+        admin_user = _discovered_admin_user
         credentials = [
-            (default_user, TEST_ADMIN_PASS),  # Previous run set password
-            (default_user, ""),  # Fresh instance, empty password
+            (admin_user, TEST_ADMIN_PASS),  # Wizard set password or prev run
+            (admin_user, ""),  # Fresh instance, empty password
         ]
         max_attempts = 10
         last_status = 0
@@ -160,7 +196,7 @@ async def admin_auth_token(jellyfin_url: str) -> str:
                 await asyncio.sleep(3)
 
         msg = (
-            f"Cannot authenticate as {default_user} after "
+            f"Cannot authenticate as {admin_user} after "
             f"{max_attempts} attempts (last status: {last_status})"
         )
         raise RuntimeError(msg)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -130,53 +130,74 @@ async def admin_auth_token(jellyfin_url: str) -> str:
     """Authenticate as the admin user and return the access token.
 
     Handles the Jellyfin 10.11.6 quirk where POST /Startup/User may fail,
-    leaving the default root user with an empty password. If the expected
-    password fails, falls back to empty password and sets the expected one.
+    leaving the default "root" user with an empty password instead of
+    creating "admin" with the expected password. Tries multiple username/
+    password combinations and normalizes to expected credentials.
     """
     auth_header = {"X-Emby-Authorization": JELLYFIN_AUTH_HEADER}
 
-    async with httpx.AsyncClient() as client:
-        # Try expected password first
-        resp = await client.post(
-            f"{jellyfin_url}/Users/AuthenticateByName",
-            json={"Username": TEST_ADMIN_USER, "Pw": TEST_ADMIN_PASS},
-            headers=auth_header,
-        )
-        if resp.is_success:
-            return resp.json()["AccessToken"]
+    # Candidates: (username, password) in priority order
+    candidates = [
+        (TEST_ADMIN_USER, TEST_ADMIN_PASS),  # Happy path: wizard worked
+        (TEST_ADMIN_USER, ""),  # Wizard renamed user but no password
+        ("root", ""),  # Default Jellyfin user, wizard POST failed
+        ("root", TEST_ADMIN_PASS),  # Previous run set password on root
+    ]
 
-        # Fallback: try empty password (Jellyfin default for fresh root)
-        resp = await client.post(
-            f"{jellyfin_url}/Users/AuthenticateByName",
-            json={"Username": TEST_ADMIN_USER, "Pw": ""},
-            headers=auth_header,
-        )
-        if not resp.is_success:
-            msg = (
-                f"Cannot authenticate as {TEST_ADMIN_USER} with expected "
-                f"or empty password (status {resp.status_code})"
+    async with httpx.AsyncClient() as client:
+        token: str | None = None
+        user_id: str | None = None
+        matched_user: str | None = None
+        matched_pass: str | None = None
+
+        for username, password in candidates:
+            resp = await client.post(
+                f"{jellyfin_url}/Users/AuthenticateByName",
+                json={"Username": username, "Pw": password},
+                headers=auth_header,
             )
+            if resp.is_success:
+                data = resp.json()
+                token = data["AccessToken"]
+                user_id = data["User"]["Id"]
+                matched_user = username
+                matched_pass = password
+                break
+
+        if token is None or user_id is None:
+            msg = "Cannot authenticate as admin with any known credential combination"
             raise RuntimeError(msg)
 
-        data = resp.json()
-        token: str = data["AccessToken"]
-        user_id: str = data["User"]["Id"]
-
-        # Set the expected password so future runs work with either path
         token_header = {
             "X-Emby-Authorization": f'{JELLYFIN_AUTH_HEADER}, Token="{token}"',
         }
-        resp = await client.post(
-            f"{jellyfin_url}/Users/{user_id}/Password",
-            json={"CurrentPw": "", "NewPw": TEST_ADMIN_PASS},
-            headers=token_header,
-        )
-        if not resp.is_success:
-            warnings.warn(
-                f"Failed to set admin password (status {resp.status_code}), "
-                f"continuing with empty password auth",
-                stacklevel=1,
+
+        # Rename user to expected name if needed
+        if matched_user != TEST_ADMIN_USER:
+            resp = await client.post(
+                f"{jellyfin_url}/Users/{user_id}",
+                json={"Name": TEST_ADMIN_USER},
+                headers=token_header,
             )
+            if not resp.is_success:
+                warnings.warn(
+                    f"Could not rename {matched_user} to {TEST_ADMIN_USER} "
+                    f"(status {resp.status_code})",
+                    stacklevel=1,
+                )
+
+        # Set expected password if needed
+        if matched_pass != TEST_ADMIN_PASS:
+            resp = await client.post(
+                f"{jellyfin_url}/Users/{user_id}/Password",
+                json={"CurrentPw": matched_pass, "NewPw": TEST_ADMIN_PASS},
+                headers=token_header,
+            )
+            if not resp.is_success:
+                warnings.warn(
+                    f"Could not set admin password (status {resp.status_code})",
+                    stacklevel=1,
+                )
 
     return token
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -127,16 +127,57 @@ async def jellyfin_url() -> str:
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture(scope="session")
 async def admin_auth_token(jellyfin_url: str) -> str:
-    """Authenticate as the admin user and return the access token."""
+    """Authenticate as the admin user and return the access token.
+
+    Handles the Jellyfin 10.11.6 quirk where POST /Startup/User may fail,
+    leaving the default root user with an empty password. If the expected
+    password fails, falls back to empty password and sets the expected one.
+    """
+    auth_header = {"X-Emby-Authorization": JELLYFIN_AUTH_HEADER}
+
     async with httpx.AsyncClient() as client:
+        # Try expected password first
         resp = await client.post(
             f"{jellyfin_url}/Users/AuthenticateByName",
             json={"Username": TEST_ADMIN_USER, "Pw": TEST_ADMIN_PASS},
-            headers={"X-Emby-Authorization": JELLYFIN_AUTH_HEADER},
+            headers=auth_header,
         )
-        resp.raise_for_status()
+        if resp.is_success:
+            return resp.json()["AccessToken"]
+
+        # Fallback: try empty password (Jellyfin default for fresh root)
+        resp = await client.post(
+            f"{jellyfin_url}/Users/AuthenticateByName",
+            json={"Username": TEST_ADMIN_USER, "Pw": ""},
+            headers=auth_header,
+        )
+        if not resp.is_success:
+            msg = (
+                f"Cannot authenticate as {TEST_ADMIN_USER} with expected "
+                f"or empty password (status {resp.status_code})"
+            )
+            raise RuntimeError(msg)
+
         data = resp.json()
         token: str = data["AccessToken"]
+        user_id: str = data["User"]["Id"]
+
+        # Set the expected password so future runs work with either path
+        token_header = {
+            "X-Emby-Authorization": f'{JELLYFIN_AUTH_HEADER}, Token="{token}"',
+        }
+        resp = await client.post(
+            f"{jellyfin_url}/Users/{user_id}/Password",
+            json={"CurrentPw": "", "NewPw": TEST_ADMIN_PASS},
+            headers=token_header,
+        )
+        if not resp.is_success:
+            warnings.warn(
+                f"Failed to set admin password (status {resp.status_code}), "
+                f"continuing with empty password auth",
+                stacklevel=1,
+            )
+
     return token
 
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -114,43 +114,55 @@ async def admin_auth_token(jellyfin_url: str) -> str:
         resp = await client.get(f"{jellyfin_url}/Startup/User")
         default_user = resp.json().get("Name", "root") if resp.is_success else "root"
 
-        # Authenticate — try expected creds first, then default empty password
-        for username, password in [
+        # Authenticate with retries — Jellyfin's auth subsystem may not
+        # be ready immediately after /Startup/Complete in Docker containers.
+        credentials = [
             (default_user, TEST_ADMIN_PASS),  # Previous run set password
             (default_user, ""),  # Fresh instance, empty password
-        ]:
-            resp = await client.post(
-                f"{jellyfin_url}/Users/AuthenticateByName",
-                json={"Username": username, "Pw": password},
-                headers=_auth_headers(),
-            )
-            if resp.is_success:
-                data = resp.json()
-                token: str = data["AccessToken"]
-                user_id: str = data["User"]["Id"]
+        ]
+        max_attempts = 10
+        last_status = 0
+        for attempt in range(max_attempts):
+            for username, password in credentials:
+                resp = await client.post(
+                    f"{jellyfin_url}/Users/AuthenticateByName",
+                    json={"Username": username, "Pw": password},
+                    headers=_auth_headers(),
+                )
+                last_status = resp.status_code
+                if resp.is_success:
+                    data = resp.json()
+                    token: str = data["AccessToken"]
+                    user_id: str = data["User"]["Id"]
 
-                # Set expected password if authenticated with empty
-                if password != TEST_ADMIN_PASS:
-                    resp = await client.post(
-                        f"{jellyfin_url}/Users/{user_id}/Password",
-                        json={
-                            "CurrentPw": password,
-                            "NewPw": TEST_ADMIN_PASS,
-                        },
-                        headers=_auth_headers(token),
-                    )
-                    # Non-fatal — password change may fail but auth works
-                    if not resp.is_success:
-                        import warnings
-
-                        warnings.warn(
-                            f"Could not set admin password (status {resp.status_code})",
-                            stacklevel=1,
+                    # Set expected password if authenticated with empty
+                    if password != TEST_ADMIN_PASS:
+                        resp = await client.post(
+                            f"{jellyfin_url}/Users/{user_id}/Password",
+                            json={
+                                "CurrentPw": password,
+                                "NewPw": TEST_ADMIN_PASS,
+                            },
+                            headers=_auth_headers(token),
                         )
+                        if not resp.is_success:
+                            import warnings
 
-                return token
+                            warnings.warn(
+                                f"Could not set admin password "
+                                f"(status {resp.status_code})",
+                                stacklevel=1,
+                            )
 
-        msg = f"Cannot authenticate as {default_user} with any known password"
+                    return token
+
+            if attempt < max_attempts - 1:
+                await asyncio.sleep(3)
+
+        msg = (
+            f"Cannot authenticate as {default_user} after "
+            f"{max_attempts} attempts (last status: {last_status})"
+        )
         raise RuntimeError(msg)
 
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,8 +1,11 @@
-"""Integration test fixtures — Jellyfin provisioning and readiness."""
+"""Integration test fixtures — Jellyfin provisioning and readiness.
+
+Wizard completion and auth follow the pattern from Jellyfin's own
+integration tests (tests/Jellyfin.Server.Integration.Tests/AuthHelper.cs).
+"""
 
 import asyncio
 import os
-import warnings
 
 import httpx
 import pytest_asyncio
@@ -14,7 +17,6 @@ JELLYFIN_TEST_URL = os.environ.get(
     "JELLYFIN_TEST_URL", "http://host.docker.internal:8096"
 )
 EXPECTED_JELLYFIN_VERSION = "10.11.6"
-TEST_ADMIN_USER = "admin"
 TEST_ADMIN_PASS = "test-admin-password"
 
 # Test users — known credentials for downstream permission-scoping tests
@@ -24,14 +26,21 @@ TEST_USER_ALICE_PASS = "test-alice-password"
 TEST_USER_BOB = "test-bob"
 TEST_USER_BOB_PASS = "test-bob-password"
 
-# Jellyfin client header required for authenticated API calls
-JELLYFIN_AUTH_HEADER = (
+# Auth header format matching Jellyfin's own integration tests.
+# Uses "Authorization" (not "X-Emby-Authorization") and no quotes on Token.
+_AUTH_HEADER = (
     'MediaBrowser Client="ai-movie-suggester-tests", '
-    'Device="pytest", DeviceId="integration-test", Version="0.0.0"'
+    'DeviceId="integration-test", Device="pytest", Version="0.0.0"'
 )
 
 POLL_INTERVAL_SECONDS = 2
 POLL_TIMEOUT_SECONDS = 60
+
+
+def _auth_headers(token: str | None = None) -> dict[str, str]:
+    """Build Jellyfin Authorization header, optionally with token."""
+    value = _AUTH_HEADER if token is None else f"{_AUTH_HEADER}, Token={token}"
+    return {"Authorization": value}
 
 
 # ---------------------------------------------------------------------------
@@ -41,7 +50,9 @@ POLL_TIMEOUT_SECONDS = 60
 async def jellyfin_url() -> str:
     """Wait for Jellyfin readiness, verify version, complete wizard if needed.
 
-    Returns the base URL of the ready Jellyfin instance.
+    Follows Jellyfin's own test pattern: read default user from
+    GET /Startup/User, then POST /Startup/Complete. Skips the unreliable
+    /Startup/Configuration, /Startup/User POST, and /Startup/RemoteAccess.
     """
     base = JELLYFIN_TEST_URL
 
@@ -77,45 +88,9 @@ async def jellyfin_url() -> str:
             raise AssertionError(msg)
 
         # Phase 3: Complete first-run wizard (idempotent)
+        # Pattern from Jellyfin's AuthHelper.cs: just POST /Startup/Complete.
         resp = await client.get(f"{base}/Startup/Configuration")
         if resp.status_code == 200:
-            # Wizard not yet completed — run through the 4-step sequence
-            resp = await client.post(
-                f"{base}/Startup/Configuration",
-                json={
-                    "UICulture": "en-US",
-                    "MetadataCountryCode": "US",
-                    "PreferredMetadataLanguage": "en",
-                },
-            )
-            resp.raise_for_status()
-
-            # POST /Startup/User returns 500 on Jellyfin 10.11.6 when the
-            # internal user database isn't fully initialized. The wizard
-            # still completes without it, so we log but don't fail.
-            resp = await client.post(
-                f"{base}/Startup/User",
-                json={
-                    "Name": TEST_ADMIN_USER,
-                    "Password": TEST_ADMIN_PASS,
-                },
-            )
-            if not resp.is_success:
-                warnings.warn(
-                    f"POST /Startup/User returned {resp.status_code} "
-                    f"(known Jellyfin 10.11.6 quirk, wizard still completes)",
-                    stacklevel=1,
-                )
-
-            resp = await client.post(
-                f"{base}/Startup/RemoteAccess",
-                json={
-                    "EnableRemoteAccess": True,
-                    "EnableAutomaticPortMapping": False,
-                },
-            )
-            resp.raise_for_status()
-
             resp = await client.post(f"{base}/Startup/Complete")
             resp.raise_for_status()
 
@@ -127,94 +102,56 @@ async def jellyfin_url() -> str:
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture(scope="session")
 async def admin_auth_token(jellyfin_url: str) -> str:
-    """Authenticate as the admin user and return the access token.
+    """Authenticate as admin and return the access token.
 
-    Handles the Jellyfin 10.11.6 quirk where POST /Startup/User may fail,
-    leaving the default "root" user with an empty password instead of
-    creating "admin" with the expected password. Tries multiple username/
-    password combinations and normalizes to expected credentials.
+    On a fresh instance after /Startup/Complete, the default user ("root")
+    has an empty password. We authenticate, then set the expected password
+    for downstream use.
     """
-    # Jellyfin may need a moment after wizard completion before auth works
-    await asyncio.sleep(2)
-
-    # Try both header styles — Jellyfin versions vary
-    header_styles = [
-        {"X-Emby-Authorization": JELLYFIN_AUTH_HEADER},
-        {"Authorization": JELLYFIN_AUTH_HEADER},
-    ]
-
-    # Candidates: (username, password) in priority order
-    candidates = [
-        (TEST_ADMIN_USER, TEST_ADMIN_PASS),  # Happy path: wizard worked
-        (TEST_ADMIN_USER, ""),  # Wizard renamed user but no password
-        ("root", ""),  # Default Jellyfin user, wizard POST failed
-        ("root", TEST_ADMIN_PASS),  # Previous run set password on root
-    ]
-
     async with httpx.AsyncClient() as client:
-        token: str | None = None
-        user_id: str | None = None
-        matched_user: str | None = None
-        matched_pass: str | None = None
-        debug_attempts: list[str] = []
+        # Discover the default admin username (typically "root")
+        # Try /Startup/User first (available before auth is needed)
+        resp = await client.get(f"{jellyfin_url}/Startup/User")
+        default_user = resp.json().get("Name", "root") if resp.is_success else "root"
 
-        for headers in header_styles:
-            for username, password in candidates:
-                resp = await client.post(
-                    f"{jellyfin_url}/Users/AuthenticateByName",
-                    json={"Username": username, "Pw": password},
-                    headers=headers,
-                )
-                hdr = "X-Emby" if "X-Emby-Authorization" in headers else "Auth"
-                debug_attempts.append(
-                    f"{username}/{password!r} {hdr} → {resp.status_code}"
-                )
-                if resp.is_success:
-                    data = resp.json()
-                    token = data["AccessToken"]
-                    user_id = data["User"]["Id"]
-                    matched_user = username
-                    matched_pass = password
-                    break
-            if token is not None:
-                break
-
-        if token is None or user_id is None:
-            msg = "Cannot authenticate as admin. Attempts: " + "; ".join(debug_attempts)
-            raise RuntimeError(msg)
-
-        token_header = {
-            "X-Emby-Authorization": f'{JELLYFIN_AUTH_HEADER}, Token="{token}"',
-        }
-
-        # Rename user to expected name if needed
-        if matched_user != TEST_ADMIN_USER:
+        # Authenticate — try expected creds first, then default empty password
+        for username, password in [
+            (default_user, TEST_ADMIN_PASS),  # Previous run set password
+            (default_user, ""),  # Fresh instance, empty password
+        ]:
             resp = await client.post(
-                f"{jellyfin_url}/Users/{user_id}",
-                json={"Name": TEST_ADMIN_USER},
-                headers=token_header,
+                f"{jellyfin_url}/Users/AuthenticateByName",
+                json={"Username": username, "Pw": password},
+                headers=_auth_headers(),
             )
-            if not resp.is_success:
-                warnings.warn(
-                    f"Could not rename {matched_user} to {TEST_ADMIN_USER} "
-                    f"(status {resp.status_code})",
-                    stacklevel=1,
-                )
+            if resp.is_success:
+                data = resp.json()
+                token: str = data["AccessToken"]
+                user_id: str = data["User"]["Id"]
 
-        # Set expected password if needed
-        if matched_pass != TEST_ADMIN_PASS:
-            resp = await client.post(
-                f"{jellyfin_url}/Users/{user_id}/Password",
-                json={"CurrentPw": matched_pass, "NewPw": TEST_ADMIN_PASS},
-                headers=token_header,
-            )
-            if not resp.is_success:
-                warnings.warn(
-                    f"Could not set admin password (status {resp.status_code})",
-                    stacklevel=1,
-                )
+                # Set expected password if authenticated with empty
+                if password != TEST_ADMIN_PASS:
+                    resp = await client.post(
+                        f"{jellyfin_url}/Users/{user_id}/Password",
+                        json={
+                            "CurrentPw": password,
+                            "NewPw": TEST_ADMIN_PASS,
+                        },
+                        headers=_auth_headers(token),
+                    )
+                    # Non-fatal — password change may fail but auth works
+                    if not resp.is_success:
+                        import warnings
 
-    return token
+                        warnings.warn(
+                            f"Could not set admin password (status {resp.status_code})",
+                            stacklevel=1,
+                        )
+
+                return token
+
+        msg = f"Cannot authenticate as {default_user} with any known password"
+        raise RuntimeError(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -226,16 +163,14 @@ async def test_users(jellyfin_url: str, admin_auth_token: str) -> dict[str, str]
 
     Idempotent — safe to run against an already-provisioned instance.
     """
-    auth_headers = {
-        "X-Emby-Authorization": (f'{JELLYFIN_AUTH_HEADER}, Token="{admin_auth_token}"'),
-    }
+    headers = _auth_headers(admin_auth_token)
     users_to_create = [
         (TEST_USER_ALICE, TEST_USER_ALICE_PASS),
         (TEST_USER_BOB, TEST_USER_BOB_PASS),
     ]
 
     async with httpx.AsyncClient() as client:
-        resp = await client.get(f"{jellyfin_url}/Users", headers=auth_headers)
+        resp = await client.get(f"{jellyfin_url}/Users", headers=headers)
         resp.raise_for_status()
         existing = {u["Name"]: u["Id"] for u in resp.json()}
 
@@ -247,7 +182,7 @@ async def test_users(jellyfin_url: str, admin_auth_token: str) -> dict[str, str]
             resp = await client.post(
                 f"{jellyfin_url}/Users/New",
                 json={"Name": username, "Password": password},
-                headers=auth_headers,
+                headers=headers,
             )
             resp.raise_for_status()
             created[username] = resp.json()["Id"]

--- a/backend/tests/integration/test_smoke.py
+++ b/backend/tests/integration/test_smoke.py
@@ -1,21 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import httpx
 import pytest
 
+if TYPE_CHECKING:
+    from tests.integration.conftest import JellyfinInstance
+
 
 @pytest.mark.integration
-async def test_jellyfin_health(jellyfin_url: str) -> None:
+async def test_jellyfin_health(jellyfin: JellyfinInstance) -> None:
     """Verify Jellyfin is reachable and returns a healthy status."""
     async with httpx.AsyncClient() as client:
-        resp = await client.get(f"{jellyfin_url}/health")
+        resp = await client.get(f"{jellyfin.url}/health")
     assert resp.status_code == 200
     assert resp.text == "Healthy"
 
 
 @pytest.mark.integration
-async def test_jellyfin_wizard_complete(jellyfin_url: str) -> None:
+async def test_jellyfin_wizard_complete(jellyfin: JellyfinInstance) -> None:
     """Verify the first-run wizard has been completed."""
     async with httpx.AsyncClient() as client:
-        resp = await client.get(f"{jellyfin_url}/System/Info/Public")
+        resp = await client.get(f"{jellyfin.url}/System/Info/Public")
     assert resp.status_code == 200
     data = resp.json()
     assert "Version" in data

--- a/backend/tests/integration/test_smoke.py
+++ b/backend/tests/integration/test_smoke.py
@@ -33,10 +33,8 @@ async def test_admin_authentication(admin_auth_token: str) -> None:
 @pytest.mark.integration
 async def test_test_users_provisioned(test_users: dict[str, str]) -> None:
     """Verify test users exist with expected names and valid IDs."""
-    from tests.integration.conftest import TEST_USER_ALICE, TEST_USER_BOB
-
-    assert TEST_USER_ALICE in test_users
-    assert TEST_USER_BOB in test_users
+    assert "test-alice" in test_users
+    assert "test-bob" in test_users
     for user_id in test_users.values():
         assert isinstance(user_id, str)
         assert len(user_id) > 0

--- a/backend/tests/integration/test_smoke.py
+++ b/backend/tests/integration/test_smoke.py
@@ -21,3 +21,22 @@ async def test_jellyfin_wizard_complete(jellyfin_url: str) -> None:
     assert "Version" in data
     assert "StartupWizardCompleted" in data
     assert data["StartupWizardCompleted"] is True
+
+
+@pytest.mark.integration
+async def test_admin_authentication(admin_auth_token: str) -> None:
+    """Verify the admin user can authenticate and receives a token."""
+    assert isinstance(admin_auth_token, str)
+    assert len(admin_auth_token) > 0
+
+
+@pytest.mark.integration
+async def test_test_users_provisioned(test_users: dict[str, str]) -> None:
+    """Verify test users exist with expected names and valid IDs."""
+    from tests.integration.conftest import TEST_USER_ALICE, TEST_USER_BOB
+
+    assert TEST_USER_ALICE in test_users
+    assert TEST_USER_BOB in test_users
+    for user_id in test_users.values():
+        assert isinstance(user_id, str)
+        assert len(user_id) > 0


### PR DESCRIPTION
## Summary

- Add idempotent test user provisioning to integration fixture (Alice + Bob)
- Admin auth fixture: authenticates via `POST /Users/AuthenticateByName`
- User creation fixture: creates users via `POST /Users/New` (skips if exists)
- Two new smoke tests: `test_admin_authentication`, `test_test_users_provisioned`
- Add integration test documentation to CLAUDE.md

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] Unit tests pass (2 passed, 4 deselected)
- [ ] `make test-integration-full` — 4 integration tests pass (requires Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)