### PR TITLE
feat: Jellyfin API client with MediaBrowser auth (#28)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,6 @@ SESSION_EXPIRY_HOURS=24
 
 # Rate limit for chat endpoint (requests per minute per user)
 CHAT_RATE_LIMIT=10
+
+# Timeout for Jellyfin API requests in seconds (default: 10)
+JELLYFIN_TIMEOUT=10.0

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,8 @@ coverage/
 # Build artifacts
 *.log
 
+# Git worktrees
+.worktrees/
+
 # SDD workflow artifacts — point-in-time, kept locally only
 docs/specs/

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
 
     # Required
     jellyfin_url: str
+    jellyfin_timeout: float = 10.0
     session_secret: Annotated[str, Field(min_length=32)]
 
     # Ollama

--- a/backend/app/jellyfin/__init__.py
+++ b/backend/app/jellyfin/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from app.jellyfin.client import JellyfinClient
 from app.jellyfin.errors import (
     JellyfinAuthError,
     JellyfinConnectionError,
@@ -12,6 +13,7 @@ from app.jellyfin.models import AuthResult, LibraryItem, PaginatedItems, UserInf
 __all__ = [
     "AuthResult",
     "JellyfinAuthError",
+    "JellyfinClient",
     "JellyfinConnectionError",
     "JellyfinError",
     "LibraryItem",

--- a/backend/app/jellyfin/__init__.py
+++ b/backend/app/jellyfin/__init__.py
@@ -1,0 +1,15 @@
+"""Jellyfin API client package."""
+
+from __future__ import annotations
+
+from app.jellyfin.errors import (
+    JellyfinAuthError,
+    JellyfinConnectionError,
+    JellyfinError,
+)
+
+__all__ = [
+    "JellyfinAuthError",
+    "JellyfinConnectionError",
+    "JellyfinError",
+]

--- a/backend/app/jellyfin/__init__.py
+++ b/backend/app/jellyfin/__init__.py
@@ -7,9 +7,14 @@ from app.jellyfin.errors import (
     JellyfinConnectionError,
     JellyfinError,
 )
+from app.jellyfin.models import AuthResult, LibraryItem, PaginatedItems, UserInfo
 
 __all__ = [
+    "AuthResult",
     "JellyfinAuthError",
     "JellyfinConnectionError",
     "JellyfinError",
+    "LibraryItem",
+    "PaginatedItems",
+    "UserInfo",
 ]

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -1,0 +1,49 @@
+"""Async HTTP client for the Jellyfin API.
+
+Uses an injected httpx.AsyncClient for connection pooling and testability.
+MediaBrowser authorization headers follow Jellyfin's own integration test
+format (Authorization header, not X-Emby-Authorization; no quotes on Token).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import httpx
+
+logger = logging.getLogger(__name__)
+
+_APP_NAME = "ai-movie-suggester"
+_APP_VERSION = "0.1.0"
+_DEVICE = "Server"
+_DEFAULT_DEVICE_ID = "ai-movie-suggester-server"
+
+
+class JellyfinClient:
+    """Async client for the Jellyfin REST API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        http_client: httpx.AsyncClient,
+        device_id: str = _DEFAULT_DEVICE_ID,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = http_client
+        self._auth_value = (
+            f'MediaBrowser Client="{_APP_NAME}", '
+            f'Device="{_DEVICE}", '
+            f'DeviceId="{device_id}", '
+            f'Version="{_APP_VERSION}"'
+        )
+
+    def _headers(self, token: str | None = None) -> dict[str, str]:
+        """Build Jellyfin Authorization header, optionally with token."""
+        value = (
+            self._auth_value
+            if token is None
+            else f"{self._auth_value}, Token={token}"
+        )
+        return {"Authorization": value}

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -8,9 +8,12 @@ format (Authorization header, not X-Emby-Authorization; no quotes on Token).
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from app.jellyfin.errors import (
     JellyfinAuthError,
@@ -20,6 +23,8 @@ from app.jellyfin.errors import (
 from app.jellyfin.models import AuthResult, PaginatedItems, UserInfo
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
 
 _APP_NAME = "ai-movie-suggester"
 _APP_VERSION = "0.1.0"
@@ -95,6 +100,18 @@ class JellyfinClient:
 
         return resp
 
+    @staticmethod
+    def _parse_response(resp: httpx.Response, parser: Callable[..., _T]) -> _T:
+        """Decode JSON and parse via *parser*, wrapping errors as JellyfinError."""
+        try:
+            data = resp.json()
+        except Exception as exc:
+            raise JellyfinError("Invalid JSON in Jellyfin response") from exc
+        try:
+            return parser(data)
+        except Exception as exc:
+            raise JellyfinError("Unexpected response shape from Jellyfin") from exc
+
     async def authenticate(self, username: str, password: str) -> AuthResult:
         """Authenticate a user against Jellyfin.
 
@@ -112,7 +129,7 @@ class JellyfinClient:
             json={"Username": username, "Pw": password},
             auth_error_message="Invalid username or password",
         )
-        return AuthResult.from_jellyfin(resp.json())
+        return self._parse_response(resp, AuthResult.from_jellyfin)
 
     async def get_user(self, token: str) -> UserInfo:
         """Get the current user's info. Validates the token is still active.
@@ -122,7 +139,7 @@ class JellyfinClient:
         Raises JellyfinConnectionError if Jellyfin is unreachable.
         """
         resp = await self._request("GET", "/Users/Me", token=token)
-        return UserInfo.model_validate(resp.json())
+        return self._parse_response(resp, UserInfo.model_validate)
 
     async def get_items(
         self,
@@ -155,4 +172,4 @@ class JellyfinClient:
             token=token,
             params=params,
         )
-        return PaginatedItems.model_validate(resp.json())
+        return self._parse_response(resp, PaginatedItems.model_validate)

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -8,6 +8,7 @@ format (Authorization header, not X-Emby-Authorization; no quotes on Token).
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import httpx
 
@@ -24,6 +25,8 @@ _APP_NAME = "ai-movie-suggester"
 _APP_VERSION = "0.1.0"
 _DEVICE = "Server"
 _DEFAULT_DEVICE_ID = "ai-movie-suggester-server"
+# Fields to request from Jellyfin — matches our LibraryItem model
+_ITEM_FIELDS = "Overview,Genres,ProductionYear"
 
 
 class JellyfinClient:
@@ -49,22 +52,31 @@ class JellyfinClient:
         value = (
             self._auth_value
             if token is None
-            else f"{self._auth_value}, Token={token}"
+            else f"{self._auth_value}, Token={token.strip()}"
         )
         return {"Authorization": value}
 
-    async def authenticate(self, username: str, password: str) -> AuthResult:
-        """Authenticate a user against Jellyfin.
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        token: str | None = None,
+        auth_error_message: str = "Token is invalid or expired",
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Send a request to Jellyfin with standard error handling.
 
-        Returns an AuthResult with the access token and user info.
-        Raises JellyfinAuthError on invalid credentials.
-        Raises JellyfinConnectionError if Jellyfin is unreachable.
+        Raises JellyfinAuthError on 401.
+        Raises JellyfinConnectionError on transport failure.
+        Raises JellyfinError on other non-2xx responses.
         """
         try:
-            resp = await self._client.post(
-                f"{self._base_url}/Users/AuthenticateByName",
-                json={"Username": username, "Pw": password},
-                headers=self._headers(),
+            resp = await self._client.request(
+                method,
+                f"{self._base_url}{path}",
+                headers=self._headers(token),
+                **kwargs,
             )
         except httpx.TransportError as exc:
             raise JellyfinConnectionError(
@@ -72,7 +84,7 @@ class JellyfinClient:
             ) from exc
 
         if resp.status_code == 401:
-            raise JellyfinAuthError("Invalid username or password")
+            raise JellyfinAuthError(auth_error_message)
 
         try:
             resp.raise_for_status()
@@ -81,6 +93,25 @@ class JellyfinClient:
                 f"Unexpected response from Jellyfin: {resp.status_code}"
             ) from exc
 
+        return resp
+
+    async def authenticate(self, username: str, password: str) -> AuthResult:
+        """Authenticate a user against Jellyfin.
+
+        Returns an AuthResult with the access token and user info.
+        Caller is responsible for storing the returned token only in an
+        encrypted server-side session — never persist to disk or expose
+        to the frontend.
+
+        Raises JellyfinAuthError on invalid credentials.
+        Raises JellyfinConnectionError if Jellyfin is unreachable.
+        """
+        resp = await self._request(
+            "POST",
+            "/Users/AuthenticateByName",
+            json={"Username": username, "Pw": password},
+            auth_error_message="Invalid username or password",
+        )
         return AuthResult.from_jellyfin(resp.json())
 
     async def get_user(self, token: str) -> UserInfo:
@@ -90,30 +121,8 @@ class JellyfinClient:
         Raises JellyfinAuthError if the token is invalid/expired.
         Raises JellyfinConnectionError if Jellyfin is unreachable.
         """
-        try:
-            resp = await self._client.get(
-                f"{self._base_url}/Users/Me",
-                headers=self._headers(token),
-            )
-        except httpx.TransportError as exc:
-            raise JellyfinConnectionError(
-                f"Cannot reach Jellyfin at {self._base_url}"
-            ) from exc
-
-        if resp.status_code == 401:
-            raise JellyfinAuthError("Token is invalid or expired")
-
-        try:
-            resp.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            raise JellyfinError(
-                f"Unexpected response from Jellyfin: {resp.status_code}"
-            ) from exc
-
+        resp = await self._request("GET", "/Users/Me", token=token)
         return UserInfo.model_validate(resp.json())
-
-    # Fields to request from Jellyfin — matches our LibraryItem model
-    _ITEM_FIELDS = "Overview,Genres,ProductionYear"
 
     async def get_items(
         self,
@@ -135,30 +144,15 @@ class JellyfinClient:
             "StartIndex": start_index,
             "Limit": limit,
             "Recursive": recursive,
-            "Fields": self._ITEM_FIELDS,
+            "Fields": _ITEM_FIELDS,
         }
         if item_types:
             params["IncludeItemTypes"] = ",".join(item_types)
 
-        try:
-            resp = await self._client.get(
-                f"{self._base_url}/Users/{user_id}/Items",
-                headers=self._headers(token),
-                params=params,
-            )
-        except httpx.TransportError as exc:
-            raise JellyfinConnectionError(
-                f"Cannot reach Jellyfin at {self._base_url}"
-            ) from exc
-
-        if resp.status_code == 401:
-            raise JellyfinAuthError("Token is invalid or expired")
-
-        try:
-            resp.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            raise JellyfinError(
-                f"Unexpected response from Jellyfin: {resp.status_code}"
-            ) from exc
-
+        resp = await self._request(
+            "GET",
+            f"/Users/{user_id}/Items",
+            token=token,
+            params=params,
+        )
         return PaginatedItems.model_validate(resp.json())

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -16,7 +16,7 @@ from app.jellyfin.errors import (
     JellyfinConnectionError,
     JellyfinError,
 )
-from app.jellyfin.models import AuthResult, UserInfo
+from app.jellyfin.models import AuthResult, PaginatedItems, UserInfo
 
 logger = logging.getLogger(__name__)
 
@@ -111,3 +111,54 @@ class JellyfinClient:
             ) from exc
 
         return UserInfo.model_validate(resp.json())
+
+    # Fields to request from Jellyfin — matches our LibraryItem model
+    _ITEM_FIELDS = "Overview,Genres,ProductionYear"
+
+    async def get_items(
+        self,
+        token: str,
+        user_id: str,
+        *,
+        item_types: list[str] | None = None,
+        start_index: int = 0,
+        limit: int = 50,
+        recursive: bool = True,
+    ) -> PaginatedItems:
+        """Get library items for a user (paginated).
+
+        Uses /Users/{userId}/Items so Jellyfin enforces per-user permissions.
+        Raises JellyfinAuthError if the token is invalid/expired.
+        Raises JellyfinConnectionError if Jellyfin is unreachable.
+        """
+        params: dict[str, str | int | bool] = {
+            "StartIndex": start_index,
+            "Limit": limit,
+            "Recursive": recursive,
+            "Fields": self._ITEM_FIELDS,
+        }
+        if item_types:
+            params["IncludeItemTypes"] = ",".join(item_types)
+
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}/Users/{user_id}/Items",
+                headers=self._headers(token),
+                params=params,
+            )
+        except httpx.TransportError as exc:
+            raise JellyfinConnectionError(
+                f"Cannot reach Jellyfin at {self._base_url}"
+            ) from exc
+
+        if resp.status_code == 401:
+            raise JellyfinAuthError("Token is invalid or expired")
+
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise JellyfinError(
+                f"Unexpected response from Jellyfin: {resp.status_code}"
+            ) from exc
+
+        return PaginatedItems.model_validate(resp.json())

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -8,10 +8,15 @@ format (Authorization header, not X-Emby-Authorization; no quotes on Token).
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import httpx
+import httpx
+
+from app.jellyfin.errors import (
+    JellyfinAuthError,
+    JellyfinConnectionError,
+    JellyfinError,
+)
+from app.jellyfin.models import AuthResult
 
 logger = logging.getLogger(__name__)
 
@@ -47,3 +52,33 @@ class JellyfinClient:
             else f"{self._auth_value}, Token={token}"
         )
         return {"Authorization": value}
+
+    async def authenticate(self, username: str, password: str) -> AuthResult:
+        """Authenticate a user against Jellyfin.
+
+        Returns an AuthResult with the access token and user info.
+        Raises JellyfinAuthError on invalid credentials.
+        Raises JellyfinConnectionError if Jellyfin is unreachable.
+        """
+        try:
+            resp = await self._client.post(
+                f"{self._base_url}/Users/AuthenticateByName",
+                json={"Username": username, "Pw": password},
+                headers=self._headers(),
+            )
+        except httpx.TransportError as exc:
+            raise JellyfinConnectionError(
+                f"Cannot reach Jellyfin at {self._base_url}"
+            ) from exc
+
+        if resp.status_code == 401:
+            raise JellyfinAuthError("Invalid username or password")
+
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise JellyfinError(
+                f"Unexpected response from Jellyfin: {resp.status_code}"
+            ) from exc
+
+        return AuthResult.from_jellyfin(resp.json())

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -16,7 +16,7 @@ from app.jellyfin.errors import (
     JellyfinConnectionError,
     JellyfinError,
 )
-from app.jellyfin.models import AuthResult
+from app.jellyfin.models import AuthResult, UserInfo
 
 logger = logging.getLogger(__name__)
 
@@ -82,3 +82,32 @@ class JellyfinClient:
             ) from exc
 
         return AuthResult.from_jellyfin(resp.json())
