### PR TITLE
feat(security): add security hardening middleware (#27)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,17 @@ TMDB_ENABLED=false
 # Only needed if TMDB_ENABLED=true
 TMDB_API_KEY=
 
+# --- Security ---
+
+# Allowed origin for CORS (the URL where the frontend is served)
+# Default: http://localhost:3000 (matches the dev frontend port)
+# CORS_ORIGIN=http://localhost:3000
+
+# Enable /docs and /redoc API documentation endpoints
+# Default: enabled when LOG_LEVEL=debug, disabled otherwise
+# Set explicitly to override the LOG_LEVEL default
+# ENABLE_DOCS=
+
 # --- Advanced ---
 
 # Log level (debug, info, warning, error)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -48,6 +48,31 @@ class Settings(BaseSettings):
     session_expiry_hours: int = 24
     chat_rate_limit: int = 10
 
+    @model_validator(mode="after")
+    def _validate_cors_origin(self) -> Settings:
+        """Reject CORS origins with paths, query strings, or fragments.
+
+        Browser Origin headers never include a path — allowing one would
+        silently break CORS matching.
+        """
+        from urllib.parse import urlparse
+
+        parsed = urlparse(str(self.cors_origin))
+        # AnyHttpUrl always adds a trailing slash, so "/" is the "no path" case
+        if parsed.path not in ("", "/"):
+            msg = (
+                "CORS_ORIGIN must be an origin (scheme + host + optional port), "
+                f"not a URL with a path: {self.cors_origin}"
+            )
+            raise ValueError(msg)
+        if parsed.query or parsed.fragment:
+            msg = (
+                "CORS_ORIGIN must not include query string or fragment: "
+                f"{self.cors_origin}"
+            )
+            raise ValueError(msg)
+        return self
+
     @property
     def cors_origin_str(self) -> str:
         """Return cors_origin as a plain string with trailing slash stripped."""

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import Field, model_validator
+from pydantic import AnyHttpUrl, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -39,7 +39,16 @@ class Settings(BaseSettings):
             raise ValueError(msg)
         return self
 
+    # Security
+    cors_origin: AnyHttpUrl = AnyHttpUrl("http://localhost:3000")
+    enable_docs: bool | None = None
+
     # Tuning
     log_level: Literal["debug", "info", "warning", "error", "critical"] = "info"
     session_expiry_hours: int = 24
     chat_rate_limit: int = 10
+
+    @property
+    def cors_origin_str(self) -> str:
+        """Return cors_origin as a plain string with trailing slash stripped."""
+        return str(self.cors_origin).rstrip("/")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from app.config import Settings
 from app.logging_config import configure_logging
+from app.middleware import SecurityHeadersMiddleware
 from app.models import EmbeddingsStatus, HealthResponse, ServiceStatus
 
 if TYPE_CHECKING:
@@ -100,8 +101,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # Security headers first, then CORS last (runs first on inbound requests)
     # When spec 03 adds CSRF + rate limiter, order becomes:
     # (1) security headers, (2) CSRF, (3) rate limiter, (4) CORS
-    from app.middleware import SecurityHeadersMiddleware
-
     application.add_middleware(SecurityHeadersMiddleware, docs_enabled=docs_enabled)
 
     # CORS — register last so it runs first on inbound requests

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -84,12 +84,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         """Service health: checks Jellyfin and Ollama connectivity."""
         async with httpx.AsyncClient() as client:
             jf, ol = await asyncio.gather(
-                _check_service(
-                    client, f"{settings.jellyfin_url}/health", _logger
-                ),
-                _check_service(
-                    client, f"{settings.ollama_host}/api/tags", _logger
-                ),
+                _check_service(client, f"{settings.jellyfin_url}/health", _logger),
+                _check_service(client, f"{settings.ollama_host}/api/tags", _logger),
             )
         return HealthResponse(
             jellyfin=jf,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
 
 from app.config import Settings
 from app.logging_config import configure_logging
@@ -17,12 +18,10 @@ from app.models import EmbeddingsStatus, HealthResponse, ServiceStatus
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
-settings = Settings()  # type: ignore[call-arg]  # env vars populate required fields
-configure_logging(settings.log_level)
-logger = logging.getLogger(__name__)
 
-
-async def _check_service(client: httpx.AsyncClient, url: str) -> ServiceStatus:
+async def _check_service(
+    client: httpx.AsyncClient, url: str, logger: logging.Logger
+) -> ServiceStatus:
     """Ping a service URL. Returns 'ok' or 'error'."""
     try:
         resp = await client.get(url, timeout=3.0)
@@ -32,37 +31,91 @@ async def _check_service(client: httpx.AsyncClient, url: str) -> ServiceStatus:
         return "error"
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Startup: log config, check connectivity. Shutdown: clean up."""
-    logger.info("starting ai-movie-suggester backend")
-    async with httpx.AsyncClient() as client:
-        jf, ol = await asyncio.gather(
-            _check_service(client, f"{settings.jellyfin_url}/health"),
-            _check_service(client, f"{settings.ollama_host}/api/tags"),
-        )
-    logger.info("startup checks: jellyfin=%s ollama=%s", jf, ol)
-    if jf == "error":
-        logger.warning("jellyfin not reachable at startup")
-    if ol == "error":
-        logger.warning("ollama not reachable at startup")
-    yield
-    logger.info("shutting down ai-movie-suggester backend")
+def create_app(settings: Settings | None = None) -> FastAPI:
+    """Create and configure the FastAPI application.
 
+    Args:
+        settings: Application settings. If None, loads from environment.
 
-app = FastAPI(title="ai-movie-suggester", lifespan=lifespan)
+    Returns:
+        Configured FastAPI application instance.
+    """
+    if settings is None:
+        settings = Settings()  # type: ignore[call-arg]
 
+    configure_logging(settings.log_level)
+    _logger = logging.getLogger(__name__)
 
-@app.get("/health", response_model=HealthResponse)
-async def health() -> HealthResponse:
-    """Service health: checks Jellyfin and Ollama connectivity."""
-    async with httpx.AsyncClient() as client:
-        jf, ol = await asyncio.gather(
-            _check_service(client, f"{settings.jellyfin_url}/health"),
-            _check_service(client, f"{settings.ollama_host}/api/tags"),
-        )
-    return HealthResponse(
-        jellyfin=jf,
-        ollama=ol,
-        embeddings=EmbeddingsStatus(total=0, pending=0),
+    # Resolve docs toggle: explicit enable_docs overrides log_level default
+    if settings.enable_docs is not None:
+        docs_enabled = settings.enable_docs
+    else:
+        docs_enabled = settings.log_level == "debug"
+
+    _logger.info("docs_enabled=%s", docs_enabled)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        """Startup: log config, check connectivity. Shutdown: clean up."""
+        _logger.info("starting ai-movie-suggester backend")
+        async with httpx.AsyncClient() as client:
+            jf, ol = await asyncio.gather(
+                _check_service(client, f"{settings.jellyfin_url}/health", _logger),
+                _check_service(client, f"{settings.ollama_host}/api/tags", _logger),
+            )
+        _logger.info("startup checks: jellyfin=%s ollama=%s", jf, ol)
+        if jf == "error":
+            _logger.warning("jellyfin not reachable at startup")
+        if ol == "error":
+            _logger.warning("ollama not reachable at startup")
+        yield
+        _logger.info("shutting down ai-movie-suggester backend")
+
+    application = FastAPI(
+        title="ai-movie-suggester",
+        lifespan=lifespan,
+        docs_url="/docs" if docs_enabled else None,
+        redoc_url="/redoc" if docs_enabled else None,
     )
+
+    @application.get("/health", response_model=HealthResponse)
+    async def health() -> HealthResponse:
+        """Service health: checks Jellyfin and Ollama connectivity."""
+        async with httpx.AsyncClient() as client:
+            jf, ol = await asyncio.gather(
+                _check_service(
+                    client, f"{settings.jellyfin_url}/health", _logger
+                ),
+                _check_service(
+                    client, f"{settings.ollama_host}/api/tags", _logger
+                ),
+            )
+        return HealthResponse(
+            jellyfin=jf,
+            ollama=ol,
+            embeddings=EmbeddingsStatus(total=0, pending=0),
+        )
+
+    # Middleware registration order matters:
+    # Security headers first, then CORS last (runs first on inbound requests)
+    # When spec 03 adds CSRF + rate limiter, order becomes:
+    # (1) security headers, (2) CSRF, (3) rate limiter, (4) CORS
+    from app.middleware import SecurityHeadersMiddleware
+
+    application.add_middleware(SecurityHeadersMiddleware, docs_enabled=docs_enabled)
+
+    # CORS — register last so it runs first on inbound requests
+    application.add_middleware(
+        CORSMiddleware,
+        allow_origins=[settings.cors_origin_str],
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+        allow_headers=["Content-Type", "X-CSRF-Token", "X-Request-ID"],
+    )
+
+    return application
+
+
+# Module-level app for uvicorn: `uvicorn app.main:app`
+settings = Settings()  # type: ignore[call-arg]
+app = create_app(settings)

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 _PRODUCTION_CSP = "default-src 'none'; frame-ancestors 'none'"
 _DEBUG_CSP = (
@@ -22,33 +25,28 @@ class SecurityHeadersMiddleware:
         Cache-Control: no-store (on 2xx responses only)
     """
 
-    def __init__(self, app: object, docs_enabled: bool = False) -> None:
+    def __init__(self, app: ASGIApp, docs_enabled: bool = False) -> None:
         self.app = app
-        self.csp = _DEBUG_CSP if docs_enabled else _PRODUCTION_CSP
+        self.csp_bytes = (_DEBUG_CSP if docs_enabled else _PRODUCTION_CSP).encode()
 
-    async def __call__(
-        self,
-        scope: dict[str, Any],
-        receive: Callable[..., Any],
-        send: Callable[..., Any],
-    ) -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
-            await self.app(scope, receive, send)  # type: ignore[union-attr]
+            await self.app(scope, receive, send)
             return
 
         status_code = 0
 
-        async def send_with_headers(message: dict) -> None:  # type: ignore[type-arg]
+        async def send_with_headers(message: Message) -> None:
             nonlocal status_code
             if message["type"] == "http.response.start":
                 status_code = message.get("status", 0)
                 headers = list(message.get("headers", []))
                 headers.append((b"x-content-type-options", b"nosniff"))
                 headers.append((b"x-frame-options", b"DENY"))
-                headers.append((b"content-security-policy", self.csp.encode()))
+                headers.append((b"content-security-policy", self.csp_bytes))
                 if 200 <= status_code < 300:
                     headers.append((b"cache-control", b"no-store"))
                 message = {**message, "headers": headers}
             await send(message)
 
-        await self.app(scope, receive, send_with_headers)  # type: ignore[union-attr]
+        await self.app(scope, receive, send_with_headers)

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,0 +1,54 @@
+"""Security headers ASGI middleware."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+_PRODUCTION_CSP = "default-src 'none'; frame-ancestors 'none'"
+_DEBUG_CSP = (
+    "default-src 'none'; frame-ancestors 'none'; "
+    "script-src 'unsafe-inline' https://cdn.jsdelivr.net; "
+    "style-src 'unsafe-inline' https://cdn.jsdelivr.net"
+)
+
+
+class SecurityHeadersMiddleware:
+    """Adds security headers to every HTTP response.
+
+    Headers:
+        X-Content-Type-Options: nosniff
+        X-Frame-Options: DENY
+        Content-Security-Policy: (strict or debug, computed once at init)
+        Cache-Control: no-store (on 2xx responses only)
+    """
+
+    def __init__(self, app: object, docs_enabled: bool = False) -> None:
+        self.app = app
+        self.csp = _DEBUG_CSP if docs_enabled else _PRODUCTION_CSP
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: Callable[..., Any],
+        send: Callable[..., Any],
+    ) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)  # type: ignore[union-attr]
+            return
+
+        status_code = 0
+
+        async def send_with_headers(message: dict) -> None:  # type: ignore[type-arg]
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message.get("status", 0)
+                headers = list(message.get("headers", []))
+                headers.append((b"x-content-type-options", b"nosniff"))
+                headers.append((b"x-frame-options", b"DENY"))
+                headers.append((b"content-security-policy", self.csp.encode()))
+                if 200 <= status_code < 300:
+                    headers.append((b"cache-control", b"no-store"))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)  # type: ignore[union-attr]

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -11,7 +11,10 @@ _PRODUCTION_CSP = "default-src 'none'; frame-ancestors 'none'"
 _DEBUG_CSP = (
     "default-src 'none'; frame-ancestors 'none'; "
     "script-src 'unsafe-inline' https://cdn.jsdelivr.net; "
-    "style-src 'unsafe-inline' https://cdn.jsdelivr.net"
+    "style-src 'unsafe-inline' https://cdn.jsdelivr.net; "
+    "connect-src 'self'; "
+    "img-src 'self' data:; "
+    "font-src https://cdn.jsdelivr.net"
 )
 
 
@@ -34,7 +37,7 @@ class SecurityHeadersMiddleware:
             await self.app(scope, receive, send)
             return
 
-        status_code = 0
+        status_code = 0  # nonlocal sentinel — overwritten in http.response.start
 
         async def send_with_headers(message: Message) -> None:
             nonlocal status_code

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,9 +8,21 @@ os.environ["SESSION_SECRET"] = "test-secret-not-real-at-least-32-characters"
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
-from app.main import app  # noqa: E402
+from app.config import Settings  # noqa: E402
+from app.main import create_app  # noqa: E402
+
+
+def make_test_settings(**overrides: str | int | float | bool | None) -> Settings:
+    """Create a Settings instance for tests with sensible defaults."""
+    defaults: dict[str, str | int | float | bool | None] = {
+        "jellyfin_url": "http://jellyfin-test:8096",
+        "session_secret": "test-secret-not-real-at-least-32-characters",
+    }
+    defaults.update(overrides)
+    return Settings(**defaults)  # type: ignore[arg-type]
 
 
 @pytest.fixture
 def client() -> TestClient:
-    return TestClient(app)
+    test_settings = make_test_settings()
+    return TestClient(create_app(test_settings))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,7 +22,13 @@ def make_test_settings(**overrides: str | int | float | bool | None) -> Settings
     return Settings(**defaults)  # type: ignore[arg-type]
 
 
+def make_test_client(
+    **settings_overrides: str | int | float | bool | None,
+) -> TestClient:
+    """Create a TestClient with custom settings for tests needing overrides."""
+    return TestClient(create_app(make_test_settings(**settings_overrides)))
+
+
 @pytest.fixture
 def client() -> TestClient:
-    test_settings = make_test_settings()
-    return TestClient(create_app(test_settings))
+    return make_test_client()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -104,6 +104,13 @@ def test_cors_origin_rejects_invalid_url() -> None:
         Settings()  # type: ignore[call-arg]
 
 
+def test_cors_origin_rejects_url_with_path() -> None:
+    """cors_origin rejects URLs with paths — Origin headers never include paths."""
+    env = {**_REQUIRED_ENV, "CORS_ORIGIN": "https://example.com/app"}
+    with patch.dict(os.environ, env, clear=True), pytest.raises(ValidationError):
+        Settings()  # type: ignore[call-arg]
+
+
 def test_cors_origin_strips_trailing_slash() -> None:
     """cors_origin_str strips trailing slash for CORS matching."""
     env = {**_REQUIRED_ENV, "CORS_ORIGIN": "http://localhost:3000/"}

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -7,6 +7,10 @@ from pydantic import ValidationError
 from app.config import Settings
 
 _VALID_SECRET = "test-secret-value-at-least-32-chars-long"
+_REQUIRED_ENV = {
+    "JELLYFIN_URL": "http://jellyfin:8096",
+    "SESSION_SECRET": _VALID_SECRET,
+}
 
 
 def test_settings_loads_defaults() -> None:
@@ -72,3 +76,64 @@ def test_settings_rejects_tmdb_enabled_without_key() -> None:
     }
     with patch.dict(os.environ, env, clear=True), pytest.raises(ValidationError):
         Settings()  # type: ignore[call-arg]
+
+
+# --- cors_origin ---
+
+
+def test_cors_origin_default() -> None:
+    """cors_origin defaults to http://localhost:3000."""
+    env = _REQUIRED_ENV.copy()
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.cors_origin_str == "http://localhost:3000"
+
+
+def test_cors_origin_custom_value() -> None:
+    """cors_origin accepts a valid URL."""
+    env = {**_REQUIRED_ENV, "CORS_ORIGIN": "https://movies.example.com"}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.cors_origin_str == "https://movies.example.com"
+
+
+def test_cors_origin_rejects_invalid_url() -> None:
+    """cors_origin rejects non-URL strings."""
+    env = {**_REQUIRED_ENV, "CORS_ORIGIN": "not-a-url"}
+    with patch.dict(os.environ, env, clear=True), pytest.raises(ValidationError):
+        Settings()  # type: ignore[call-arg]
+
+
+def test_cors_origin_strips_trailing_slash() -> None:
+    """cors_origin_str strips trailing slash for CORS matching."""
+    env = {**_REQUIRED_ENV, "CORS_ORIGIN": "http://localhost:3000/"}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.cors_origin_str == "http://localhost:3000"
+
+
+# --- enable_docs ---
+
+
+def test_enable_docs_default_none() -> None:
+    """enable_docs defaults to None when not set."""
+    env = _REQUIRED_ENV.copy()
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.enable_docs is None
+
+
+def test_enable_docs_true() -> None:
+    """enable_docs=true produces True."""
+    env = {**_REQUIRED_ENV, "ENABLE_DOCS": "true"}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.enable_docs is True
+
+
+def test_enable_docs_false() -> None:
+    """enable_docs=false produces False."""
+    env = {**_REQUIRED_ENV, "ENABLE_DOCS": "false"}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.enable_docs is False

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,18 +1,11 @@
 """CORS middleware tests — verify single-origin enforcement."""
 
-from fastapi.testclient import TestClient
-
-from app.main import create_app
-from tests.conftest import make_test_settings
-
-
-def _make_client(**settings_overrides: str | int | float | bool | None) -> TestClient:
-    return TestClient(create_app(make_test_settings(**settings_overrides)))
+from tests.conftest import make_test_client
 
 
 def test_cors_rejects_unknown_origin() -> None:
     """OPTIONS from unknown origin gets no Access-Control-Allow-Origin."""
-    client = _make_client()
+    client = make_test_client()
     response = client.options(
         "/health",
         headers={
@@ -25,7 +18,7 @@ def test_cors_rejects_unknown_origin() -> None:
 
 def test_cors_allows_configured_origin_preflight() -> None:
     """OPTIONS from configured origin gets correct ACAO header."""
-    client = _make_client()
+    client = make_test_client()
     response = client.options(
         "/health",
         headers={
@@ -38,7 +31,7 @@ def test_cors_allows_configured_origin_preflight() -> None:
 
 def test_cors_allows_configured_origin_simple_request() -> None:
     """GET from configured origin gets correct ACAO header."""
-    client = _make_client()
+    client = make_test_client()
     response = client.get(
         "/health",
         headers={"Origin": "http://localhost:3000"},
@@ -48,7 +41,7 @@ def test_cors_allows_configured_origin_simple_request() -> None:
 
 def test_cors_allows_credentials() -> None:
     """CORS preflight includes Allow-Credentials for cookie auth."""
-    client = _make_client()
+    client = make_test_client()
     response = client.options(
         "/health",
         headers={

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -26,7 +26,9 @@ def test_cors_allows_configured_origin_preflight() -> None:
             "Access-Control-Request-Method": "GET",
         },
     )
-    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+    assert (
+        response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+    )
 
 
 def test_cors_allows_configured_origin_simple_request() -> None:
@@ -36,7 +38,9 @@ def test_cors_allows_configured_origin_simple_request() -> None:
         "/health",
         headers={"Origin": "http://localhost:3000"},
     )
-    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+    assert (
+        response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+    )
 
 
 def test_cors_allows_credentials() -> None:

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,59 @@
+"""CORS middleware tests — verify single-origin enforcement."""
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from tests.conftest import make_test_settings
+
+
+def _make_client(**settings_overrides: str | int | float | bool | None) -> TestClient:
+    return TestClient(create_app(make_test_settings(**settings_overrides)))
+
+
+def test_cors_rejects_unknown_origin() -> None:
+    """OPTIONS from unknown origin gets no Access-Control-Allow-Origin."""
+    client = _make_client()
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "https://evil.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_cors_allows_configured_origin_preflight() -> None:
+    """OPTIONS from configured origin gets correct ACAO header."""
+    client = _make_client()
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_cors_allows_configured_origin_simple_request() -> None:
+    """GET from configured origin gets correct ACAO header."""
+    client = _make_client()
+    response = client.get(
+        "/health",
+        headers={"Origin": "http://localhost:3000"},
+    )
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_cors_allows_credentials() -> None:
+    """CORS preflight includes Allow-Credentials for cookie auth."""
+    client = _make_client()
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.headers.get("access-control-allow-credentials") == "true"

--- a/backend/tests/test_docs_toggle.py
+++ b/backend/tests/test_docs_toggle.py
@@ -1,45 +1,38 @@
 """Docs toggle tests — verify /docs and /redoc conditional access."""
 
-from fastapi.testclient import TestClient
-
-from app.main import create_app
-from tests.conftest import make_test_settings
-
-
-def _make_client(**settings_overrides: str | int | float | bool | None) -> TestClient:
-    return TestClient(create_app(make_test_settings(**settings_overrides)))
+from tests.conftest import make_test_client
 
 
 def test_docs_enabled_in_debug_mode() -> None:
     """LOG_LEVEL=debug enables /docs by default."""
-    client = _make_client(log_level="debug")
+    client = make_test_client(log_level="debug")
     response = client.get("/docs")
     assert response.status_code == 200
 
 
 def test_docs_disabled_in_info_mode() -> None:
     """LOG_LEVEL=info disables /docs by default."""
-    client = _make_client(log_level="info")
+    client = make_test_client(log_level="info")
     response = client.get("/docs")
     assert response.status_code == 404
 
 
 def test_docs_override_enable() -> None:
     """ENABLE_DOCS=true overrides LOG_LEVEL=info."""
-    client = _make_client(log_level="info", enable_docs=True)
+    client = make_test_client(log_level="info", enable_docs=True)
     response = client.get("/docs")
     assert response.status_code == 200
 
 
 def test_docs_override_disable() -> None:
     """ENABLE_DOCS=false overrides LOG_LEVEL=debug."""
-    client = _make_client(log_level="debug", enable_docs=False)
+    client = make_test_client(log_level="debug", enable_docs=False)
     response = client.get("/docs")
     assert response.status_code == 404
 
 
 def test_redoc_disabled_in_info_mode() -> None:
     """LOG_LEVEL=info disables /redoc by default."""
-    client = _make_client(log_level="info")
+    client = make_test_client(log_level="info")
     response = client.get("/redoc")
     assert response.status_code == 404

--- a/backend/tests/test_docs_toggle.py
+++ b/backend/tests/test_docs_toggle.py
@@ -1,0 +1,45 @@
+"""Docs toggle tests — verify /docs and /redoc conditional access."""
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from tests.conftest import make_test_settings
+
+
+def _make_client(**settings_overrides: str | int | float | bool | None) -> TestClient:
+    return TestClient(create_app(make_test_settings(**settings_overrides)))
+
+
+def test_docs_enabled_in_debug_mode() -> None:
+    """LOG_LEVEL=debug enables /docs by default."""
+    client = _make_client(log_level="debug")
+    response = client.get("/docs")
+    assert response.status_code == 200
+
+
+def test_docs_disabled_in_info_mode() -> None:
+    """LOG_LEVEL=info disables /docs by default."""
+    client = _make_client(log_level="info")
+    response = client.get("/docs")
+    assert response.status_code == 404
+
+
+def test_docs_override_enable() -> None:
+    """ENABLE_DOCS=true overrides LOG_LEVEL=info."""
+    client = _make_client(log_level="info", enable_docs=True)
+    response = client.get("/docs")
+    assert response.status_code == 200
+
+
+def test_docs_override_disable() -> None:
+    """ENABLE_DOCS=false overrides LOG_LEVEL=debug."""
+    client = _make_client(log_level="debug", enable_docs=False)
+    response = client.get("/docs")
+    assert response.status_code == 404
+
+
+def test_redoc_disabled_in_info_mode() -> None:
+    """LOG_LEVEL=info disables /redoc by default."""
+    client = _make_client(log_level="info")
+    response = client.get("/redoc")
+    assert response.status_code == 404

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,0 +1,78 @@
+"""Security headers middleware tests."""
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from tests.conftest import make_test_settings
+
+
+def _make_client(**settings_overrides: str | int | float | bool | None) -> TestClient:
+    return TestClient(create_app(make_test_settings(**settings_overrides)))
+
+
+# --- Static headers (docs disabled = default test settings) ---
+
+
+def test_x_content_type_options() -> None:
+    """Every response has X-Content-Type-Options: nosniff."""
+    client = _make_client()
+    response = client.get("/health")
+    assert response.headers.get("x-content-type-options") == "nosniff"
+
+
+def test_x_frame_options() -> None:
+    """Every response has X-Frame-Options: DENY."""
+    client = _make_client()
+    response = client.get("/health")
+    assert response.headers.get("x-frame-options") == "DENY"
+
+
+def test_csp_header_present() -> None:
+    """Every response has a Content-Security-Policy header."""
+    client = _make_client()
+    response = client.get("/health")
+    assert "content-security-policy" in response.headers
+
+
+def test_cache_control_on_2xx() -> None:
+    """2xx responses have Cache-Control: no-store."""
+    client = _make_client()
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.headers.get("cache-control") == "no-store"
+
+
+def test_no_hsts() -> None:
+    """Responses must NOT include Strict-Transport-Security."""
+    client = _make_client()
+    response = client.get("/health")
+    assert "strict-transport-security" not in response.headers
+
+
+# --- CSP dual-mode ---
+
+
+def test_csp_production_mode() -> None:
+    """Docs disabled: CSP is strict production policy."""
+    client = _make_client(log_level="info")
+    response = client.get("/health")
+    csp = response.headers.get("content-security-policy", "")
+    assert csp == "default-src 'none'; frame-ancestors 'none'"
+
+
+def test_csp_debug_mode() -> None:
+    """LOG_LEVEL=debug + ENABLE_DOCS unset: CSP allows Swagger UI resources."""
+    client = _make_client(log_level="debug")
+    response = client.get("/health")
+    csp = response.headers.get("content-security-policy", "")
+    assert "script-src 'unsafe-inline' https://cdn.jsdelivr.net" in csp
+    assert "style-src 'unsafe-inline' https://cdn.jsdelivr.net" in csp
+    assert "frame-ancestors 'none'" in csp
+
+
+def test_csp_enable_docs_override() -> None:
+    """LOG_LEVEL=info + ENABLE_DOCS=true: CSP allows Swagger UI resources."""
+    client = _make_client(log_level="info", enable_docs=True)
+    response = client.get("/health")
+    csp = response.headers.get("content-security-policy", "")
+    assert "script-src 'unsafe-inline' https://cdn.jsdelivr.net" in csp

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,42 +1,34 @@
 """Security headers middleware tests."""
 
-from fastapi.testclient import TestClient
-
-from app.main import create_app
-from tests.conftest import make_test_settings
-
-
-def _make_client(**settings_overrides: str | int | float | bool | None) -> TestClient:
-    return TestClient(create_app(make_test_settings(**settings_overrides)))
-
+from tests.conftest import make_test_client
 
 # --- Static headers (docs disabled = default test settings) ---
 
 
 def test_x_content_type_options() -> None:
     """Every response has X-Content-Type-Options: nosniff."""
-    client = _make_client()
+    client = make_test_client()
     response = client.get("/health")
     assert response.headers.get("x-content-type-options") == "nosniff"
 
 
 def test_x_frame_options() -> None:
     """Every response has X-Frame-Options: DENY."""
-    client = _make_client()
+    client = make_test_client()
     response = client.get("/health")
     assert response.headers.get("x-frame-options") == "DENY"
 
 
 def test_csp_header_present() -> None:
     """Every response has a Content-Security-Policy header."""
-    client = _make_client()
+    client = make_test_client()
     response = client.get("/health")
     assert "content-security-policy" in response.headers
 
 
 def test_cache_control_on_2xx() -> None:
     """2xx responses have Cache-Control: no-store."""
-    client = _make_client()
+    client = make_test_client()
     response = client.get("/health")
     assert response.status_code == 200
     assert response.headers.get("cache-control") == "no-store"
@@ -44,7 +36,7 @@ def test_cache_control_on_2xx() -> None:
 
 def test_no_hsts() -> None:
     """Responses must NOT include Strict-Transport-Security."""
-    client = _make_client()
+    client = make_test_client()
     response = client.get("/health")
     assert "strict-transport-security" not in response.headers
 
@@ -54,7 +46,7 @@ def test_no_hsts() -> None:
 
 def test_csp_production_mode() -> None:
     """Docs disabled: CSP is strict production policy."""
-    client = _make_client(log_level="info")
+    client = make_test_client(log_level="info")
     response = client.get("/health")
     csp = response.headers.get("content-security-policy", "")
     assert csp == "default-src 'none'; frame-ancestors 'none'"
@@ -62,7 +54,7 @@ def test_csp_production_mode() -> None:
 
 def test_csp_debug_mode() -> None:
     """LOG_LEVEL=debug + ENABLE_DOCS unset: CSP allows Swagger UI resources."""
-    client = _make_client(log_level="debug")
+    client = make_test_client(log_level="debug")
     response = client.get("/health")
     csp = response.headers.get("content-security-policy", "")
     assert "script-src 'unsafe-inline' https://cdn.jsdelivr.net" in csp
@@ -72,7 +64,7 @@ def test_csp_debug_mode() -> None:
 
 def test_csp_enable_docs_override() -> None:
     """LOG_LEVEL=info + ENABLE_DOCS=true: CSP allows Swagger UI resources."""
-    client = _make_client(log_level="info", enable_docs=True)
+    client = make_test_client(log_level="info", enable_docs=True)
     response = client.get("/health")
     csp = response.headers.get("content-security-policy", "")
     assert "script-src 'unsafe-inline' https://cdn.jsdelivr.net" in csp

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -68,3 +68,27 @@ def test_csp_enable_docs_override() -> None:
     response = client.get("/health")
     csp = response.headers.get("content-security-policy", "")
     assert "script-src 'unsafe-inline' https://cdn.jsdelivr.net" in csp
+
+
+def test_csp_disable_docs_override_in_debug() -> None:
+    """ENABLE_DOCS=false overrides LOG_LEVEL=debug: CSP is strict production."""
+    client = make_test_client(log_level="debug", enable_docs=False)
+    response = client.get("/health")
+    csp = response.headers.get("content-security-policy", "")
+    assert csp == "default-src 'none'; frame-ancestors 'none'"
+
+
+def test_no_cache_control_on_404() -> None:
+    """Non-2xx responses do NOT get Cache-Control: no-store."""
+    client = make_test_client()
+    response = client.get("/nonexistent-route")
+    assert response.status_code == 404
+    assert "cache-control" not in response.headers
+
+
+def test_debug_csp_includes_connect_src() -> None:
+    """Debug CSP includes connect-src 'self' so Swagger can fetch /openapi.json."""
+    client = make_test_client(log_level="debug")
+    response = client.get("/health")
+    csp = response.headers.get("content-security-policy", "")
+    assert "connect-src 'self'" in csp


### PR DESCRIPTION
## Summary

- Introduces `create_app()` factory pattern for testable app configuration (foundation for #29 session management)
- Adds CORS middleware with single-origin enforcement (`CORS_ORIGIN` setting, defaults to `http://localhost:3000`)
- Adds security headers middleware: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, dual-mode `Content-Security-Policy`, `Cache-Control: no-store` on 2xx
- Adds conditional `/docs` and `/redoc` toggle: `LOG_LEVEL=debug` enables by default, `ENABLE_DOCS` overrides explicitly
- No new Python dependencies — `CORSMiddleware` ships with Starlette

### Security decisions (council-reviewed)
- **No HSTS** — dangerous for self-hosted HTTP users; Caddy handles it at TLS termination
- **No Referrer-Policy or Permissions-Policy** — inert on JSON API responses
- **Rate limiting deferred** to Epic 3 (#9) — no endpoint to protect yet
- **`allow_headers`** restricted to `Content-Type`, `X-CSRF-Token`, `X-Request-ID`
- **CSP** strict in production, relaxed for Swagger UI CDN in debug mode only

### New config fields
| Field | Type | Default | Purpose |
|-------|------|---------|---------|
| `CORS_ORIGIN` | URL | `http://localhost:3000` | Allowed CORS origin |
| `ENABLE_DOCS` | bool \| None | None | Override docs toggle (None = defer to LOG_LEVEL) |

## Test plan
- [x] 24 new tests: CORS (4), docs toggle (5), security headers (8), config fields (7)
- [x] 68 total tests pass, 0 failures
- [x] `ruff check` — 0 errors
- [x] `pyright` — 0 errors
- [x] No new dependencies in `pyproject.toml`
- [x] `.env.example` updated with new fields
- [ ] Existing health endpoint still works unchanged
- [ ] `uvicorn app.main:app` production startup still works

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)