+
+    async def get_user(self, token: str) -> UserInfo:
+        """Get the current user's info. Validates the token is still active.
+
+        Calls /Users/Me which returns the user associated with the token.
+        Raises JellyfinAuthError if the token is invalid/expired.
+        Raises JellyfinConnectionError if Jellyfin is unreachable.
+        """
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}/Users/Me",
+                headers=self._headers(token),
+            )
+        except httpx.TransportError as exc:
+            raise JellyfinConnectionError(
+                f"Cannot reach Jellyfin at {self._base_url}"
+            ) from exc
+
+        if resp.status_code == 401:
+            raise JellyfinAuthError("Token is invalid or expired")
+
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise JellyfinError(
+                f"Unexpected response from Jellyfin: {resp.status_code}"
+            ) from exc
+
+        return UserInfo.model_validate(resp.json())

--- a/backend/app/jellyfin/errors.py
+++ b/backend/app/jellyfin/errors.py
@@ -1,0 +1,15 @@
+"""Jellyfin API client exceptions."""
+
+from __future__ import annotations
+
+
+class JellyfinError(Exception):
+    """Base exception for Jellyfin API errors."""
+
+
+class JellyfinAuthError(JellyfinError):
+    """Authentication failed — invalid credentials or expired token."""
+
+
+class JellyfinConnectionError(JellyfinError):
+    """Cannot reach the Jellyfin server."""

--- a/backend/app/jellyfin/models.py
+++ b/backend/app/jellyfin/models.py
@@ -1,0 +1,61 @@
+"""Pydantic models for Jellyfin API responses.
+
+Uses Field aliases to map Jellyfin's PascalCase JSON to snake_case Python.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Self
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AuthResult(BaseModel):
+    """Result of a successful authentication against Jellyfin."""
+
+    access_token: str
+    user_id: str
+    user_name: str
+
+    @classmethod
+    def from_jellyfin(cls, data: dict[str, Any]) -> Self:
+        """Parse from Jellyfin's AuthenticateByName response shape."""
+        return cls(
+            access_token=data["AccessToken"],
+            user_id=data["User"]["Id"],
+            user_name=data["User"]["Name"],
+        )
+
+
+class UserInfo(BaseModel):
+    """Jellyfin user info (from /Users/Me or /Users/{id})."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str = Field(alias="Id")
+    name: str = Field(alias="Name")
+    server_id: str = Field(alias="ServerId")
+    has_password: bool = Field(alias="HasPassword")
+
+
+class LibraryItem(BaseModel):
+    """A single item from a Jellyfin library."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str = Field(alias="Id")
+    name: str = Field(alias="Name")
+    type: str = Field(alias="Type")
+    overview: str | None = Field(default=None, alias="Overview")
+    genres: list[str] = Field(default_factory=list, alias="Genres")
+    production_year: int | None = Field(default=None, alias="ProductionYear")
+
+
+class PaginatedItems(BaseModel):
+    """Paginated response from Jellyfin's item listing endpoints."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    items: list[LibraryItem] = Field(alias="Items")
+    total_count: int = Field(alias="TotalRecordCount")
+    start_index: int = Field(alias="StartIndex")

--- a/backend/tests/integration/test_jellyfin_client.py
+++ b/backend/tests/integration/test_jellyfin_client.py
@@ -1,0 +1,116 @@
+"""Integration tests for JellyfinClient against a real Jellyfin instance.
+
+Requires: make jellyfin-up (disposable Jellyfin on localhost:8096).
+Uses the existing fixture chain: jellyfin -> admin_auth_token -> test_users.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from app.jellyfin.client import JellyfinClient
+from app.jellyfin.errors import JellyfinAuthError
+from app.jellyfin.models import AuthResult, PaginatedItems, UserInfo
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from tests.integration.conftest import JellyfinInstance
+
+# Re-use credentials from conftest
+from tests.integration.conftest import TEST_USER_ALICE, TEST_USER_ALICE_PASS
+
+
+@pytest_asyncio.fixture
+async def jf_client(
+    jellyfin: JellyfinInstance,
+) -> AsyncGenerator[JellyfinClient, None]:
+    """JellyfinClient pointed at the test instance."""
+    # TODO(#29): Read timeout from Settings.jellyfin_timeout when wired
+    async with httpx.AsyncClient(timeout=10.0) as http:
+        yield JellyfinClient(base_url=jellyfin.url, http_client=http)
+
+
+@pytest.mark.integration
+async def test_authenticate_valid_credentials(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+) -> None:
+    """Authenticate as test-alice with correct password."""
+    result = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    assert isinstance(result, AuthResult)
+    assert result.user_name == TEST_USER_ALICE
+    assert result.user_id == test_users[TEST_USER_ALICE]
+    assert len(result.access_token) > 0
+
+
+@pytest.mark.integration
+async def test_authenticate_invalid_credentials(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+) -> None:
+    """Invalid password should raise JellyfinAuthError."""
+    with pytest.raises(JellyfinAuthError):
+        await jf_client.authenticate(TEST_USER_ALICE, "wrong-password")
+
+
+@pytest.mark.integration
+async def test_get_user_with_valid_token(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+) -> None:
+    """get_user() returns correct info for an authenticated user."""
+    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    user = await jf_client.get_user(auth.access_token)
+    assert isinstance(user, UserInfo)
+    assert user.name == TEST_USER_ALICE
+    assert user.id == test_users[TEST_USER_ALICE]
+
+
+@pytest.mark.integration
+async def test_get_user_with_invalid_token(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+) -> None:
+    """Invalid token should raise JellyfinAuthError."""
+    with pytest.raises(JellyfinAuthError):
+        await jf_client.get_user("not-a-real-token")
+
+
+@pytest.mark.integration
+async def test_get_items_returns_paginated_result(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+) -> None:
+    """get_items() returns a PaginatedItems even if library is empty."""
+    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    result = await jf_client.get_items(
+        auth.access_token,
+        auth.user_id,
+        item_types=["Movie"],
+    )
+    assert isinstance(result, PaginatedItems)
+    assert result.start_index == 0
+    # Library may be empty in test Jellyfin -- that's fine
+    assert result.total_count >= 0
+
+
+@pytest.mark.integration
+async def test_get_items_pagination_params(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+) -> None:
+    """Pagination parameters are respected (no crash, correct start_index)."""
+    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    result = await jf_client.get_items(
+        auth.access_token,
+        auth.user_id,
+        start_index=0,
+        limit=5,
+    )
+    assert isinstance(result, PaginatedItems)
+    assert result.start_index == 0

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -52,6 +52,17 @@ def test_settings_rejects_short_session_secret() -> None:
         Settings()  # type: ignore[call-arg]
 
 
+def test_settings_jellyfin_timeout_default() -> None:
+    """Jellyfin timeout should default to 10 seconds."""
+    env = {
+        "JELLYFIN_URL": "http://jellyfin:8096",
+        "SESSION_SECRET": _VALID_SECRET,
+    }
+    with patch.dict(os.environ, env, clear=False):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.jellyfin_timeout == 10.0
+
+
 def test_settings_rejects_tmdb_enabled_without_key() -> None:
     """TMDB_ENABLED=true requires TMDB_API_KEY."""
     env = {

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -212,3 +212,48 @@ class TestAuthenticate:
         mock_http.post.return_value = httpx.Response(500, request=_FAKE_REQUEST)
         with pytest.raises(JellyfinError):
             await jf_client.authenticate("alice", "password")
+
+
+class TestGetUser:
+    async def test_get_user_success(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.get.return_value = httpx.Response(
+            200,
+            json={
+                "Id": "uid-1",
+                "Name": "alice",
+                "ServerId": "srv-1",
+                "HasPassword": True,
+            },
+            request=_FAKE_REQUEST,
+        )
+        user = await jf_client.get_user("tok-123")
+        assert isinstance(user, UserInfo)
+        assert user.id == "uid-1"
+        assert user.name == "alice"
+        assert user.server_id == "srv-1"
+        # Verify token is passed in headers
+        call_args = mock_http.get.call_args
+        assert "Token=tok-123" in call_args.kwargs["headers"]["Authorization"]
+
+    async def test_get_user_invalid_token(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.get.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinAuthError):
+            await jf_client.get_user("expired-token")
+
+    async def test_get_user_server_unreachable(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.get.side_effect = httpx.ConnectError("Connection refused")
+        with pytest.raises(JellyfinConnectionError):
+            await jf_client.get_user("tok-123")
+
+    async def test_get_user_unexpected_status(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.get.return_value = httpx.Response(500, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinError):
+            await jf_client.get_user("tok-123")

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -3,15 +3,33 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
+import httpx
 import pytest
 from pydantic import ValidationError
 
+from app.jellyfin.client import JellyfinClient
 from app.jellyfin.errors import (
     JellyfinAuthError,
     JellyfinConnectionError,
     JellyfinError,
 )
 from app.jellyfin.models import AuthResult, LibraryItem, PaginatedItems, UserInfo
+
+
+@pytest.fixture
+def mock_http() -> AsyncMock:
+    """Mock httpx.AsyncClient for unit tests."""
+    return AsyncMock(spec=httpx.AsyncClient)
+
+
+@pytest.fixture
+def jf_client(mock_http: AsyncMock) -> JellyfinClient:
+    return JellyfinClient(
+        base_url="http://jellyfin:8096",
+        http_client=mock_http,
+    )
 
 
 class TestErrorHierarchy:
@@ -112,3 +130,37 @@ class TestPaginatedItems:
         page = PaginatedItems.model_validate(data)
         assert page.items == []
         assert page.total_count == 0
+
+
+class TestHeaderConstruction:
+    def test_headers_without_token(self, jf_client: JellyfinClient) -> None:
+        headers = jf_client._headers()
+        auth = headers["Authorization"]
+        assert auth.startswith("MediaBrowser ")
+        assert 'Client="ai-movie-suggester"' in auth
+        assert 'Device="Server"' in auth
+        assert "DeviceId=" in auth
+        assert 'Version="0.1.0"' in auth
+        assert "Token=" not in auth
+
+    def test_headers_with_token(self, jf_client: JellyfinClient) -> None:
+        headers = jf_client._headers(token="my-token")
+        auth = headers["Authorization"]
+        assert auth.endswith(", Token=my-token")
+        assert 'Client="ai-movie-suggester"' in auth
+
+    def test_custom_device_id(self, mock_http: AsyncMock) -> None:
+        client = JellyfinClient(
+            base_url="http://jellyfin:8096",
+            http_client=mock_http,
+            device_id="custom-id",
+        )
+        headers = client._headers()
+        assert 'DeviceId="custom-id"' in headers["Authorization"]
+
+    def test_base_url_trailing_slash_stripped(self, mock_http: AsyncMock) -> None:
+        client = JellyfinClient(
+            base_url="http://jellyfin:8096/",
+            http_client=mock_http,
+        )
+        assert client._base_url == "http://jellyfin:8096"

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -3,11 +3,15 @@
 
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
 from app.jellyfin.errors import (
     JellyfinAuthError,
     JellyfinConnectionError,
     JellyfinError,
 )
+from app.jellyfin.models import AuthResult, LibraryItem, PaginatedItems, UserInfo
 
 
 class TestErrorHierarchy:
@@ -27,3 +31,84 @@ class TestErrorHierarchy:
     def test_connection_error_message(self) -> None:
         err = JellyfinConnectionError("Connection refused")
         assert str(err) == "Connection refused"
+
+
+class TestAuthResult:
+    def test_parse_jellyfin_response(self) -> None:
+        """AuthResult parses from Jellyfin's AuthenticateByName response."""
+        data = {
+            "AccessToken": "abc123",
+            "User": {"Id": "user-1", "Name": "alice"},
+        }
+        result = AuthResult.from_jellyfin(data)
+        assert result.access_token == "abc123"
+        assert result.user_id == "user-1"
+        assert result.user_name == "alice"
+
+
+class TestUserInfo:
+    def test_parse_from_jellyfin(self) -> None:
+        data = {
+            "Id": "user-1",
+            "Name": "alice",
+            "ServerId": "server-1",
+            "HasPassword": True,
+        }
+        user = UserInfo.model_validate(data)
+        assert user.id == "user-1"
+        assert user.name == "alice"
+        assert user.server_id == "server-1"
+        assert user.has_password is True
+
+    def test_missing_required_field_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            UserInfo.model_validate({"Name": "alice"})
+
+
+class TestLibraryItem:
+    def test_parse_minimal_item(self) -> None:
+        data = {"Id": "item-1", "Name": "Alien", "Type": "Movie"}
+        item = LibraryItem.model_validate(data)
+        assert item.id == "item-1"
+        assert item.name == "Alien"
+        assert item.type == "Movie"
+        assert item.overview is None
+        assert item.genres == []
+        assert item.production_year is None
+
+    def test_parse_full_item(self) -> None:
+        data = {
+            "Id": "item-2",
+            "Name": "Galaxy Quest",
+            "Type": "Movie",
+            "Overview": "A great comedy.",
+            "Genres": ["Comedy", "Sci-Fi"],
+            "ProductionYear": 1999,
+        }
+        item = LibraryItem.model_validate(data)
+        assert item.overview == "A great comedy."
+        assert item.genres == ["Comedy", "Sci-Fi"]
+        assert item.production_year == 1999
+
+
+class TestPaginatedItems:
+    def test_parse_from_jellyfin(self) -> None:
+        data = {
+            "Items": [
+                {"Id": "1", "Name": "Alien", "Type": "Movie"},
+                {"Id": "2", "Name": "Aliens", "Type": "Movie"},
+            ],
+            "TotalRecordCount": 50,
+            "StartIndex": 0,
+        }
+        page = PaginatedItems.model_validate(data)
+        assert len(page.items) == 2
+        assert page.total_count == 50
+        assert page.start_index == 0
+        assert page.items[0].name == "Alien"
+
+    def test_empty_library(self) -> None:
+        data = {"Items": [], "TotalRecordCount": 0, "StartIndex": 0}
+        page = PaginatedItems.model_validate(data)
+        assert page.items == []
+        assert page.total_count == 0

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -257,3 +257,107 @@ class TestGetUser:
         mock_http.get.return_value = httpx.Response(500, request=_FAKE_REQUEST)
         with pytest.raises(JellyfinError):
             await jf_client.get_user("tok-123")
+
+
+class TestGetItems:
+    async def test_get_items_success(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.get.return_value = httpx.Response(
+            200,
+            json={
+                "Items": [
+                    {"Id": "1", "Name": "Alien", "Type": "Movie"},
+                    {"Id": "2", "Name": "Aliens", "Type": "Movie"},
+                ],
+                "TotalRecordCount": 50,
+                "StartIndex": 0,
+            },
+            request=_FAKE_REQUEST,
+        )
+        result = await jf_client.get_items("tok-123", "uid-1")
+        assert isinstance(result, PaginatedItems)
+        assert len(result.items) == 2
+        assert result.total_count == 50
+        assert result.items[0].name == "Alien"
+
+    async def test_get_items_passes_pagination_params(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.get.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0, "StartIndex": 10},
+            request=_FAKE_REQUEST,
+        )
+        await jf_client.get_items(
+            "tok-123", "uid-1", start_index=10, limit=25,
+        )
+        call_args = mock_http.get.call_args
+        params = call_args.kwargs["params"]
+        assert params["StartIndex"] == 10
+        assert params["Limit"] == 25
+
+    async def test_get_items_with_item_types_filter(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.get.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
+            request=_FAKE_REQUEST,
+        )
+        await jf_client.get_items(
+            "tok-123", "uid-1", item_types=["Movie", "Series"],
+        )
+        call_args = mock_http.get.call_args
+        params = call_args.kwargs["params"]
+        assert params["IncludeItemTypes"] == "Movie,Series"
+
+    async def test_get_items_requests_metadata_fields(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Verify we request the fields our models expect."""
+        mock_http.get.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
+            request=_FAKE_REQUEST,
+        )
+        await jf_client.get_items("tok-123", "uid-1")
+        call_args = mock_http.get.call_args
+        params = call_args.kwargs["params"]
+        assert "Fields" in params
+        assert "Overview" in params["Fields"]
+        assert "Genres" in params["Fields"]
+
+    async def test_get_items_uses_per_user_endpoint(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Items endpoint must be /Users/{id}/Items for permission filtering."""
+        mock_http.get.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
+            request=_FAKE_REQUEST,
+        )
+        await jf_client.get_items("tok-123", "uid-1")
+        url = mock_http.get.call_args.args[0]
+        assert "/Users/uid-1/Items" in url
+
+    async def test_get_items_invalid_token(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.get.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinAuthError):
+            await jf_client.get_items("bad-tok", "uid-1")
+
+    async def test_get_items_server_unreachable(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.get.side_effect = httpx.ConnectError("Connection refused")
+        with pytest.raises(JellyfinConnectionError):
+            await jf_client.get_items("tok-123", "uid-1")
+
+    async def test_get_items_unexpected_status(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.get.return_value = httpx.Response(500, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinError):
+            await jf_client.get_items("tok-123", "uid-1")

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -296,7 +296,10 @@ class TestGetItems:
             request=_FAKE_REQUEST,
         )
         await jf_client.get_items(
-            "tok-123", "uid-1", start_index=10, limit=25,
+            "tok-123",
+            "uid-1",
+            start_index=10,
+            limit=25,
         )
         call_args = mock_http.request.call_args
         params = call_args.kwargs["params"]
@@ -312,7 +315,9 @@ class TestGetItems:
             request=_FAKE_REQUEST,
         )
         await jf_client.get_items(
-            "tok-123", "uid-1", item_types=["Movie", "Series"],
+            "tok-123",
+            "uid-1",
+            item_types=["Movie", "Series"],
         )
         call_args = mock_http.request.call_args
         params = call_args.kwargs["params"]

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -165,6 +165,11 @@ class TestHeaderConstruction:
         )
         assert client._base_url == "http://jellyfin:8096"
 
+    def test_token_whitespace_stripped(self, jf_client: JellyfinClient) -> None:
+        headers = jf_client._headers(token="  tok-123  ")
+        auth = headers["Authorization"]
+        assert auth.endswith(", Token=tok-123")
+
 
 _FAKE_REQUEST = httpx.Request("GET", "http://fake")
 
@@ -173,7 +178,7 @@ class TestAuthenticate:
     async def test_authenticate_success(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.post.return_value = httpx.Response(
+        mock_http.request.return_value = httpx.Response(
             200,
             json={
                 "AccessToken": "tok-123",
@@ -186,30 +191,31 @@ class TestAuthenticate:
         assert result.access_token == "tok-123"
         assert result.user_id == "uid-1"
         assert result.user_name == "alice"
-        # Verify correct URL and payload
-        mock_http.post.assert_called_once()
-        call_args = mock_http.post.call_args
-        assert "/Users/AuthenticateByName" in call_args.args[0]
+        # Verify correct method, URL, and payload
+        mock_http.request.assert_called_once()
+        call_args = mock_http.request.call_args
+        assert call_args.args[0] == "POST"
+        assert "/Users/AuthenticateByName" in call_args.args[1]
         assert call_args.kwargs["json"] == {"Username": "alice", "Pw": "password123"}
 
     async def test_authenticate_invalid_credentials(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.post.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        mock_http.request.return_value = httpx.Response(401, request=_FAKE_REQUEST)
         with pytest.raises(JellyfinAuthError):
             await jf_client.authenticate("alice", "wrong")
 
     async def test_authenticate_server_unreachable(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.post.side_effect = httpx.ConnectError("Connection refused")
+        mock_http.request.side_effect = httpx.ConnectError("Connection refused")
         with pytest.raises(JellyfinConnectionError):
             await jf_client.authenticate("alice", "password")
 
     async def test_authenticate_unexpected_status(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.post.return_value = httpx.Response(500, request=_FAKE_REQUEST)
+        mock_http.request.return_value = httpx.Response(500, request=_FAKE_REQUEST)
         with pytest.raises(JellyfinError):
             await jf_client.authenticate("alice", "password")
 
@@ -218,7 +224,7 @@ class TestGetUser:
     async def test_get_user_success(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.get.return_value = httpx.Response(
+        mock_http.request.return_value = httpx.Response(
             200,
             json={
                 "Id": "uid-1",
@@ -234,27 +240,27 @@ class TestGetUser:
         assert user.name == "alice"
         assert user.server_id == "srv-1"
         # Verify token is passed in headers
-        call_args = mock_http.get.call_args
+        call_args = mock_http.request.call_args
         assert "Token=tok-123" in call_args.kwargs["headers"]["Authorization"]
 
     async def test_get_user_invalid_token(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.get.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        mock_http.request.return_value = httpx.Response(401, request=_FAKE_REQUEST)
         with pytest.raises(JellyfinAuthError):
             await jf_client.get_user("expired-token")
 
     async def test_get_user_server_unreachable(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.get.side_effect = httpx.ConnectError("Connection refused")
+        mock_http.request.side_effect = httpx.ConnectError("Connection refused")
         with pytest.raises(JellyfinConnectionError):
             await jf_client.get_user("tok-123")
 
     async def test_get_user_unexpected_status(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.get.return_value = httpx.Response(500, request=_FAKE_REQUEST)
+        mock_http.request.return_value = httpx.Response(500, request=_FAKE_REQUEST)
         with pytest.raises(JellyfinError):
             await jf_client.get_user("tok-123")
 
@@ -263,7 +269,7 @@ class TestGetItems:
     async def test_get_items_success(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.get.return_value = httpx.Response(
+        mock_http.request.return_value = httpx.Response(
             200,
             json={
                 "Items": [
@@ -284,7 +290,7 @@ class TestGetItems:
     async def test_get_items_passes_pagination_params(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.get.return_value = httpx.Response(
+        mock_http.request.return_value = httpx.Response(
             200,
             json={"Items": [], "TotalRecordCount": 0, "StartIndex": 10},
             request=_FAKE_REQUEST,
@@ -292,7 +298,7 @@ class TestGetItems:
         await jf_client.get_items(
             "tok-123", "uid-1", start_index=10, limit=25,
         )
-        call_args = mock_http.get.call_args
+        call_args = mock_http.request.call_args
         params = call_args.kwargs["params"]
         assert params["StartIndex"] == 10
         assert params["Limit"] == 25
@@ -300,7 +306,7 @@ class TestGetItems:
     async def test_get_items_with_item_types_filter(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.get.return_value = httpx.Response(
+        mock_http.request.return_value = httpx.Response(
             200,
             json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
             request=_FAKE_REQUEST,
@@ -308,7 +314,7 @@ class TestGetItems:
         await jf_client.get_items(
             "tok-123", "uid-1", item_types=["Movie", "Series"],
         )
-        call_args = mock_http.get.call_args
+        call_args = mock_http.request.call_args
         params = call_args.kwargs["params"]
         assert params["IncludeItemTypes"] == "Movie,Series"
 
@@ -316,13 +322,13 @@ class TestGetItems:
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
         """Verify we request the fields our models expect."""
-        mock_http.get.return_value = httpx.Response(
+        mock_http.request.return_value = httpx.Response(
             200,
             json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
             request=_FAKE_REQUEST,
         )
         await jf_client.get_items("tok-123", "uid-1")
-        call_args = mock_http.get.call_args
+        call_args = mock_http.request.call_args
         params = call_args.kwargs["params"]
         assert "Fields" in params
         assert "Overview" in params["Fields"]
@@ -332,32 +338,32 @@ class TestGetItems:
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
         """Items endpoint must be /Users/{id}/Items for permission filtering."""
-        mock_http.get.return_value = httpx.Response(
+        mock_http.request.return_value = httpx.Response(
             200,
             json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
             request=_FAKE_REQUEST,
         )
         await jf_client.get_items("tok-123", "uid-1")
-        url = mock_http.get.call_args.args[0]
+        url = mock_http.request.call_args.args[1]
         assert "/Users/uid-1/Items" in url
 
     async def test_get_items_invalid_token(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.get.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        mock_http.request.return_value = httpx.Response(401, request=_FAKE_REQUEST)
         with pytest.raises(JellyfinAuthError):
             await jf_client.get_items("bad-tok", "uid-1")
 
     async def test_get_items_server_unreachable(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.get.side_effect = httpx.ConnectError("Connection refused")
+        mock_http.request.side_effect = httpx.ConnectError("Connection refused")
         with pytest.raises(JellyfinConnectionError):
             await jf_client.get_items("tok-123", "uid-1")
 
     async def test_get_items_unexpected_status(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
-        mock_http.get.return_value = httpx.Response(500, request=_FAKE_REQUEST)
+        mock_http.request.return_value = httpx.Response(500, request=_FAKE_REQUEST)
         with pytest.raises(JellyfinError):
             await jf_client.get_items("tok-123", "uid-1")

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -164,3 +164,51 @@ class TestHeaderConstruction:
             http_client=mock_http,
         )
         assert client._base_url == "http://jellyfin:8096"
+
+
+_FAKE_REQUEST = httpx.Request("GET", "http://fake")
+
+
+class TestAuthenticate:
+    async def test_authenticate_success(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.post.return_value = httpx.Response(
+            200,
+            json={
+                "AccessToken": "tok-123",
+                "User": {"Id": "uid-1", "Name": "alice"},
+            },
+            request=_FAKE_REQUEST,
+        )
+        result = await jf_client.authenticate("alice", "password123")
+        assert isinstance(result, AuthResult)
+        assert result.access_token == "tok-123"
+        assert result.user_id == "uid-1"
+        assert result.user_name == "alice"
+        # Verify correct URL and payload
+        mock_http.post.assert_called_once()
+        call_args = mock_http.post.call_args
+        assert "/Users/AuthenticateByName" in call_args.args[0]
+        assert call_args.kwargs["json"] == {"Username": "alice", "Pw": "password123"}
+
+    async def test_authenticate_invalid_credentials(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.post.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinAuthError):
+            await jf_client.authenticate("alice", "wrong")
+
+    async def test_authenticate_server_unreachable(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.post.side_effect = httpx.ConnectError("Connection refused")
+        with pytest.raises(JellyfinConnectionError):
+            await jf_client.authenticate("alice", "password")
+
+    async def test_authenticate_unexpected_status(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.post.return_value = httpx.Response(500, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinError):
+            await jf_client.authenticate("alice", "password")

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -1,0 +1,29 @@
+# backend/tests/test_jellyfin_client.py
+"""Unit tests for the Jellyfin API client (mock httpx)."""
+
+from __future__ import annotations
+
+from app.jellyfin.errors import (
+    JellyfinAuthError,
+    JellyfinConnectionError,
+    JellyfinError,
+)
+
+
+class TestErrorHierarchy:
+    def test_auth_error_is_jellyfin_error(self) -> None:
+        assert issubclass(JellyfinAuthError, JellyfinError)
+
+    def test_connection_error_is_jellyfin_error(self) -> None:
+        assert issubclass(JellyfinConnectionError, JellyfinError)
+
+    def test_jellyfin_error_is_exception(self) -> None:
+        assert issubclass(JellyfinError, Exception)
+
+    def test_auth_error_message(self) -> None:
+        err = JellyfinAuthError("Invalid credentials")
+        assert str(err) == "Invalid credentials"
+
+    def test_connection_error_message(self) -> None:
+        err = JellyfinConnectionError("Connection refused")
+        assert str(err) == "Connection refused"


### PR DESCRIPTION
## Summary

- Add async `JellyfinClient` wrapping an injected `httpx.AsyncClient` with MediaBrowser header construction matching Jellyfin's own auth format
- Implement `authenticate()`, `get_user()`, and `get_items()` with typed error hierarchy (`JellyfinAuthError`, `JellyfinConnectionError`, `JellyfinError`)
- Pydantic v2 response models with aliases mapping Jellyfin's PascalCase JSON to snake_case Python
- Add `JELLYFIN_TIMEOUT` config setting (default 10s, wired in #29)

## Test Plan

- [x] 32 unit tests (mock httpx) covering all methods, error paths, header construction
- [x] 6 integration tests against real Jellyfin (authenticate, get_user, get_items)
- [x] 6 config tests (including new jellyfin_timeout default)
- [x] ruff lint: all checks passed
- [x] pyright: 0 errors, 0 warnings
- [x] `make test-integration-full` passes (53/53 tests)

## Files Changed

| File | Action | Lines |
|------|--------|-------|
| `backend/app/jellyfin/__init__.py` | New | ~15 |
| `backend/app/jellyfin/errors.py` | New | ~15 |
| `backend/app/jellyfin/models.py` | New | ~55 |
| `backend/app/jellyfin/client.py` | New | ~115 |
| `backend/app/config.py` | Modified | +1 |
| `backend/tests/test_jellyfin_client.py` | New | ~260 |
| `backend/tests/integration/test_jellyfin_client.py` | New | ~95 |
| `backend/tests/test_config.py` | Modified | +10 |
| `.env.example` | Modified | +2 |

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)