### PR TITLE
feat(library): Jellyfin library client + item metadata store (#92)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,22 @@ CHAT_RATE_LIMIT=10
 # Timeout for Jellyfin API requests in seconds (default: 10)
 JELLYFIN_TIMEOUT=10.0
 
+# --- Library Sync ---
+
+# Jellyfin API key for background library sync (optional).
+# Enables automatic sync without requiring a logged-in user session.
+# Generate in Jellyfin: Dashboard > API Keys > Add.
+# SECURITY WARNING: Treat this like a root password — it grants full
+# access to your Jellyfin server. Never commit to version control.
+# If not set, library sync is triggered only via user session tokens.
+# JELLYFIN_API_KEY=
+
+# Path to the library metadata SQLite database file
+# LIBRARY_DB_PATH=data/library.db
+
+# Page size for Jellyfin library sync pagination
+# LIBRARY_SYNC_PAGE_SIZE=200
+
 # --- Local Development ---
 # For local HTTP development only, uncomment the line below.
 # WARNING: This MUST remain commented out (or set to true) for any

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,11 +110,15 @@ sequenceDiagram
 - **Session manager** (Epic 4): Device picker for "Play on TV"
 - **PWA shell**: Installable, mobile-first, works on phone-as-remote use case
 
-### SQLite-vec
-- **Vector storage**: 768-dimensional embeddings for library items
-- **App data**: Content hashes, sync timestamps, embedding metadata
-- **Access pattern**: WAL mode, separate read/write connection pools
-- **Abstraction**: Behind a repository interface for potential future swap
+### SQLite-vec / SQLite Databases
+The application uses a two-file database strategy:
+- **`data/sessions.db`**: Auth/session data — encrypted tokens, CSRF, expiry. Small rows, frequent read/write. Managed by `SessionStore`.
+- **`data/library.db`**: Library item metadata — titles, genres, content hashes, and future vector embeddings (SQLite-vec). Large batch writes during sync, read-heavy during search. Managed by `LibraryStore`.
+
+Rationale: Different access patterns (sessions are small/frequent; library is large/batch), different backup and migration lifecycles. `library.db` will eventually house SQLite-vec extension data; `sessions.db` is plain SQLite. Both use WAL mode and aiosqlite.
+
+- **Vector storage**: 768-dimensional embeddings for library items (future — Spec 06)
+- **Abstraction**: Behind repository interfaces (`SessionStoreProtocol`, `LibraryStoreProtocol`) for potential future swap
 
 ### Ollama
 - **Embedding model**: `nomic-embed-text` for library indexing
@@ -131,6 +135,9 @@ sequenceDiagram
 - **Network**: Backend binds to 127.0.0.1 by default. External access via existing reverse proxy (Caddy).
 - **Privacy**: All AI inference is local. TMDb enrichment is opt-in with documented data disclosure.
 - **API hardening**: CORS restricted to frontend origin. `/docs` disabled in production. Rate limiting on chat endpoint. Security headers via middleware.
+- **Credential distinction**: Two types of Jellyfin credentials are used, with different handling:
+  - **User tokens** (per-session): Encrypted at rest in `sessions.db` using Fernet with HKDF-derived keys. Never persisted to objects, never logged. Request-scoped — passed as parameters, not stored on instances.
+  - **Infrastructure API key** (`JELLYFIN_API_KEY`): Operator-configured, server-scoped. Enables background library sync without a logged-in user session. Loaded once at startup from environment. Never logged at any level. Treat like a root password.
 
 ## Configuration
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -76,8 +76,23 @@ class Settings(BaseSettings):
     enable_docs: bool | None = None
 
     # Library sync
+    jellyfin_api_key: str | None = None
     library_db_path: str = "data/library.db"
     library_sync_page_size: int = 200
+
+    @model_validator(mode="after")
+    def _validate_jellyfin_api_key(self) -> Settings:
+        """Strip whitespace from API key; treat empty/whitespace-only as None."""
+        if self.jellyfin_api_key is not None:
+            stripped = self.jellyfin_api_key.strip()
+            if not stripped:
+                _logger.warning(
+                    "JELLYFIN_API_KEY is empty/whitespace-only — treating as unset"
+                )
+                self.jellyfin_api_key = None
+            else:
+                self.jellyfin_api_key = stripped
+        return self
 
     # Tuning
     log_level: Literal["debug", "info", "warning", "error", "critical"] = "info"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Literal
 
-from pydantic import AnyHttpUrl, Field, model_validator
+from pydantic import AnyHttpUrl, Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _logger = logging.getLogger(__name__)
@@ -76,7 +76,7 @@ class Settings(BaseSettings):
     enable_docs: bool | None = None
 
     # Library sync
-    jellyfin_api_key: str | None = None
+    jellyfin_api_key: SecretStr | None = None
     library_db_path: str = "data/library.db"
     library_sync_page_size: int = 200
 
@@ -84,14 +84,14 @@ class Settings(BaseSettings):
     def _validate_jellyfin_api_key(self) -> Settings:
         """Strip whitespace from API key; treat empty/whitespace-only as None."""
         if self.jellyfin_api_key is not None:
-            stripped = self.jellyfin_api_key.strip()
+            stripped = self.jellyfin_api_key.get_secret_value().strip()
             if not stripped:
                 _logger.warning(
                     "JELLYFIN_API_KEY is empty/whitespace-only — treating as unset"
                 )
                 self.jellyfin_api_key = None
-            else:
-                self.jellyfin_api_key = stripped
+            elif stripped != self.jellyfin_api_key.get_secret_value():
+                self.jellyfin_api_key = SecretStr(stripped)
         return self
 
     # Tuning

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -76,6 +76,7 @@ class Settings(BaseSettings):
     enable_docs: bool | None = None
 
     # Library sync
+    library_db_path: str = "data/library.db"
     library_sync_page_size: int = 200
 
     # Tuning

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -75,6 +75,9 @@ class Settings(BaseSettings):
     cors_origin: AnyHttpUrl = AnyHttpUrl("http://localhost:3000")
     enable_docs: bool | None = None
 
+    # Library sync
+    library_sync_page_size: int = 200
+
     # Tuning
     log_level: Literal["debug", "info", "warning", "error", "critical"] = "info"
     session_expiry_hours: int = 24

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 import httpx
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import AsyncIterator, Callable
 
 from app.jellyfin.errors import (
     JellyfinAuthError,
@@ -31,7 +31,7 @@ _APP_VERSION = "0.1.0"
 _DEVICE = "Server"
 _DEFAULT_DEVICE_ID = "ai-movie-suggester-server"
 # Fields to request from Jellyfin — matches our LibraryItem model
-_ITEM_FIELDS = "Overview,Genres,ProductionYear"
+_ITEM_FIELDS = "Overview,Genres,ProductionYear,Tags,Studios,CommunityRating,People"
 
 
 class JellyfinClient:
@@ -203,3 +203,43 @@ class JellyfinClient:
             params=params,
         )
         return self._parse_response(resp, PaginatedItems.model_validate)
+
+    async def get_all_items(
+        self,
+        token: str,
+        user_id: str,
+        *,
+        item_types: list[str] | None = None,
+        page_size: int = 200,
+    ) -> AsyncIterator[PaginatedItems]:
+        """Auto-paginate library items, yielding each page.
+
+        Calls get_items() in a loop, yielding each PaginatedItems page.
+        Stops when all items have been fetched (start_index >= total_count).
+        Propagates JellyfinAuthError and JellyfinConnectionError without
+        catching them — the caller handles partial failure.
+
+        Token is passed through to get_items() on each call, never stored.
+        """
+        start_index = 0
+        page_number = 0
+
+        while True:
+            page = await self.get_items(
+                token,
+                user_id,
+                item_types=item_types,
+                start_index=start_index,
+                limit=page_size,
+            )
+            page_number += 1
+            logger.debug(
+                "library fetch page=%d items_on_page=%d",
+                page_number,
+                len(page.items),
+            )
+            yield page
+
+            start_index += len(page.items)
+            if start_index >= page.total_count:
+                break

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -221,6 +221,10 @@ class JellyfinClient:
 
         Token is passed through to get_items() on each call, never stored.
         """
+        if page_size <= 0:
+            msg = f"page_size must be positive, got {page_size}"
+            raise ValueError(msg)
+
         start_index = 0
         page_number = 0
 
@@ -239,6 +243,16 @@ class JellyfinClient:
                 len(page.items),
             )
             yield page
+
+            if not page.items:
+                logger.warning(
+                    "empty page from Jellyfin; stopping pagination "
+                    "(page=%d, start_index=%d, total_count=%d)",
+                    page_number,
+                    start_index,
+                    page.total_count,
+                )
+                break
 
             start_index += len(page.items)
             if start_index >= page.total_count:

--- a/backend/app/jellyfin/models.py
+++ b/backend/app/jellyfin/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Any, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class AuthResult(BaseModel):
@@ -49,6 +49,24 @@ class LibraryItem(BaseModel):
     overview: str | None = Field(default=None, alias="Overview")
     genres: list[str] = Field(default_factory=list, alias="Genres")
     production_year: int | None = Field(default=None, alias="ProductionYear")
+    tags: list[str] = Field(default_factory=list, alias="Tags")
+    studios: list[str] = Field(default_factory=list, alias="Studios")
+    community_rating: float | None = Field(default=None, alias="CommunityRating")
+    people: list[dict[str, str]] = Field(default_factory=list, alias="People")
+
+    @field_validator("studios", mode="before")
+    @classmethod
+    def _extract_studio_names(cls, v: Any) -> list[str]:
+        """Extract Name from studio objects; pass through plain strings."""
+        if not isinstance(v, list):
+            return []
+        result: list[str] = []
+        for item in v:
+            if isinstance(item, dict) and "Name" in item:
+                result.append(item["Name"])
+            elif isinstance(item, str):
+                result.append(item)
+        return result
 
 
 class PaginatedItems(BaseModel):

--- a/backend/app/jellyfin/models.py
+++ b/backend/app/jellyfin/models.py
@@ -52,7 +52,7 @@ class LibraryItem(BaseModel):
     tags: list[str] = Field(default_factory=list, alias="Tags")
     studios: list[str] = Field(default_factory=list, alias="Studios")
     community_rating: float | None = Field(default=None, alias="CommunityRating")
-    people: list[dict[str, str]] = Field(default_factory=list, alias="People")
+    people: list[dict[str, Any]] = Field(default_factory=list, alias="People")
 
     @field_validator("studios", mode="before")
     @classmethod

--- a/backend/app/library/hashing.py
+++ b/backend/app/library/hashing.py
@@ -1,0 +1,50 @@
+"""Content hash computation for library items.
+
+The content hash is a SHA-256 digest of a deterministic string built from
+item fields. This drives incremental sync — if the hash changes, the item
+needs re-embedding.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.library.models import LibraryItemRow
+
+
+def compute_content_hash(item: LibraryItemRow) -> str:
+    """Compute a deterministic SHA-256 hash from a library item's fields.
+
+    # TODO: Replace with text_builder from Spec 07
+    # When the text_builder module lands (app/ollama/text_builder.py),
+    # replace this placeholder with hashing the composite text output.
+    # A template change will cause all hashes to differ, triggering a
+    # full re-embed — this is intentional.
+
+    Field ordering (deterministic):
+    1. title
+    2. overview (or empty string)
+    3. production_year (or empty string)
+    4. genres (sorted JSON array)
+    5. tags (sorted JSON array)
+    6. studios (sorted JSON array)
+    7. community_rating (or empty string)
+    8. people (sorted JSON array)
+
+    All JSON arrays are sorted to ensure determinism regardless of input order.
+    """
+    parts = [
+        item.title,
+        item.overview or "",
+        str(item.production_year) if item.production_year is not None else "",
+        json.dumps(sorted(item.genres)),
+        json.dumps(sorted(item.tags)),
+        json.dumps(sorted(item.studios)),
+        str(item.community_rating) if item.community_rating is not None else "",
+        json.dumps(sorted(item.people)),
+    ]
+    composite = "|".join(parts)
+    return hashlib.sha256(composite.encode()).hexdigest()

--- a/backend/app/library/models.py
+++ b/backend/app/library/models.py
@@ -1,0 +1,58 @@
+"""Data models for library metadata storage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryItemRow:
+    """A library item row as stored in the database.
+
+    People contains actor names only (filtered from Jellyfin's full People list).
+    JSON array fields (genres, tags, studios, people) are serialized to/from
+    JSON strings by the store layer.
+    """
+
+    jellyfin_id: str
+    title: str
+    overview: str | None
+    production_year: int | None
+    genres: list[str]
+    tags: list[str]
+    studios: list[str]
+    community_rating: float | None
+    people: list[str]  # Actor names only
+    content_hash: str  # SHA-256 hex digest
+    synced_at: int  # Unix epoch seconds
+
+
+@dataclass(frozen=True, slots=True)
+class UpsertResult:
+    """Result of a bulk upsert operation."""
+
+    created: int
+    updated: int
+    unchanged: int
+
+
+# --- Library store protocol ---
+
+
+class LibraryStoreProtocol(Protocol):
+    """Structural interface for library storage backends."""
+
+    async def init(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+    async def upsert_many(self, items: list[LibraryItemRow]) -> UpsertResult: ...
+
+    async def get(self, jellyfin_id: str) -> LibraryItemRow | None: ...
+
+    async def get_many(self, ids: list[str]) -> list[LibraryItemRow]: ...
+
+    async def get_all_hashes(self) -> dict[str, str]: ...
+
+    async def count(self) -> int: ...

--- a/backend/app/library/store.py
+++ b/backend/app/library/store.py
@@ -79,7 +79,21 @@ class LibraryStore:
 
     @staticmethod
     def _row_to_item(row: Any) -> LibraryItemRow:
-        """Deserialize a database row into a LibraryItemRow."""
+        """Deserialize a database row into a LibraryItemRow.
+
+        Column mapping (must match SELECT order in all queries):
+          0: jellyfin_id   TEXT PK
+          1: title          TEXT NOT NULL
+          2: overview       TEXT (nullable)
+          3: production_year INTEGER (nullable)
+          4: genres         TEXT (JSON array)
+          5: tags           TEXT (JSON array)
+          6: studios        TEXT (JSON array)
+          7: community_rating REAL (nullable)
+          8: people         TEXT (JSON array)
+          9: content_hash   TEXT NOT NULL
+         10: synced_at      INTEGER NOT NULL
+        """
         return LibraryItemRow(
             jellyfin_id=row[0],
             title=row[1],
@@ -94,23 +108,45 @@ class LibraryStore:
             synced_at=row[10],
         )
 
+    async def _get_hashes_for_ids(self, ids: list[str]) -> dict[str, str]:
+        """Return {jellyfin_id: content_hash} for the given IDs only."""
+        if not ids:
+            return {}
+
+        result: dict[str, str] = {}
+        for i in range(0, len(ids), _BATCH_SIZE):
+            batch = ids[i : i + _BATCH_SIZE]
+            placeholders = ",".join("?" * len(batch))
+            cursor = await self._conn.execute(
+                f"SELECT jellyfin_id, content_hash FROM library_items "
+                f"WHERE jellyfin_id IN ({placeholders})",
+                batch,
+            )
+            rows = await cursor.fetchall()
+            for row in rows:
+                result[row[0]] = row[1]
+        return result
+
     async def upsert_many(self, items: list[LibraryItemRow]) -> UpsertResult:
         """Bulk upsert library items with created/updated/unchanged tracking.
 
         Wraps the entire batch in a single transaction. Fetches existing
-        hashes first to classify each item as created, updated, or unchanged.
-        Uses INSERT ... ON CONFLICT(jellyfin_id) DO UPDATE SET ... — never
-        INSERT OR REPLACE.
+        hashes for the batch IDs to classify each item as created, updated,
+        or unchanged. Unchanged items are skipped entirely. Uses executemany()
+        for a single batch SQL call. Uses INSERT ... ON CONFLICT(jellyfin_id)
+        DO UPDATE SET ... — never INSERT OR REPLACE.
         """
         if not items:
             return UpsertResult(created=0, updated=0, unchanged=0)
 
-        # Fetch existing hashes in bulk for comparison
-        existing_hashes = await self.get_all_hashes()
+        # Fetch existing hashes only for IDs in this batch
+        batch_ids = [item.jellyfin_id for item in items]
+        existing_hashes = await self._get_hashes_for_ids(batch_ids)
 
         created = 0
         updated = 0
         unchanged = 0
+        params_list: list[tuple[object, ...]] = []
 
         for item in items:
             old_hash = existing_hashes.get(item.jellyfin_id)
@@ -120,8 +156,24 @@ class LibraryStore:
                 updated += 1
             else:
                 unchanged += 1
+                continue  # Skip unchanged items — no SQL needed
 
-            await self._conn.execute(
+            params_list.append((
+                item.jellyfin_id,
+                item.title,
+                item.overview,
+                item.production_year,
+                json.dumps(item.genres),
+                json.dumps(item.tags),
+                json.dumps(item.studios),
+                item.community_rating,
+                json.dumps(item.people),
+                item.content_hash,
+                item.synced_at,
+            ))
+
+        if params_list:
+            await self._conn.executemany(
                 """INSERT INTO library_items
                    (jellyfin_id, title, overview, production_year,
                     genres, tags, studios, community_rating,
@@ -138,19 +190,7 @@ class LibraryStore:
                     people = excluded.people,
                     content_hash = excluded.content_hash,
                     synced_at = excluded.synced_at""",
-                (
-                    item.jellyfin_id,
-                    item.title,
-                    item.overview,
-                    item.production_year,
-                    json.dumps(item.genres),
-                    json.dumps(item.tags),
-                    json.dumps(item.studios),
-                    item.community_rating,
-                    json.dumps(item.people),
-                    item.content_hash,
-                    item.synced_at,
-                ),
+                params_list,
             )
 
         await self._conn.commit()

--- a/backend/app/library/store.py
+++ b/backend/app/library/store.py
@@ -158,19 +158,21 @@ class LibraryStore:
                 unchanged += 1
                 continue  # Skip unchanged items — no SQL needed
 
-            params_list.append((
-                item.jellyfin_id,
-                item.title,
-                item.overview,
-                item.production_year,
-                json.dumps(item.genres),
-                json.dumps(item.tags),
-                json.dumps(item.studios),
-                item.community_rating,
-                json.dumps(item.people),
-                item.content_hash,
-                item.synced_at,
-            ))
+            params_list.append(
+                (
+                    item.jellyfin_id,
+                    item.title,
+                    item.overview,
+                    item.production_year,
+                    json.dumps(item.genres),
+                    json.dumps(item.tags),
+                    json.dumps(item.studios),
+                    item.community_rating,
+                    json.dumps(item.people),
+                    item.content_hash,
+                    item.synced_at,
+                )
+            )
 
         if params_list:
             await self._conn.executemany(

--- a/backend/app/library/store.py
+++ b/backend/app/library/store.py
@@ -175,27 +175,32 @@ class LibraryStore:
             )
 
         if params_list:
-            await self._conn.executemany(
-                """INSERT INTO library_items
-                   (jellyfin_id, title, overview, production_year,
-                    genres, tags, studios, community_rating,
-                    people, content_hash, synced_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                   ON CONFLICT(jellyfin_id) DO UPDATE SET
-                    title = excluded.title,
-                    overview = excluded.overview,
-                    production_year = excluded.production_year,
-                    genres = excluded.genres,
-                    tags = excluded.tags,
-                    studios = excluded.studios,
-                    community_rating = excluded.community_rating,
-                    people = excluded.people,
-                    content_hash = excluded.content_hash,
-                    synced_at = excluded.synced_at""",
-                params_list,
-            )
-
-        await self._conn.commit()
+            await self._conn.execute("BEGIN")
+            try:
+                await self._conn.executemany(
+                    """INSERT INTO library_items
+                       (jellyfin_id, title, overview, production_year,
+                        genres, tags, studios, community_rating,
+                        people, content_hash, synced_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                       ON CONFLICT(jellyfin_id) DO UPDATE SET
+                        title = excluded.title,
+                        overview = excluded.overview,
+                        production_year = excluded.production_year,
+                        genres = excluded.genres,
+                        tags = excluded.tags,
+                        studios = excluded.studios,
+                        community_rating = excluded.community_rating,
+                        people = excluded.people,
+                        content_hash = excluded.content_hash,
+                        synced_at = excluded.synced_at""",
+                    params_list,
+                )
+            except Exception:
+                await self._conn.rollback()
+                raise
+            else:
+                await self._conn.commit()
         return UpsertResult(created=created, updated=updated, unchanged=unchanged)
 
     async def get(self, jellyfin_id: str) -> LibraryItemRow | None:

--- a/backend/app/library/store.py
+++ b/backend/app/library/store.py
@@ -1,0 +1,212 @@
+"""Async SQLite library metadata repository.
+
+Stores Jellyfin library item metadata with content hashing for incremental
+sync. Follows the same init()/close()/_conn pattern as SessionStore.
+Uses aiosqlite in WAL mode for concurrent read access.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import aiosqlite
+
+from app.library.models import LibraryItemRow, UpsertResult
+
+logger = logging.getLogger(__name__)
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS library_items (
+    jellyfin_id       TEXT PRIMARY KEY,
+    title             TEXT NOT NULL,
+    overview          TEXT,
+    production_year   INTEGER,
+    genres            TEXT NOT NULL DEFAULT '[]',
+    tags              TEXT NOT NULL DEFAULT '[]',
+    studios           TEXT NOT NULL DEFAULT '[]',
+    community_rating  REAL,
+    people            TEXT NOT NULL DEFAULT '[]',
+    content_hash      TEXT NOT NULL,
+    synced_at         INTEGER NOT NULL
+)
+"""
+
+_CREATE_INDEX_HASH = """
+CREATE INDEX IF NOT EXISTS idx_library_items_content_hash
+ON library_items(content_hash)
+"""
+
+_CREATE_INDEX_SYNCED = """
+CREATE INDEX IF NOT EXISTS idx_library_items_synced_at
+ON library_items(synced_at)
+"""
+
+# Maximum number of IDs per SQL IN clause batch
+_BATCH_SIZE = 500
+
+
+class LibraryStore:
+    """Async library metadata repository backed by SQLite."""
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._db: aiosqlite.Connection | None = None
+
+    async def init(self) -> None:
+        """Open the database connection and create the schema."""
+        self._db = await aiosqlite.connect(self._db_path)
+        await self._db.execute("PRAGMA journal_mode=WAL")
+        await self._db.execute("PRAGMA foreign_keys = ON")
+        await self._db.execute(_CREATE_TABLE)
+        await self._db.execute(_CREATE_INDEX_HASH)
+        await self._db.execute(_CREATE_INDEX_SYNCED)
+        await self._db.commit()
+
+    async def close(self) -> None:
+        """Close the database connection."""
+        if self._db:
+            await self._db.close()
+            self._db = None
+
+    @property
+    def _conn(self) -> aiosqlite.Connection:
+        if self._db is None:
+            msg = "LibraryStore not initialised — call init() first"
+            raise RuntimeError(msg)
+        return self._db
+
+    @staticmethod
+    def _row_to_item(row: Any) -> LibraryItemRow:
+        """Deserialize a database row into a LibraryItemRow."""
+        return LibraryItemRow(
+            jellyfin_id=row[0],
+            title=row[1],
+            overview=row[2],
+            production_year=row[3],
+            genres=json.loads(row[4]),
+            tags=json.loads(row[5]),
+            studios=json.loads(row[6]),
+            community_rating=row[7],
+            people=json.loads(row[8]),
+            content_hash=row[9],
+            synced_at=row[10],
+        )
+
+    async def upsert_many(self, items: list[LibraryItemRow]) -> UpsertResult:
+        """Bulk upsert library items with created/updated/unchanged tracking.
+
+        Wraps the entire batch in a single transaction. Fetches existing
+        hashes first to classify each item as created, updated, or unchanged.
+        Uses INSERT ... ON CONFLICT(jellyfin_id) DO UPDATE SET ... — never
+        INSERT OR REPLACE.
+        """
+        if not items:
+            return UpsertResult(created=0, updated=0, unchanged=0)
+
+        # Fetch existing hashes in bulk for comparison
+        existing_hashes = await self.get_all_hashes()
+
+        created = 0
+        updated = 0
+        unchanged = 0
+
+        for item in items:
+            old_hash = existing_hashes.get(item.jellyfin_id)
+            if old_hash is None:
+                created += 1
+            elif old_hash != item.content_hash:
+                updated += 1
+            else:
+                unchanged += 1
+
+            await self._conn.execute(
+                """INSERT INTO library_items
+                   (jellyfin_id, title, overview, production_year,
+                    genres, tags, studios, community_rating,
+                    people, content_hash, synced_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(jellyfin_id) DO UPDATE SET
+                    title = excluded.title,
+                    overview = excluded.overview,
+                    production_year = excluded.production_year,
+                    genres = excluded.genres,
+                    tags = excluded.tags,
+                    studios = excluded.studios,
+                    community_rating = excluded.community_rating,
+                    people = excluded.people,
+                    content_hash = excluded.content_hash,
+                    synced_at = excluded.synced_at""",
+                (
+                    item.jellyfin_id,
+                    item.title,
+                    item.overview,
+                    item.production_year,
+                    json.dumps(item.genres),
+                    json.dumps(item.tags),
+                    json.dumps(item.studios),
+                    item.community_rating,
+                    json.dumps(item.people),
+                    item.content_hash,
+                    item.synced_at,
+                ),
+            )
+
+        await self._conn.commit()
+        return UpsertResult(created=created, updated=updated, unchanged=unchanged)
+
+    async def get(self, jellyfin_id: str) -> LibraryItemRow | None:
+        """Fetch a single item by primary key."""
+        cursor = await self._conn.execute(
+            """SELECT jellyfin_id, title, overview, production_year,
+                      genres, tags, studios, community_rating,
+                      people, content_hash, synced_at
+               FROM library_items WHERE jellyfin_id = ?""",
+            (jellyfin_id,),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return self._row_to_item(row)
+
+    async def get_many(self, ids: list[str]) -> list[LibraryItemRow]:
+        """Fetch multiple items by Jellyfin IDs.
+
+        Uses parameterized queries (no string interpolation). Chunks into
+        batches of 500 for safety against SQLITE_MAX_VARIABLE_NUMBER.
+        Returns items in no guaranteed order.
+        """
+        if not ids:
+            return []
+
+        results: list[LibraryItemRow] = []
+
+        for i in range(0, len(ids), _BATCH_SIZE):
+            batch = ids[i : i + _BATCH_SIZE]
+            placeholders = ",".join("?" * len(batch))
+            cursor = await self._conn.execute(
+                f"""SELECT jellyfin_id, title, overview, production_year,
+                          genres, tags, studios, community_rating,
+                          people, content_hash, synced_at
+                   FROM library_items WHERE jellyfin_id IN ({placeholders})""",
+                batch,
+            )
+            rows = await cursor.fetchall()
+            results.extend(self._row_to_item(r) for r in rows)
+
+        return results
+
+    async def get_all_hashes(self) -> dict[str, str]:
+        """Return {jellyfin_id: content_hash} mapping for all items."""
+        cursor = await self._conn.execute(
+            "SELECT jellyfin_id, content_hash FROM library_items"
+        )
+        rows = await cursor.fetchall()
+        return {row[0]: row[1] for row in rows}
+
+    async def count(self) -> int:
+        """Return total number of items in the store."""
+        cursor = await self._conn.execute("SELECT COUNT(*) FROM library_items")
+        row = await cursor.fetchone()
+        return row[0] if row else 0

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from app.auth.service import AuthService, cleanup_expired_sessions
 from app.auth.session_store import SessionStore
 from app.config import Settings
 from app.jellyfin.client import JellyfinClient
+from app.library.store import LibraryStore
 from app.logging_config import configure_logging
 from app.middleware import SecurityHeadersMiddleware
 from app.middleware.csrf import CSRFMiddleware
@@ -87,6 +88,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         app.state.session_store = store
         app.state.cookie_key = cookie_key
 
+        # Open library store (after session store)
+        lib_db_dir = pathlib.Path(settings.library_db_path).parent
+        lib_db_dir.mkdir(parents=True, exist_ok=True)
+        library_store = LibraryStore(settings.library_db_path)
+        await library_store.init()
+        app.state.library_store = library_store
+
         # Create shared HTTP client and Jellyfin client
         http_client = httpx.AsyncClient(timeout=settings.jellyfin_timeout)
         jf_client = JellyfinClient(
@@ -94,6 +102,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             http_client=http_client,
         )
         app.state.jellyfin_client = jf_client
+
+        # Create sync JellyfinClient if API key is configured
+        if settings.jellyfin_api_key:
+            sync_jf_client = JellyfinClient(
+                base_url=settings.jellyfin_url,
+                http_client=http_client,
+                device_id="ai-movie-suggester-sync",
+            )
+            app.state.sync_jellyfin_client = sync_jf_client
+        else:
+            _logger.info("background sync disabled — JELLYFIN_API_KEY not configured")
 
         # Wire auth service and router
         auth_service = AuthService(
@@ -149,11 +168,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
         yield
 
-        # Shutdown
+        # Shutdown (reverse initialization order)
         cleanup_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await cleanup_task
         _logger.info("shutting down ai-movie-suggester backend")
+        await library_store.close()
         await store.close()
         await http_client.aclose()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -104,7 +104,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         app.state.jellyfin_client = jf_client
 
         # Create sync JellyfinClient if API key is configured
-        if settings.jellyfin_api_key:
+        if settings.jellyfin_api_key is not None:
             sync_jf_client = JellyfinClient(
                 base_url=settings.jellyfin_url,
                 http_client=http_client,

--- a/backend/tests/integration/test_jellyfin_library.py
+++ b/backend/tests/integration/test_jellyfin_library.py
@@ -6,6 +6,7 @@ Uses the existing fixture chain: jellyfin -> admin_auth_token -> test_users.
 
 from __future__ import annotations
 
+import dataclasses
 import time
 from typing import TYPE_CHECKING
 
@@ -63,20 +64,8 @@ def _to_library_row(item: LibraryItem) -> LibraryItemRow:
         content_hash="placeholder",
         synced_at=int(time.time()),
     )
-    # Compute real hash
-    return LibraryItemRow(
-        jellyfin_id=row.jellyfin_id,
-        title=row.title,
-        overview=row.overview,
-        production_year=row.production_year,
-        genres=row.genres,
-        tags=row.tags,
-        studios=row.studios,
-        community_rating=row.community_rating,
-        people=row.people,
-        content_hash=compute_content_hash(row),
-        synced_at=row.synced_at,
-    )
+    # Compute real hash and replace placeholder
+    return dataclasses.replace(row, content_hash=compute_content_hash(row))
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/test_jellyfin_library.py
+++ b/backend/tests/integration/test_jellyfin_library.py
@@ -1,0 +1,151 @@
+"""Integration tests for Jellyfin library client + store cycle.
+
+Requires: make jellyfin-up (disposable Jellyfin on localhost:8096).
+Uses the existing fixture chain: jellyfin -> admin_auth_token -> test_users.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from app.jellyfin.client import JellyfinClient
+from app.library.hashing import compute_content_hash
+from app.library.models import LibraryItemRow
+from app.library.store import LibraryStore
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import AsyncGenerator
+
+    from app.jellyfin.models import LibraryItem, PaginatedItems
+    from tests.integration.conftest import JellyfinInstance
+
+from tests.integration.conftest import TEST_USER_ALICE, TEST_USER_ALICE_PASS
+
+
+@pytest_asyncio.fixture
+async def jf_client(
+    jellyfin: JellyfinInstance,
+) -> AsyncGenerator[JellyfinClient, None]:
+    """JellyfinClient pointed at the test instance."""
+    async with httpx.AsyncClient(timeout=10.0) as http:
+        yield JellyfinClient(base_url=jellyfin.url, http_client=http)
+
+
+@pytest_asyncio.fixture
+async def library_store(tmp_path: pathlib.Path) -> AsyncGenerator[LibraryStore, None]:
+    """Temporary LibraryStore for integration tests."""
+    db_path = tmp_path / "test_library.db"
+    store = LibraryStore(str(db_path))
+    await store.init()
+    yield store
+    await store.close()
+
+
+def _to_library_row(item: LibraryItem) -> LibraryItemRow:
+    """Convert a LibraryItem to a LibraryItemRow for storage."""
+    actor_names = [p["Name"] for p in item.people if p.get("Type") == "Actor"]
+    row = LibraryItemRow(
+        jellyfin_id=item.id,
+        title=item.name,
+        overview=item.overview,
+        production_year=item.production_year,
+        genres=item.genres,
+        tags=item.tags,
+        studios=item.studios,
+        community_rating=item.community_rating,
+        people=actor_names,
+        content_hash="placeholder",
+        synced_at=int(time.time()),
+    )
+    # Compute real hash
+    return LibraryItemRow(
+        jellyfin_id=row.jellyfin_id,
+        title=row.title,
+        overview=row.overview,
+        production_year=row.production_year,
+        genres=row.genres,
+        tags=row.tags,
+        studios=row.studios,
+        community_rating=row.community_rating,
+        people=row.people,
+        content_hash=compute_content_hash(row),
+        synced_at=row.synced_at,
+    )
+
+
+@pytest.mark.integration
+async def test_get_all_items_returns_pages(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+) -> None:
+    """get_all_items returns pages — may be 0 items on fresh Jellyfin."""
+    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    pages: list[PaginatedItems] = []
+    async for page in jf_client.get_all_items(
+        auth.access_token,
+        auth.user_id,
+        item_types=["Movie"],
+    ):
+        pages.append(page)
+
+    assert len(pages) >= 1
+    # First page always exists (even if empty)
+    assert pages[0].total_count >= 0
+
+
+@pytest.mark.integration
+async def test_fetch_and_store_cycle(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+    library_store: LibraryStore,
+) -> None:
+    """Fetch items via get_all_items, store in LibraryStore, verify count."""
+    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    total_items = 0
+    all_rows: list[LibraryItemRow] = []
+
+    async for page in jf_client.get_all_items(
+        auth.access_token,
+        auth.user_id,
+        item_types=["Movie"],
+    ):
+        total_items = page.total_count
+        for item in page.items:
+            all_rows.append(_to_library_row(item))
+
+    if all_rows:
+        await library_store.upsert_many(all_rows)
+
+    count = await library_store.count()
+    assert count == len(all_rows)
+    # On a fresh Jellyfin with no movies, both should be 0
+    assert count == total_items
+
+
+@pytest.mark.integration
+async def test_extended_fields_no_validation_errors(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+) -> None:
+    """Extended fields parse without Pydantic validation errors."""
+    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    async for page in jf_client.get_all_items(
+        auth.access_token,
+        auth.user_id,
+        item_types=["Movie"],
+    ):
+        for item in page.items:
+            # These should not raise — Pydantic validates on construction
+            assert isinstance(item.tags, list)
+            assert isinstance(item.studios, list)
+            assert isinstance(item.people, list)
+            # community_rating can be None
+            assert item.community_rating is None or isinstance(
+                item.community_rating, float
+            )

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -258,11 +258,12 @@ def test_jellyfin_api_key_default_none() -> None:
 
 
 def test_jellyfin_api_key_valid_value() -> None:
-    """Valid JELLYFIN_API_KEY is stored in settings."""
+    """Valid JELLYFIN_API_KEY is stored as SecretStr in settings."""
     env = {**_REQUIRED_ENV, "JELLYFIN_API_KEY": "my-api-key-123"}
     with patch.dict(os.environ, env, clear=True):
         s = Settings()  # type: ignore[call-arg]
-    assert s.jellyfin_api_key == "my-api-key-123"
+    assert s.jellyfin_api_key is not None
+    assert s.jellyfin_api_key.get_secret_value() == "my-api-key-123"
 
 
 def test_jellyfin_api_key_empty_treated_as_none() -> None:
@@ -286,4 +287,5 @@ def test_jellyfin_api_key_whitespace_stripped() -> None:
     env = {**_REQUIRED_ENV, "JELLYFIN_API_KEY": "  key123  "}
     with patch.dict(os.environ, env, clear=True):
         s = Settings()  # type: ignore[call-arg]
-    assert s.jellyfin_api_key == "key123"
+    assert s.jellyfin_api_key is not None
+    assert s.jellyfin_api_key.get_secret_value() == "key123"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -225,3 +225,14 @@ def test_blocklist_accepts_strong_secret() -> None:
     with patch.dict(os.environ, env, clear=True):
         s = Settings()  # type: ignore[call-arg]
     assert len(s.session_secret) >= 32
+
+
+# --- library sync config ---
+
+
+def test_library_sync_page_size_default() -> None:
+    """library_sync_page_size defaults to 200."""
+    env = _REQUIRED_ENV.copy()
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.library_sync_page_size == 200

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -236,3 +236,11 @@ def test_library_sync_page_size_default() -> None:
     with patch.dict(os.environ, env, clear=True):
         s = Settings()  # type: ignore[call-arg]
     assert s.library_sync_page_size == 200
+
+
+def test_library_db_path_default() -> None:
+    """library_db_path defaults to 'data/library.db'."""
+    env = _REQUIRED_ENV.copy()
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.library_db_path == "data/library.db"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -244,3 +244,46 @@ def test_library_db_path_default() -> None:
     with patch.dict(os.environ, env, clear=True):
         s = Settings()  # type: ignore[call-arg]
     assert s.library_db_path == "data/library.db"
+
+
+# --- jellyfin_api_key ---
+
+
+def test_jellyfin_api_key_default_none() -> None:
+    """jellyfin_api_key defaults to None when env var not set."""
+    env = _REQUIRED_ENV.copy()
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.jellyfin_api_key is None
+
+
+def test_jellyfin_api_key_valid_value() -> None:
+    """Valid JELLYFIN_API_KEY is stored in settings."""
+    env = {**_REQUIRED_ENV, "JELLYFIN_API_KEY": "my-api-key-123"}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.jellyfin_api_key == "my-api-key-123"
+
+
+def test_jellyfin_api_key_empty_treated_as_none() -> None:
+    """Empty string JELLYFIN_API_KEY is treated as None."""
+    env = {**_REQUIRED_ENV, "JELLYFIN_API_KEY": ""}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.jellyfin_api_key is None
+
+
+def test_jellyfin_api_key_whitespace_treated_as_none() -> None:
+    """Whitespace-only JELLYFIN_API_KEY is treated as None."""
+    env = {**_REQUIRED_ENV, "JELLYFIN_API_KEY": "   "}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.jellyfin_api_key is None
+
+
+def test_jellyfin_api_key_whitespace_stripped() -> None:
+    """JELLYFIN_API_KEY with leading/trailing whitespace is stripped."""
+    env = {**_REQUIRED_ENV, "JELLYFIN_API_KEY": "  key123  "}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.jellyfin_api_key == "key123"

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 from pydantic import ValidationError
 
-from app.jellyfin.client import JellyfinClient
+from app.jellyfin.client import _ITEM_FIELDS, JellyfinClient
 from app.jellyfin.errors import (
     JellyfinAuthError,
     JellyfinConnectionError,
@@ -107,6 +107,87 @@ class TestLibraryItem:
         assert item.overview == "A great comedy."
         assert item.genres == ["Comedy", "Sci-Fi"]
         assert item.production_year == 1999
+
+    def test_parse_all_extended_fields(self) -> None:
+        """LibraryItem parses all new fields from representative Jellyfin JSON."""
+        data = {
+            "Id": "item-3",
+            "Name": "Toy Story",
+            "Type": "Movie",
+            "Overview": "A story about toys.",
+            "Genres": ["Animation", "Comedy"],
+            "ProductionYear": 1995,
+            "Tags": ["family", "classic"],
+            "Studios": [{"Name": "Pixar", "Id": "studio-1"}],
+            "CommunityRating": 8.3,
+            "People": [
+                {"Name": "Tom Hanks", "Role": "Woody", "Type": "Actor"},
+                {"Name": "John Lasseter", "Role": "", "Type": "Director"},
+            ],
+        }
+        item = LibraryItem.model_validate(data)
+        assert item.tags == ["family", "classic"]
+        assert item.studios == ["Pixar"]
+        assert item.community_rating == 8.3
+        assert len(item.people) == 2
+        assert item.people[0]["Name"] == "Tom Hanks"
+        assert item.people[0]["Type"] == "Actor"
+        assert item.people[1]["Type"] == "Director"
+
+    def test_extended_fields_default_when_absent(self) -> None:
+        """New fields default correctly when absent from JSON."""
+        data = {"Id": "item-4", "Name": "Minimal Movie", "Type": "Movie"}
+        item = LibraryItem.model_validate(data)
+        assert item.tags == []
+        assert item.studios == []
+        assert item.community_rating is None
+        assert item.people == []
+
+    def test_studios_validator_extracts_names_from_objects(self) -> None:
+        """Studios validator extracts Name from studio objects."""
+        data = {
+            "Id": "item-5",
+            "Name": "Finding Nemo",
+            "Type": "Movie",
+            "Studios": [
+                {"Name": "Pixar", "Id": "abc"},
+                {"Name": "Disney", "Id": "def"},
+            ],
+        }
+        item = LibraryItem.model_validate(data)
+        assert item.studios == ["Pixar", "Disney"]
+
+    def test_studios_validator_handles_plain_string_list(self) -> None:
+        """Studios validator passes through plain string list."""
+        data = {
+            "Id": "item-6",
+            "Name": "Some Movie",
+            "Type": "Movie",
+            "Studios": ["Pixar", "Disney"],
+        }
+        item = LibraryItem.model_validate(data)
+        assert item.studios == ["Pixar", "Disney"]
+
+    def test_people_field_parses_raw_jellyfin_array(self) -> None:
+        """People field parses raw Jellyfin People array with Name, Role, Type."""
+        data = {
+            "Id": "item-7",
+            "Name": "Cast Movie",
+            "Type": "Movie",
+            "People": [
+                {"Name": "Actor One", "Role": "Lead", "Type": "Actor"},
+                {"Name": "Director One", "Role": "", "Type": "Director"},
+                {"Name": "Writer One", "Role": "", "Type": "Writer"},
+            ],
+        }
+        item = LibraryItem.model_validate(data)
+        assert len(item.people) == 3
+        assert item.people[0] == {
+            "Name": "Actor One",
+            "Role": "Lead",
+            "Type": "Actor",
+        }
+        assert item.people[2]["Type"] == "Writer"
 
 
 class TestPaginatedItems:
@@ -443,3 +524,117 @@ class TestGetItems:
         mock_http.request.return_value = httpx.Response(500, request=_FAKE_REQUEST)
         with pytest.raises(JellyfinError):
             await jf_client.get_items("tok-123", "uid-1")
+
+
+class TestGetAllItems:
+    """Tests for get_all_items() auto-paginating async iterator."""
+
+    async def test_two_pages_yields_both(self, jf_client: JellyfinClient) -> None:
+        """Mock get_items() returning two pages, verify iterator yields both."""
+        page1_items = [
+            LibraryItem(id=f"item-{i}", name=f"Movie {i}", type="Movie")
+            for i in range(200)
+        ]
+        page2_items = [
+            LibraryItem(id=f"item-{i}", name=f"Movie {i}", type="Movie")
+            for i in range(200, 250)
+        ]
+        page1 = PaginatedItems(items=page1_items, total_count=250, start_index=0)
+        page2 = PaginatedItems(items=page2_items, total_count=250, start_index=200)
+
+        call_count = 0
+
+        async def mock_get_items(
+            token: str,
+            user_id: str,
+            *,
+            item_types: list[str] | None = None,
+            start_index: int = 0,
+            limit: int = 50,
+            recursive: bool = True,
+        ) -> PaginatedItems:
+            nonlocal call_count
+            call_count += 1
+            if start_index == 0:
+                return page1
+            return page2
+
+        with patch.object(jf_client, "get_items", side_effect=mock_get_items):
+            pages: list[PaginatedItems] = []
+            async for page in jf_client.get_all_items(
+                "tok-123", "uid-1", page_size=200
+            ):
+                pages.append(page)
+
+        assert len(pages) == 2
+        assert len(pages[0].items) == 200
+        assert len(pages[1].items) == 50
+        assert call_count == 2
+
+    async def test_empty_library(self, jf_client: JellyfinClient) -> None:
+        """Empty library yields one page with zero items and stops."""
+        empty_page = PaginatedItems(items=[], total_count=0, start_index=0)
+
+        with patch.object(jf_client, "get_items", return_value=empty_page):
+            pages: list[PaginatedItems] = []
+            async for page in jf_client.get_all_items("tok-123", "uid-1"):
+                pages.append(page)
+
+        assert len(pages) == 1
+        assert pages[0].items == []
+        assert pages[0].total_count == 0
+
+    async def test_auth_error_propagates(self, jf_client: JellyfinClient) -> None:
+        """JellyfinAuthError on first page propagates immediately."""
+        with (
+            patch.object(
+                jf_client, "get_items", side_effect=JellyfinAuthError("expired")
+            ),
+            pytest.raises(JellyfinAuthError),
+        ):
+            async for _page in jf_client.get_all_items("bad-tok", "uid-1"):
+                pass  # pragma: no cover
+
+    async def test_mid_pagination_error(self, jf_client: JellyfinClient) -> None:
+        """JellyfinConnectionError on second page propagates after first yielded."""
+        page1_items = [
+            LibraryItem(id=f"item-{i}", name=f"Movie {i}", type="Movie")
+            for i in range(200)
+        ]
+        page1 = PaginatedItems(items=page1_items, total_count=400, start_index=0)
+
+        call_count = 0
+
+        async def mock_get_items(
+            token: str,
+            user_id: str,
+            *,
+            item_types: list[str] | None = None,
+            start_index: int = 0,
+            limit: int = 50,
+            recursive: bool = True,
+        ) -> PaginatedItems:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return page1
+            raise JellyfinConnectionError("Connection lost")
+
+        pages_received: list[PaginatedItems] = []
+        with (
+            patch.object(jf_client, "get_items", side_effect=mock_get_items),
+            pytest.raises(JellyfinConnectionError),
+        ):
+            async for page in jf_client.get_all_items(
+                "tok-123", "uid-1", page_size=200
+            ):
+                pages_received.append(page)
+
+        assert len(pages_received) == 1
+
+    def test_item_fields_includes_extended_fields(self) -> None:
+        """_ITEM_FIELDS constant includes Tags, Studios, CommunityRating, People."""
+        assert "Tags" in _ITEM_FIELDS
+        assert "Studios" in _ITEM_FIELDS
+        assert "CommunityRating" in _ITEM_FIELDS
+        assert "People" in _ITEM_FIELDS

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -532,15 +532,15 @@ class TestGetAllItems:
     async def test_two_pages_yields_both(self, jf_client: JellyfinClient) -> None:
         """Mock get_items() returning two pages, verify iterator yields both."""
         page1_items = [
-            LibraryItem(id=f"item-{i}", name=f"Movie {i}", type="Movie")
+            LibraryItem(Id=f"item-{i}", Name=f"Movie {i}", Type="Movie")
             for i in range(200)
         ]
         page2_items = [
-            LibraryItem(id=f"item-{i}", name=f"Movie {i}", type="Movie")
+            LibraryItem(Id=f"item-{i}", Name=f"Movie {i}", Type="Movie")
             for i in range(200, 250)
         ]
-        page1 = PaginatedItems(items=page1_items, total_count=250, start_index=0)
-        page2 = PaginatedItems(items=page2_items, total_count=250, start_index=200)
+        page1 = PaginatedItems(Items=page1_items, TotalRecordCount=250, StartIndex=0)
+        page2 = PaginatedItems(Items=page2_items, TotalRecordCount=250, StartIndex=200)
 
         call_count = 0
 
@@ -573,7 +573,7 @@ class TestGetAllItems:
 
     async def test_empty_library(self, jf_client: JellyfinClient) -> None:
         """Empty library yields one page with zero items and stops."""
-        empty_page = PaginatedItems(items=[], total_count=0, start_index=0)
+        empty_page = PaginatedItems(Items=[], TotalRecordCount=0, StartIndex=0)
 
         with patch.object(jf_client, "get_items", return_value=empty_page):
             pages: list[PaginatedItems] = []
@@ -598,10 +598,10 @@ class TestGetAllItems:
     async def test_mid_pagination_error(self, jf_client: JellyfinClient) -> None:
         """JellyfinConnectionError on second page propagates after first yielded."""
         page1_items = [
-            LibraryItem(id=f"item-{i}", name=f"Movie {i}", type="Movie")
+            LibraryItem(Id=f"item-{i}", Name=f"Movie {i}", Type="Movie")
             for i in range(200)
         ]
-        page1 = PaginatedItems(items=page1_items, total_count=400, start_index=0)
+        page1 = PaginatedItems(Items=page1_items, TotalRecordCount=400, StartIndex=0)
 
         call_count = 0
 

--- a/backend/tests/test_library_store.py
+++ b/backend/tests/test_library_store.py
@@ -1,0 +1,326 @@
+"""Unit tests for the async SQLite library metadata repository."""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.library.hashing import compute_content_hash
+from app.library.models import LibraryItemRow, UpsertResult
+from app.library.store import LibraryStore
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _make_item(
+    jellyfin_id: str = "jf-1",
+    title: str = "Alien",
+    overview: str | None = "In space no one can hear you scream.",
+    production_year: int | None = 1979,
+    genres: list[str] | None = None,
+    tags: list[str] | None = None,
+    studios: list[str] | None = None,
+    community_rating: float | None = 8.5,
+    people: list[str] | None = None,
+    content_hash: str = "abc123hash",
+    synced_at: int | None = None,
+) -> LibraryItemRow:
+    """Helper to build LibraryItemRow with sensible defaults."""
+    return LibraryItemRow(
+        jellyfin_id=jellyfin_id,
+        title=title,
+        overview=overview,
+        production_year=production_year,
+        genres=genres if genres is not None else ["Sci-Fi", "Horror"],
+        tags=tags if tags is not None else ["classic"],
+        studios=studios if studios is not None else ["20th Century Fox"],
+        community_rating=community_rating,
+        people=people if people is not None else ["Sigourney Weaver", "Tom Skerritt"],
+        content_hash=content_hash,
+        synced_at=synced_at if synced_at is not None else _now(),
+    )
+
+
+@pytest.fixture
+async def store(tmp_path: object) -> AsyncIterator[LibraryStore]:
+    """Provide a fresh LibraryStore backed by a temp DB."""
+    db_path = pathlib.Path(str(tmp_path)) / "test_library.db"
+    s = LibraryStore(str(db_path))
+    await s.init()
+    yield s  # type: ignore[misc]
+    await s.close()
+
+
+class TestInit:
+    """Verify schema creation and PRAGMA settings."""
+
+    async def test_table_exists(self, store: LibraryStore) -> None:
+        cursor = await store._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='library_items'"
+        )
+        row = await cursor.fetchone()
+        assert row is not None
+        assert row[0] == "library_items"
+
+    async def test_indexes_exist(self, store: LibraryStore) -> None:
+        cursor = await store._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND name IN ("
+            "'idx_library_items_content_hash', "
+            "'idx_library_items_synced_at')"
+        )
+        rows = await cursor.fetchall()
+        index_names = {r[0] for r in rows}
+        assert "idx_library_items_content_hash" in index_names
+        assert "idx_library_items_synced_at" in index_names
+
+    async def test_wal_mode(self, store: LibraryStore) -> None:
+        cursor = await store._conn.execute("PRAGMA journal_mode")
+        row = await cursor.fetchone()
+        assert row is not None
+        assert row[0] == "wal"
+
+    async def test_foreign_keys_enabled(self, store: LibraryStore) -> None:
+        cursor = await store._conn.execute("PRAGMA foreign_keys")
+        row = await cursor.fetchone()
+        assert row is not None
+        assert row[0] == 1
+
+    def test_conn_before_init_raises(self) -> None:
+        s = LibraryStore("/tmp/nonexistent.db")
+        with pytest.raises(RuntimeError, match="LibraryStore not initialised"):
+            _ = s._conn
+
+
+class TestUpsertMany:
+    """upsert_many() created/updated/unchanged tracking."""
+
+    async def test_insert_new_items(self, store: LibraryStore) -> None:
+        items = [_make_item(jellyfin_id=f"jf-{i}") for i in range(3)]
+        result = await store.upsert_many(items)
+        assert result == UpsertResult(created=3, updated=0, unchanged=0)
+
+    async def test_reupsert_same_hash_unchanged(self, store: LibraryStore) -> None:
+        items = [
+            _make_item(jellyfin_id=f"jf-{i}", content_hash="same-hash")
+            for i in range(3)
+        ]
+        await store.upsert_many(items)
+        result = await store.upsert_many(items)
+        assert result == UpsertResult(created=0, updated=0, unchanged=3)
+
+    async def test_changed_hash_counts_as_updated(self, store: LibraryStore) -> None:
+        items = [
+            _make_item(jellyfin_id=f"jf-{i}", content_hash=f"hash-{i}")
+            for i in range(3)
+        ]
+        await store.upsert_many(items)
+        # Change hash for one item
+        updated_items = [
+            _make_item(jellyfin_id="jf-0", content_hash="new-hash"),
+            _make_item(jellyfin_id="jf-1", content_hash="hash-1"),
+            _make_item(jellyfin_id="jf-2", content_hash="hash-2"),
+        ]
+        result = await store.upsert_many(updated_items)
+        assert result == UpsertResult(created=0, updated=1, unchanged=2)
+
+    async def test_empty_list(self, store: LibraryStore) -> None:
+        result = await store.upsert_many([])
+        assert result == UpsertResult(created=0, updated=0, unchanged=0)
+
+
+class TestGet:
+    """get() single item retrieval."""
+
+    async def test_round_trip_all_fields(self, store: LibraryStore) -> None:
+        item = _make_item(
+            jellyfin_id="jf-roundtrip",
+            title="Galaxy Quest",
+            overview="A comedy about actors in space.",
+            production_year=1999,
+            genres=["Comedy", "Sci-Fi"],
+            tags=["family", "fun"],
+            studios=["DreamWorks"],
+            community_rating=7.4,
+            people=["Tim Allen", "Sigourney Weaver"],
+            content_hash="hash-gq",
+            synced_at=1700000000,
+        )
+        await store.upsert_many([item])
+        fetched = await store.get("jf-roundtrip")
+        assert fetched is not None
+        assert fetched.jellyfin_id == "jf-roundtrip"
+        assert fetched.title == "Galaxy Quest"
+        assert fetched.overview == "A comedy about actors in space."
+        assert fetched.production_year == 1999
+        assert fetched.genres == ["Comedy", "Sci-Fi"]
+        assert fetched.tags == ["family", "fun"]
+        assert fetched.studios == ["DreamWorks"]
+        assert fetched.community_rating == 7.4
+        assert fetched.people == ["Tim Allen", "Sigourney Weaver"]
+        assert fetched.content_hash == "hash-gq"
+        assert fetched.synced_at == 1700000000
+
+    async def test_missing_id_returns_none(self, store: LibraryStore) -> None:
+        assert await store.get("nonexistent") is None
+
+
+class TestGetMany:
+    """get_many() batch retrieval."""
+
+    async def test_fetch_subset(self, store: LibraryStore) -> None:
+        items = [_make_item(jellyfin_id=f"jf-{i}") for i in range(5)]
+        await store.upsert_many(items)
+        results = await store.get_many(["jf-0", "jf-2", "jf-4"])
+        assert len(results) == 3
+        ids = {r.jellyfin_id for r in results}
+        assert ids == {"jf-0", "jf-2", "jf-4"}
+
+    async def test_mix_existing_and_nonexistent(self, store: LibraryStore) -> None:
+        items = [_make_item(jellyfin_id=f"jf-{i}") for i in range(3)]
+        await store.upsert_many(items)
+        results = await store.get_many(["jf-0", "jf-1", "nonexistent", "also-missing"])
+        assert len(results) == 2
+        ids = {r.jellyfin_id for r in results}
+        assert ids == {"jf-0", "jf-1"}
+
+    async def test_empty_list_returns_empty(self, store: LibraryStore) -> None:
+        results = await store.get_many([])
+        assert results == []
+
+
+class TestGetAllHashes:
+    """get_all_hashes() hash mapping."""
+
+    async def test_returns_hash_mapping(self, store: LibraryStore) -> None:
+        items = [
+            _make_item(jellyfin_id=f"jf-{i}", content_hash=f"hash-{i}")
+            for i in range(3)
+        ]
+        await store.upsert_many(items)
+        hashes = await store.get_all_hashes()
+        assert hashes == {"jf-0": "hash-0", "jf-1": "hash-1", "jf-2": "hash-2"}
+
+    async def test_empty_store_returns_empty_dict(self, store: LibraryStore) -> None:
+        hashes = await store.get_all_hashes()
+        assert hashes == {}
+
+
+class TestCount:
+    """count() total items."""
+
+    async def test_empty_store_returns_zero(self, store: LibraryStore) -> None:
+        assert await store.count() == 0
+
+    async def test_after_inserts(self, store: LibraryStore) -> None:
+        items = [_make_item(jellyfin_id=f"jf-{i}") for i in range(5)]
+        await store.upsert_many(items)
+        assert await store.count() == 5
+
+
+class TestContentHash:
+    """Content hash computation determinism."""
+
+    def test_deterministic(self) -> None:
+        item = _make_item()
+        hash1 = compute_content_hash(item)
+        hash2 = compute_content_hash(item)
+        assert hash1 == hash2
+
+    def test_different_input_different_hash(self) -> None:
+        item1 = _make_item(title="Alien")
+        item2 = _make_item(title="Aliens")
+        assert compute_content_hash(item1) != compute_content_hash(item2)
+
+
+class TestPeopleFiltering:
+    """Verify people filtering from Jellyfin's raw People array."""
+
+    async def test_only_actor_names_stored(self, store: LibraryStore) -> None:
+        """When building LibraryItemRow from Jellyfin data, only Actor names
+        should be in the people list. Non-Actor entries are excluded."""
+        # Simulating the conversion logic that would be done by the sync layer:
+        # Jellyfin raw people data
+        raw_people = [
+            {"Name": "Tom Hanks", "Role": "Woody", "Type": "Actor"},
+            {"Name": "Tim Allen", "Role": "Buzz", "Type": "Actor"},
+            {"Name": "John Lasseter", "Role": "", "Type": "Director"},
+            {"Name": "Randy Newman", "Role": "", "Type": "Composer"},
+        ]
+        # Filter to actors only (as the sync layer should do)
+        actor_names = [p["Name"] for p in raw_people if p.get("Type") == "Actor"]
+        item = _make_item(
+            jellyfin_id="jf-actors",
+            people=actor_names,
+        )
+        await store.upsert_many([item])
+        fetched = await store.get("jf-actors")
+        assert fetched is not None
+        assert fetched.people == ["Tom Hanks", "Tim Allen"]
+        assert "John Lasseter" not in fetched.people
+        assert "Randy Newman" not in fetched.people
+
+
+class TestValidation:
+    """Malformed data handling."""
+
+    async def test_malformed_item_skipped_valid_stored(
+        self, store: LibraryStore, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Malformed Jellyfin item data is skipped with WARNING log,
+        valid items in the same batch are stored."""
+        from pydantic import ValidationError as PydanticValidationError
+
+        from app.jellyfin.models import LibraryItem
+
+        # One valid, one malformed (missing required Id)
+        valid_data = {"Id": "valid-1", "Name": "Good Movie", "Type": "Movie"}
+        malformed_data = {"Name": "Bad Movie", "Type": "Movie"}  # Missing Id
+
+        items_to_store: list[LibraryItemRow] = []
+
+        for raw in [valid_data, malformed_data]:
+            try:
+                lib_item = LibraryItem.model_validate(raw)
+                # Filter people to actors only
+                actor_names = [
+                    p["Name"] for p in lib_item.people if p.get("Type") == "Actor"
+                ]
+                row = LibraryItemRow(
+                    jellyfin_id=lib_item.id,
+                    title=lib_item.name,
+                    overview=lib_item.overview,
+                    production_year=lib_item.production_year,
+                    genres=lib_item.genres,
+                    tags=lib_item.tags,
+                    studios=lib_item.studios,
+                    community_rating=lib_item.community_rating,
+                    people=actor_names,
+                    content_hash="placeholder-hash",
+                    synced_at=_now(),
+                )
+                items_to_store.append(row)
+            except PydanticValidationError:
+                item_id = raw.get("Id", "unknown")
+                logging.getLogger(__name__).warning(
+                    "Skipping malformed library item: %s", item_id
+                )
+
+        with caplog.at_level(logging.WARNING):
+            result = await store.upsert_many(items_to_store)
+
+        assert result.created == 1
+        assert await store.count() == 1
+        fetched = await store.get("valid-1")
+        assert fetched is not None
+        assert fetched.title == "Good Movie"
+        assert any("malformed" in r.message.lower() for r in caplog.records)

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,132 @@
+"""Unit tests for application lifespan and wiring."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from tests.conftest import make_test_settings
+
+
+class TestLifespan:
+    """Verify LibraryStore wiring in lifespan."""
+
+    @patch("app.main.LibraryStore")
+    @patch("app.main.SessionStore")
+    def test_library_store_init_called(
+        self,
+        mock_session_cls: MagicMock,
+        mock_library_cls: MagicMock,
+    ) -> None:
+        """LibraryStore.init() is called during startup."""
+        mock_session_instance = AsyncMock()
+        mock_session_cls.return_value = mock_session_instance
+        mock_library_instance = AsyncMock()
+        mock_library_cls.return_value = mock_library_instance
+
+        from app.main import create_app
+
+        settings = make_test_settings()
+        app = create_app(settings)
+
+        with TestClient(app):
+            mock_library_instance.init.assert_called_once()
+
+    @patch("app.main.LibraryStore")
+    @patch("app.main.SessionStore")
+    def test_library_store_on_app_state(
+        self,
+        mock_session_cls: MagicMock,
+        mock_library_cls: MagicMock,
+    ) -> None:
+        """app.state.library_store is set after startup."""
+        mock_session_instance = AsyncMock()
+        mock_session_cls.return_value = mock_session_instance
+        mock_library_instance = AsyncMock()
+        mock_library_cls.return_value = mock_library_instance
+
+        from app.main import create_app
+
+        settings = make_test_settings()
+        app = create_app(settings)
+
+        with TestClient(app):
+            assert app.state.library_store is mock_library_instance
+
+    @patch("app.main.LibraryStore")
+    @patch("app.main.SessionStore")
+    def test_shutdown_order_library_before_session(
+        self,
+        mock_session_cls: MagicMock,
+        mock_library_cls: MagicMock,
+    ) -> None:
+        """LibraryStore.close() is called before SessionStore.close()."""
+        mock_session_instance = AsyncMock()
+        mock_session_cls.return_value = mock_session_instance
+        mock_library_instance = AsyncMock()
+        mock_library_cls.return_value = mock_library_instance
+
+        # Track call order
+        call_order: list[str] = []
+        mock_library_instance.close.side_effect = lambda: call_order.append(
+            "library_close"
+        )
+        mock_session_instance.close.side_effect = lambda: call_order.append(
+            "session_close"
+        )
+
+        from app.main import create_app
+
+        settings = make_test_settings()
+        app = create_app(settings)
+
+        with TestClient(app):
+            pass  # startup + shutdown
+
+        assert "library_close" in call_order
+        assert "session_close" in call_order
+        assert call_order.index("library_close") < call_order.index("session_close")
+
+    @patch("app.main.LibraryStore")
+    @patch("app.main.SessionStore")
+    def test_sync_client_created_with_api_key(
+        self,
+        mock_session_cls: MagicMock,
+        mock_library_cls: MagicMock,
+    ) -> None:
+        """Sync JellyfinClient created when jellyfin_api_key is set."""
+        mock_session_instance = AsyncMock()
+        mock_session_cls.return_value = mock_session_instance
+        mock_library_instance = AsyncMock()
+        mock_library_cls.return_value = mock_library_instance
+
+        from app.main import create_app
+
+        settings = make_test_settings(jellyfin_api_key="test-api-key")
+        app = create_app(settings)
+
+        with TestClient(app):
+            assert hasattr(app.state, "sync_jellyfin_client")
+            assert app.state.sync_jellyfin_client is not None
+
+    @patch("app.main.LibraryStore")
+    @patch("app.main.SessionStore")
+    def test_no_sync_client_without_api_key(
+        self,
+        mock_session_cls: MagicMock,
+        mock_library_cls: MagicMock,
+    ) -> None:
+        """Sync JellyfinClient NOT created when jellyfin_api_key is None."""
+        mock_session_instance = AsyncMock()
+        mock_session_cls.return_value = mock_session_instance
+        mock_library_instance = AsyncMock()
+        mock_library_cls.return_value = mock_library_instance
+
+        from app.main import create_app
+
+        settings = make_test_settings()
+        app = create_app(settings)
+
+        with TestClient(app):
+            assert not hasattr(app.state, "sync_jellyfin_client")

--- a/docs/specs/05-spec-jellyfin-library-client/05-proofs/05-task-10-proofs.md
+++ b/docs/specs/05-spec-jellyfin-library-client/05-proofs/05-task-10-proofs.md
@@ -1,0 +1,38 @@
+# Task 1.0 Proof Artifacts — Extended LibraryItem Model + Auto-Paginated Client
+
+## Test Results
+
+```
+155 passed, 17 warnings in 0.65s
+```
+
+All unit tests pass (excluding integration tests).
+
+## Tests Added
+
+### TestLibraryItem (model extensions)
+- `test_parse_all_extended_fields` — All new fields (tags, studios, community_rating, people) parse from representative Jellyfin JSON
+- `test_extended_fields_default_when_absent` — New fields default correctly (tags=[], studios=[], community_rating=None, people=[])
+- `test_studios_validator_extracts_names_from_objects` — Studios validator extracts Name from `[{"Name": "Pixar", "Id": "abc"}]` -> `["Pixar"]`
+- `test_studios_validator_handles_plain_string_list` — Studios validator passes through plain string list
+- `test_people_field_parses_raw_jellyfin_array` — People field parses raw Jellyfin People array with Name, Role, Type dicts
+
+### TestGetAllItems (auto-pagination)
+- `test_two_pages_yields_both` — Mock get_items() returning 200 + 50 items (total_count=250), verifies exactly two PaginatedItems yielded, stops after second page
+- `test_empty_library` — Empty library yields one page with zero items and stops
+- `test_auth_error_propagates` — JellyfinAuthError on first page propagates immediately
+- `test_mid_pagination_error` — JellyfinConnectionError on second page propagates after first page yielded
+- `test_item_fields_includes_extended_fields` — _ITEM_FIELDS includes Tags, Studios, CommunityRating, People
+
+### Config
+- `test_library_sync_page_size_default` — library_sync_page_size defaults to 200
+
+## Verification
+
+- `_ITEM_FIELDS` in `backend/app/jellyfin/client.py`: `"Overview,Genres,ProductionYear,Tags,Studios,CommunityRating,People"`
+- `LIBRARY_SYNC_PAGE_SIZE` in `backend/app/config.py`: defaults to `200`
+
+## Lint / Format
+
+- `ruff check app/ tests/` — All checks passed
+- `ruff format --check app/ tests/` — All files formatted

--- a/docs/specs/05-spec-jellyfin-library-client/05-proofs/05-task-20-proofs.md
+++ b/docs/specs/05-spec-jellyfin-library-client/05-proofs/05-task-20-proofs.md
@@ -1,0 +1,67 @@
+# Task 2.0 Proof Artifacts — Library Metadata Store (SQLite Repository)
+
+## Test Results
+
+```
+178 passed, 17 warnings in 0.73s
+```
+
+All unit tests pass (excluding integration tests). 23 new tests added for Task 2.0.
+
+## Tests Added
+
+### TestInit (schema and PRAGMAs)
+- `test_table_exists` — library_items table exists in sqlite_master
+- `test_indexes_exist` — idx_library_items_content_hash and idx_library_items_synced_at exist
+- `test_wal_mode` — PRAGMA journal_mode returns 'wal'
+- `test_foreign_keys_enabled` — PRAGMA foreign_keys returns 1
+- `test_conn_before_init_raises` — _conn raises RuntimeError before init()
+
+### TestUpsertMany (created/updated/unchanged tracking)
+- `test_insert_new_items` — 3 new items -> UpsertResult(created=3, updated=0, unchanged=0)
+- `test_reupsert_same_hash_unchanged` — same items same hash -> UpsertResult(created=0, updated=0, unchanged=3)
+- `test_changed_hash_counts_as_updated` — one changed hash -> UpsertResult(created=0, updated=1, unchanged=2)
+- `test_empty_list` — empty list -> UpsertResult(created=0, updated=0, unchanged=0)
+
+### TestGet (single item)
+- `test_round_trip_all_fields` — all fields round-trip correctly including JSON arrays
+- `test_missing_id_returns_none` — non-existent ID returns None
+
+### TestGetMany (batch)
+- `test_fetch_subset` — 5 items, fetch 3, verify 3 returned
+- `test_mix_existing_and_nonexistent` — mixed IDs, only existing returned
+- `test_empty_list_returns_empty` — empty ID list returns empty list
+
+### TestGetAllHashes
+- `test_returns_hash_mapping` — maps jellyfin_id to content_hash for all items
+- `test_empty_store_returns_empty_dict` — empty store returns {}
+
+### TestCount
+- `test_empty_store_returns_zero` — returns 0
+- `test_after_inserts` — after 5 inserts returns 5
+
+### TestContentHash
+- `test_deterministic` — same input always produces same hash
+- `test_different_input_different_hash` — different title produces different hash
+
+### TestPeopleFiltering
+- `test_only_actor_names_stored` — non-Actor entries excluded from stored people list
+
+### TestValidation
+- `test_malformed_item_skipped_valid_stored` — malformed item skipped with WARNING, valid items stored
+
+### Config
+- `test_library_db_path_default` — library_db_path defaults to "data/library.db"
+
+## Files Created
+- `backend/app/library/__init__.py` — empty module file
+- `backend/app/library/models.py` — LibraryItemRow, UpsertResult, LibraryStoreProtocol
+- `backend/app/library/store.py` — LibraryStore (SQLite repository)
+- `backend/app/library/hashing.py` — placeholder hash with TODO comment
+
+## Verification
+- `library_db_path` in `backend/app/config.py`: defaults to `"data/library.db"`
+
+## Lint / Format
+- `ruff check app/ tests/` — All checks passed
+- `ruff format --check app/ tests/` — All files formatted

--- a/docs/specs/05-spec-jellyfin-library-client/05-proofs/05-task-30-proofs.md
+++ b/docs/specs/05-spec-jellyfin-library-client/05-proofs/05-task-30-proofs.md
@@ -1,0 +1,43 @@
+# Task 3.0 Proof Artifacts — App Wiring, Config, and Documentation
+
+## Test Results
+
+```
+188 passed, 17 warnings in 0.85s
+```
+
+All unit tests pass (excluding integration tests). 10 new tests added for Task 3.0.
+
+## Tests Added
+
+### Config — jellyfin_api_key
+- `test_jellyfin_api_key_default_none` — defaults to None
+- `test_jellyfin_api_key_valid_value` — valid key stored
+- `test_jellyfin_api_key_empty_treated_as_none` — "" treated as None
+- `test_jellyfin_api_key_whitespace_treated_as_none` — "   " treated as None
+- `test_jellyfin_api_key_whitespace_stripped` — "  key123  " -> "key123"
+
+### Lifespan — TestLifespan
+- `test_library_store_init_called` — LibraryStore.init() called during startup
+- `test_library_store_on_app_state` — app.state.library_store set after startup
+- `test_shutdown_order_library_before_session` — LibraryStore.close() before SessionStore.close()
+- `test_sync_client_created_with_api_key` — sync JellyfinClient on app.state when API key set
+- `test_no_sync_client_without_api_key` — no sync client when API key not set
+
+### Integration Tests (created, not run — require real Jellyfin)
+- `test_get_all_items_returns_pages` — get_all_items returns pages
+- `test_fetch_and_store_cycle` — full fetch-store-count cycle
+- `test_extended_fields_no_validation_errors` — extended fields parse without errors
+
+## Verification
+
+- `.env.example` contains `JELLYFIN_API_KEY` with security warning comment block
+- `.env.example` contains `LIBRARY_DB_PATH` and `LIBRARY_SYNC_PAGE_SIZE` entries
+- `ARCHITECTURE.md` documents two-database strategy and credential distinction
+- `backend/app/library/__init__.py` exists as module file
+- `app.state.library_store` is set during lifespan startup (verified by test)
+
+## Lint / Format
+
+- `ruff check app/ tests/` — All checks passed
+- `ruff format --check app/ tests/` — All files formatted

--- a/docs/specs/05-spec-jellyfin-library-client/05-spec-jellyfin-library-client.md
+++ b/docs/specs/05-spec-jellyfin-library-client/05-spec-jellyfin-library-client.md
@@ -1,0 +1,326 @@
+# 05-spec-jellyfin-library-client
+
+## Introduction/Overview
+
+This spec extends the existing `JellyfinClient` to fetch a user's full movie library with auto-pagination, and introduces a SQLite metadata store (`library.db`) with content hashing for incremental sync. Together these components provide the data foundation that the embedding pipeline (Spec 07) and semantic search (Spec 06) build upon — the app cannot recommend movies it has never seen.
+
+## Goals
+
+- **Complete library fetching**: Auto-paginate the Jellyfin `/Users/{userId}/Items` endpoint to retrieve all movie items, yielding pages via an async iterator so memory usage stays bounded regardless of library size.
+- **Persistent metadata store**: Store library item metadata in a SQLite repository (`library.db`) using the same `init()`/`close()`/`_conn` pattern as `SessionStore`, with upsert semantics for incremental sync.
+- **Content-hash-driven sync**: Hash the composite text template output (SHA-256) and store it per item, so downstream consumers (embedding pipeline) can detect which items are new or changed without re-embedding the entire library.
+- **Flexible sync credentials**: Support both user-triggered sync (session token passed as parameter) and background sync (optional `JELLYFIN_API_KEY` env var), with strict token-handling discipline — tokens are never stored on objects or logged.
+- **Input validation**: All Jellyfin API data passes through Pydantic models before storage, preventing malformed or unexpected data from reaching the database.
+
+## User Stories
+
+- **As the server operator**, I want the backend to fetch my entire Jellyfin movie library so that the recommendation engine has complete knowledge of available content.
+- **As a self-hoster with a large library**, I want library sync to be incremental (only re-processing changed items) so that sync completes quickly and doesn't waste CPU on unchanged content.
+- **As a privacy-conscious user**, I want sync credentials to be handled securely — API keys never logged, user tokens never persisted to objects — so that credential exposure risk is minimized.
+- **As a developer**, I want the library metadata store to follow the same repository patterns as `SessionStore` so that the codebase stays consistent and easy to navigate.
+
+## Demoable Units of Work
+
+### Unit 1: Extended LibraryItem Model + Auto-Paginated Client
+
+**Purpose:** Extend the `LibraryItem` Pydantic model with all fields needed for embedding and recommendation, and add an auto-paginating async iterator to `JellyfinClient` that yields pages of library items until the entire library is fetched.
+
+**Functional Requirements:**
+
+- FR-1.1: The system shall extend `LibraryItem` in `backend/app/jellyfin/models.py` with the following optional fields (all with sensible defaults so existing code is unaffected):
+  - `tags: list[str] = Field(default_factory=list, alias="Tags")` — user-assigned tags from Jellyfin.
+  - `studios: list[str] = Field(default_factory=list, alias="Studios")` — parsed from Jellyfin's `Studios` array (extract `Name` from each studio object).
+  - `community_rating: float | None = Field(default=None, alias="CommunityRating")` — Jellyfin's community/audience rating.
+  - `people: list[dict[str, str]] = Field(default_factory=list, alias="People")` — raw Jellyfin People array (each entry has `Name`, `Role`, `Type`). Filtering to cast-only is the consumer's responsibility.
+- FR-1.2: The system shall update the `_ITEM_FIELDS` constant in `backend/app/jellyfin/client.py` to include `Tags,Studios,CommunityRating,People` in addition to the existing `Overview,Genres,ProductionYear`.
+- FR-1.3: The `Studios` field in Jellyfin's API returns an array of objects (`[{"Name": "Pixar", "Id": "..."}]`). The `LibraryItem` model shall use a Pydantic `@field_validator` (or equivalent) to extract the `Name` string from each studio object, storing `studios` as `list[str]`.
+- FR-1.4: The system shall add a `LIBRARY_SYNC_PAGE_SIZE` setting to `Settings` in `backend/app/config.py`, defaulting to `200`. This controls the page size for library sync pagination.
+- FR-1.5: The system shall add an `async def get_all_items()` method to `JellyfinClient` that auto-paginates by calling the existing `get_items()` in a loop, yielding each `PaginatedItems` page as it arrives. Signature:
+  ```python
+  async def get_all_items(
+      self,
+      token: str,
+      user_id: str,
+      *,
+      item_types: list[str] | None = None,
+      page_size: int = 200,
+  ) -> AsyncIterator[PaginatedItems]:
+  ```
+  The method shall:
+  1. Start at `start_index=0` and request `limit=page_size` items per call.
+  2. Yield each `PaginatedItems` response.
+  3. Increment `start_index` by the number of items received.
+  4. Stop when `start_index >= total_count` from the response.
+  5. Log at DEBUG: page number and item count per page. Never log user_id paired with item data.
+- FR-1.6: The `get_all_items()` method shall propagate `JellyfinAuthError` and `JellyfinConnectionError` from the underlying `get_items()` calls without catching them. The caller is responsible for handling partial failure.
+- FR-1.7: The token parameter in `get_all_items()` shall be passed through to `get_items()` on each call — never stored as an instance attribute.
+
+**Proof Artifacts:**
+
+- Unit tests for `LibraryItem` model: verify that all new fields parse correctly from representative Jellyfin JSON, verify defaults when fields are absent, verify `Studios` validator extracts names from objects.
+- Unit tests for `get_all_items()`: mock `get_items()` to return two pages (e.g., 200 + 50 items with `total_count=250`), verify the iterator yields exactly two pages, verify it stops after the second page.
+- Unit test for `get_all_items()` with an empty library: verify the iterator yields one page with zero items and stops.
+- Unit test for `get_all_items()` auth error: verify `JellyfinAuthError` propagates on the first page.
+- Unit test for `get_all_items()` mid-pagination error: verify `JellyfinConnectionError` propagates after yielding the first page.
+
+---
+
+### Unit 2: Library Metadata Store (SQLite Repository)
+
+**Purpose:** Create a SQLite-backed repository for library item metadata, following the `SessionStore` pattern, with bulk upsert support and content-hash tracking for incremental sync.
+
+**Functional Requirements:**
+
+- FR-2.1: The system shall add a `library_db_path: str = "data/library.db"` field to `Settings` in `backend/app/config.py`.
+- FR-2.2: The system shall add a `jellyfin_api_key: str | None = None` field to `Settings` in `backend/app/config.py`. This enables background sync when set. The field shall be loaded from the `JELLYFIN_API_KEY` environment variable.
+- FR-2.3: The system shall create a new module `backend/app/library/store.py` containing a `LibraryStore` class with the same structural pattern as `SessionStore`:
+  - Constructor: `__init__(self, db_path: str)`.
+  - `async def init(self) -> None` — opens the aiosqlite connection, enables WAL mode, enables `PRAGMA foreign_keys = ON`, and creates the schema.
+  - `async def close(self) -> None` — closes the connection.
+  - `_conn` property that raises `RuntimeError` if not initialized.
+- FR-2.4: The `init()` method shall create the `library_items` table with the following schema:
+  ```sql
+  CREATE TABLE IF NOT EXISTS library_items (
+      jellyfin_id       TEXT PRIMARY KEY,
+      title             TEXT NOT NULL,
+      overview          TEXT,
+      production_year   INTEGER,
+      genres            TEXT NOT NULL DEFAULT '[]',    -- JSON array of strings
+      tags              TEXT NOT NULL DEFAULT '[]',    -- JSON array of strings
+      studios           TEXT NOT NULL DEFAULT '[]',    -- JSON array of strings
+      community_rating  REAL,
+      people            TEXT NOT NULL DEFAULT '[]',    -- JSON array of strings (cast names only)
+      content_hash      TEXT NOT NULL,                 -- SHA-256 hex digest
+      synced_at         INTEGER NOT NULL               -- Unix epoch seconds
+  );
+  CREATE INDEX IF NOT EXISTS idx_library_items_content_hash ON library_items(content_hash);
+  CREATE INDEX IF NOT EXISTS idx_library_items_synced_at ON library_items(synced_at);
+  ```
+- FR-2.5: The `people` column shall store a JSON array of actor name strings only — e.g., `["Tom Hanks", "Robin Wright"]`. The store's upsert logic shall filter the raw Jellyfin `People` array to entries where `Type == "Actor"` and extract only the `Name` field.
+- FR-2.6: The system shall create a `LibraryStoreProtocol` in `backend/app/library/models.py` (or a shared location), following the `SessionStoreProtocol` pattern:
+  ```python
+  class LibraryStoreProtocol(Protocol):
+      async def init(self) -> None: ...
+      async def close(self) -> None: ...
+      async def upsert_many(self, items: list[LibraryItemRow]) -> UpsertResult: ...
+      async def get(self, jellyfin_id: str) -> LibraryItemRow | None: ...
+      async def get_many(self, ids: list[str]) -> list[LibraryItemRow]: ...
+      async def get_all_hashes(self) -> dict[str, str]: ...
+      async def count(self) -> int: ...
+  ```
+- FR-2.7: The system shall define a `LibraryItemRow` dataclass in `backend/app/library/models.py`:
+  ```python
+  @dataclass(frozen=True, slots=True)
+  class LibraryItemRow:
+      jellyfin_id: str
+      title: str
+      overview: str | None
+      production_year: int | None
+      genres: list[str]
+      tags: list[str]
+      studios: list[str]
+      community_rating: float | None
+      people: list[str]       # Actor names only
+      content_hash: str       # SHA-256 hex digest
+      synced_at: int          # Unix epoch seconds
+  ```
+- FR-2.8: The system shall define an `UpsertResult` dataclass:
+  ```python
+  @dataclass(frozen=True, slots=True)
+  class UpsertResult:
+      created: int
+      updated: int
+      unchanged: int
+  ```
+- FR-2.9: The `LibraryStore` shall implement `async def upsert_many(self, items: list[LibraryItemRow]) -> UpsertResult` that:
+  1. Wraps the entire batch in a single transaction.
+  2. For each item, executes `INSERT INTO library_items (...) VALUES (...) ON CONFLICT(jellyfin_id) DO UPDATE SET ...` — never `INSERT OR REPLACE` (which deletes and re-inserts, losing any future foreign key references).
+  3. The `ON CONFLICT ... DO UPDATE` clause shall update all columns except `jellyfin_id`.
+  4. Tracks created/updated/unchanged counts by comparing `content_hash` before and after (fetch existing hashes in bulk before the upsert, compare to determine which items are new, changed, or unchanged).
+  5. JSON array fields (`genres`, `tags`, `studios`, `people`) are serialized to JSON strings via `json.dumps()` before storage and deserialized via `json.loads()` on read.
+- FR-2.10: The `LibraryStore` shall implement `async def get(self, jellyfin_id: str) -> LibraryItemRow | None` — fetch a single item by primary key.
+- FR-2.11: The `LibraryStore` shall implement `async def get_many(self, ids: list[str]) -> list[LibraryItemRow]` — fetch multiple items by a list of Jellyfin IDs. This supports the search endpoint (issue #98) which needs to hydrate vector search results with metadata. Use a single query with `WHERE jellyfin_id IN (?, ?, ...)` parameterization (not string interpolation). Return items in no guaranteed order.
+- FR-2.12: The `LibraryStore` shall implement `async def get_all_hashes(self) -> dict[str, str]` — return a `{jellyfin_id: content_hash}` mapping for all items. This allows the sync orchestrator to diff against incoming items without loading full rows.
+- FR-2.13: The `LibraryStore` shall implement `async def count(self) -> int` — return the total number of items in the store.
+- FR-2.14: The content hash for each item shall be computed as `hashlib.sha256(composite_text.encode()).hexdigest()` where `composite_text` is the output of the text builder from Spec 07 (`app/ollama/text_builder.py`). If the text builder module does not yet exist at implementation time, use a placeholder function in `backend/app/library/hashing.py` that builds a deterministic string from the item's fields (title, overview, genres, tags, studios, people, production year, community rating) and hashes it. The placeholder must be clearly marked with a `# TODO: Replace with text_builder from Spec 07` comment, and the function signature must accept a `LibraryItemRow` and return a `str` (the hex digest).
+- FR-2.15: All Jellyfin API response data shall pass through Pydantic validation (the extended `LibraryItem` model from Unit 1) before being converted to `LibraryItemRow` for storage. Malformed items that fail Pydantic validation shall be logged at WARNING (item ID only, no metadata) and skipped — they shall not prevent other items from being stored.
+
+**Proof Artifacts:**
+
+- Unit tests for `LibraryStore.init()`: verify table and indexes are created, verify WAL mode is enabled, verify `PRAGMA foreign_keys` is ON.
+- Unit tests for `upsert_many()`: insert 3 new items and verify `UpsertResult(created=3, updated=0, unchanged=0)`; upsert the same 3 items with same content hash and verify `UpsertResult(created=0, updated=0, unchanged=3)`; change one item's content hash and verify `UpsertResult(created=0, updated=1, unchanged=2)`.
+- Unit tests for `get()`: fetch an existing item, verify all fields round-trip correctly (including JSON arrays), verify `None` for missing ID.
+- Unit tests for `get_many()`: insert 5 items, fetch 3 by ID, verify 3 returned; fetch with non-existent IDs mixed in, verify only existing items returned.
+- Unit tests for `get_all_hashes()`: insert items, verify the returned dict maps jellyfin_id to content_hash for all items.
+- Unit tests for `count()`: empty store returns 0, after inserting 5 items returns 5.
+- Unit test for content hash computation: verify deterministic output, verify different input produces different hash.
+- Unit test for people filtering: verify that non-Actor entries from the Jellyfin People array are excluded from the stored `people` list.
+- Unit test for Pydantic validation: malformed item data is skipped with a WARNING log, valid items are stored.
+
+---
+
+### Unit 3: App Wiring + Config + Documentation
+
+**Purpose:** Wire the `LibraryStore` into the application lifespan, add the `JELLYFIN_API_KEY` configuration with validation, and update project documentation to reflect the two-database strategy and credential handling.
+
+**Functional Requirements:**
+
+- FR-3.1: The system shall update the lifespan in `backend/app/main.py` to:
+  1. Create the `data/` directory for `library.db` if it does not exist (same pattern as session DB).
+  2. Initialize `LibraryStore` after `SessionStore` initialization.
+  3. Store the `LibraryStore` instance on `app.state.library_store`.
+  4. Close the `LibraryStore` before closing the `SessionStore` during shutdown (reverse order of initialization).
+- FR-3.2: If `JELLYFIN_API_KEY` is set in the environment, the system shall validate at startup that it is non-empty after stripping whitespace. If it is empty/whitespace-only, log a WARNING and treat it as unset (`None`). The API key shall never be logged at any level.
+- FR-3.3: The sync JellyfinClient (used for library sync with `JELLYFIN_API_KEY`) shall be a separate instance from the user-facing JellyfinClient. It shall be created during lifespan startup only if `JELLYFIN_API_KEY` is configured. Both clients share the same `httpx.AsyncClient` for connection pooling but are distinct `JellyfinClient` instances.
+- FR-3.4: The system shall update `.env.example` to document the `JELLYFIN_API_KEY` setting:
+  ```
+  # --- Library Sync ---
+
+  # Jellyfin API key for background library sync (optional).
+  # Enables automatic sync without requiring a logged-in user session.
+  # Generate in Jellyfin: Dashboard > API Keys > Add.
+  # SECURITY WARNING: Treat this like a root password — it grants full
+  # access to your Jellyfin server. Never commit to version control.
+  # If not set, library sync is triggered only via user session tokens.
+  # JELLYFIN_API_KEY=
+
+  # Path to the library metadata SQLite database file
+  # LIBRARY_DB_PATH=data/library.db
+
+  # Page size for Jellyfin library sync pagination
+  # LIBRARY_SYNC_PAGE_SIZE=200
+  ```
+- FR-3.5: The system shall update `ARCHITECTURE.md` to:
+  1. Document the two-file database strategy under the existing "SQLite-vec" component section: `sessions.db` for auth/session data, `library.db` for item metadata and future vector embeddings.
+  2. Add a note under the "Security Model" section distinguishing infrastructure credentials (`JELLYFIN_API_KEY` — operator-configured, server-scoped, enables background sync) from user tokens (per-session, encrypted at rest, never persisted to objects).
+- FR-3.6: Logging for library sync operations shall follow these rules:
+  - DEBUG: Item metadata (for troubleshooting only).
+  - INFO: Sync start, sync complete with counts (`items_synced=N, created=N, updated=N, unchanged=N`).
+  - WARNING: Pydantic validation failures (item ID only), partial page failures (page number + HTTP status only).
+  - ERROR: Complete sync failure.
+  - NEVER: user_id paired with item lists, API key values, token values.
+- FR-3.7: The system shall add a `backend/app/library/__init__.py` module file.
+
+**Proof Artifacts:**
+
+- Integration test with real Jellyfin: connect to the test Jellyfin instance, call `get_all_items()` with `item_types=["Movie"]`, verify items are returned with expected fields populated, store them in a `LibraryStore`, verify `count()` matches `total_count` from Jellyfin.
+- Unit test for lifespan: verify `LibraryStore.init()` is called after `SessionStore.init()`, verify `LibraryStore.close()` is called before `SessionStore.close()`.
+- Unit test for `JELLYFIN_API_KEY` validation: empty/whitespace key treated as `None`, valid key stored in settings.
+- Verify `.env.example` contains `JELLYFIN_API_KEY` with security warning.
+- Verify `ARCHITECTURE.md` documents the two-database strategy and credential distinction.
+
+## Non-Goals (Out of Scope)
+
+1. **Embedding generation** — Spec 07 covers the Ollama embedding client and text builder. This spec stores the content hash but does not generate embeddings.
+2. **Vector storage** — Spec 06 covers the SQLite-vec repository. `library.db` stores metadata only; vector data is a separate concern.
+3. **Sync orchestration / scheduling** — This spec provides the client and store primitives. The sync coordinator (cron-like scheduling, progress tracking, cancellation) is a separate concern.
+4. **TMDb enrichment** — TMDb metadata is opt-in and handled by a separate module. This spec works with Jellyfin metadata only.
+5. **API endpoints for sync** — No REST endpoints are added in this spec. Sync is triggered programmatically (by future orchestration code or integration tests).
+6. **Item deletion / library diffing** — This spec handles upserts only. Detecting and removing items that were deleted from Jellyfin is deferred.
+7. **Permission filtering** — Per-user permission checks happen at query time (Spec 06 / search), not at sync time. The library store contains all items from the server.
+
+## Design Considerations
+
+### Two-Database Strategy
+
+```
+data/
+├── sessions.db    # Auth sessions (Spec 03) — encrypted tokens, CSRF, expiry
+└── library.db     # Library metadata (this spec) — items, content hashes, future vectors
+```
+
+Rationale:
+- Different access patterns: sessions are small/frequent; library is large/batch.
+- Different backup and migration lifecycles.
+- `library.db` will eventually house SQLite-vec extension data; `sessions.db` is plain SQLite.
+- Both use WAL mode and aiosqlite.
+
+### Content Hash Strategy
+
+The content hash is a SHA-256 digest of the composite text string — the same string that will be fed to the embedding model. This means:
+
+1. If Jellyfin metadata changes, the hash changes, triggering a re-embed.
+2. If the text template changes (Spec 07), all hashes change, triggering a full re-embed. This is intentional — a template change means the semantic representation changed.
+3. The hash is computed by the caller before passing items to `upsert_many()`. The store does not compute hashes — it stores them.
+
+If the text builder from Spec 07 is not yet available, a placeholder hashing function provides a deterministic hash from raw fields. When the text builder lands, the placeholder is replaced and a one-time full re-sync is expected.
+
+### Token Handling
+
+```
+User-triggered sync:
+  Frontend → POST /api/sync (future) → backend uses session token
+  Token source: decrypted from session store, passed as parameter
+  Token lifetime: request-scoped, never stored on objects
+
+Background sync (if JELLYFIN_API_KEY set):
+  Startup/cron → sync coordinator → JellyfinClient.get_all_items(api_key, ...)
+  Token source: JELLYFIN_API_KEY from Settings (loaded once at startup)
+  Token lifetime: process-scoped, read from settings, never logged
+```
+
+Both paths use the same `get_all_items(token, user_id, ...)` signature. The sync JellyfinClient is a separate instance to avoid cross-contamination with user-facing request handling.
+
+### Module Layout
+
+```
+backend/app/
+├── jellyfin/
+│   ├── client.py          # Extended: get_all_items() async iterator
+│   └── models.py          # Extended: LibraryItem with Tags, Studios, etc.
+├── library/
+│   ├── __init__.py
+│   ├── models.py          # LibraryItemRow, UpsertResult, LibraryStoreProtocol
+│   ├── store.py           # LibraryStore (SQLite repository)
+│   └── hashing.py         # Content hash computation (placeholder or text_builder)
+├── config.py              # Extended: library_db_path, jellyfin_api_key, library_sync_page_size
+└── main.py                # Extended: LibraryStore in lifespan
+```
+
+## Repository Standards
+
+- All new code uses `async/await` for I/O (aiosqlite, httpx).
+- Type hints on all function signatures. Pydantic models for API response parsing.
+- Tests use `pytest` with `pytest-asyncio`. Mark integration tests with `@pytest.mark.integration`.
+- Lint with `ruff`. Type-check with `pyright` (basic mode).
+- Conventional commits: `feat(library):`, `test(library):`, `fix(library):`, `docs:`.
+- No `any` types in Python — use proper types or generics.
+- No ad-hoc `os.environ` calls — all config via `Settings` (Pydantic BaseSettings).
+- No logging of PII, tokens, or API keys.
+- Mock Jellyfin API in unit tests; integration tests use the real Jellyfin instance (`make test-integration`).
+
+## Technical Considerations
+
+- **aiosqlite**: Already a project dependency (used by `SessionStore`). The `LibraryStore` uses the same library and patterns.
+- **`INSERT ... ON CONFLICT DO UPDATE`**: This is SQLite's upsert syntax (available since 3.24.0, 2018). It updates in-place without deleting the row, preserving any future foreign key references or rowid-dependent data. Never use `INSERT OR REPLACE` which performs a delete+insert.
+- **JSON array storage**: Genres, tags, studios, and people are stored as JSON text columns (`json.dumps()` / `json.loads()`). SQLite's JSON functions could be used for querying, but are not needed for this spec's access patterns (full-row reads).
+- **`get_many()` parameterization**: For large ID lists, SQLite has a `SQLITE_MAX_VARIABLE_NUMBER` limit (default 999 in older versions, 32766 in 3.32+). If the ID list exceeds a safe threshold (e.g., 500), chunk into multiple queries. This is a defensive measure for very large search result sets.
+- **Async iterator**: `get_all_items()` uses `async for` / `yield` to produce an `AsyncIterator[PaginatedItems]`. This keeps memory usage proportional to a single page, not the entire library.
+- **Content hash determinism**: The hash input string must be built deterministically — sorted JSON arrays, consistent field ordering, normalized whitespace. The placeholder hashing function must document its field ordering.
+- **Startup order**: `LibraryStore.init()` runs after `SessionStore.init()` because sessions are required for the app to be functional (auth), while library data is supplementary. Shutdown reverses this order.
+
+## Security Considerations
+
+- **`JELLYFIN_API_KEY` is a high-privilege credential**: It grants server-admin-level access to Jellyfin. It must never appear in logs, error messages, or API responses at any log level. The `.env.example` documentation warns operators to treat it like a root password.
+- **Token parameter discipline**: Both `get_all_items()` and the sync orchestrator accept tokens as function parameters, never storing them on `self`. This ensures tokens cannot leak via object serialization, logging of object state, or accidental cross-request reuse.
+- **Sync client isolation**: The sync `JellyfinClient` instance is separate from the user-facing instance. This prevents a background sync's API key from accidentally being used for a user request or vice versa.
+- **No PII in logs**: Item metadata (titles, genres, etc.) is logged at DEBUG only. User IDs are never paired with item lists. Sync results use aggregate counts only at INFO level.
+- **Input validation**: All Jellyfin data passes through Pydantic models before storage. This prevents injection of malformed data into the SQLite database. Items that fail validation are skipped and logged (ID only).
+- **SQL injection prevention**: All database queries use parameterized queries (`?` placeholders). No string interpolation or f-strings in SQL statements.
+- **`PRAGMA foreign_keys = ON`**: Enabled on every connection to enforce referential integrity for any future foreign key constraints.
+
+## Success Metrics
+
+1. `get_all_items()` correctly auto-paginates a library of any size, verified by unit tests with mocked multi-page responses and integration test against real Jellyfin.
+2. `LibraryStore.upsert_many()` correctly reports created/updated/unchanged counts, verified by unit tests with sequential upserts of the same and modified data.
+3. Content hashes are deterministic — the same item data always produces the same hash, and any field change produces a different hash (verified by unit test).
+4. The `people` field stores actor names only — non-actor People entries are filtered out (verified by unit test).
+5. `get_many()` returns correct items for a batch of IDs, supporting the search endpoint hydration use case (verified by unit test).
+6. The lifespan correctly initializes `LibraryStore` after `SessionStore` and closes in reverse order (verified by unit test).
+7. `JELLYFIN_API_KEY` is never logged at any level (verified by log output inspection in tests).
+8. Integration test: full cycle — fetch library from real Jellyfin, store in `LibraryStore`, verify `count()` matches Jellyfin's `TotalRecordCount`.
+9. `.env.example` and `ARCHITECTURE.md` are updated with the new configuration and architectural context.
+
+## Open Questions
+
+None — all design decisions have been resolved through the Watch Council review process.

--- a/docs/specs/05-spec-jellyfin-library-client/05-tasks-jellyfin-library-client.md
+++ b/docs/specs/05-spec-jellyfin-library-client/05-tasks-jellyfin-library-client.md
@@ -1,0 +1,225 @@
+# 05 Tasks - Jellyfin Library Client
+
+## Relevant Files
+
+### Files to Create
+- `backend/app/library/__init__.py` — module init
+- `backend/app/library/models.py` — `LibraryItemRow`, `UpsertResult`, `LibraryStoreProtocol`
+- `backend/app/library/store.py` — `LibraryStore` (SQLite repository)
+- `backend/app/library/hashing.py` — placeholder content-hash function
+- `backend/tests/test_library_store.py` — unit tests for `LibraryStore`
+- `backend/tests/integration/test_jellyfin_library.py` — integration test for full fetch+store cycle
+
+### Files to Modify
+- `backend/app/jellyfin/models.py` — extend `LibraryItem` with tags, studios, community_rating, people
+- `backend/app/jellyfin/client.py` — update `_ITEM_FIELDS`, add `get_all_items()` async iterator
+- `backend/app/config.py` — add `library_db_path`, `jellyfin_api_key`, `library_sync_page_size`
+- `backend/app/main.py` — wire `LibraryStore` into lifespan, create sync `JellyfinClient`
+- `backend/tests/test_jellyfin_client.py` — add tests for extended `LibraryItem` and `get_all_items()`
+- `backend/tests/test_config.py` — add tests for new config fields (`jellyfin_api_key`, `library_db_path`, `library_sync_page_size`)
+- `.env.example` — add `JELLYFIN_API_KEY`, `LIBRARY_DB_PATH`, `LIBRARY_SYNC_PAGE_SIZE` entries
+- `ARCHITECTURE.md` — document two-database strategy and credential distinction
+
+---
+
+## Tasks
+
+### [~] 1.0 Extended LibraryItem Model + Auto-Paginated Client
+
+Extend the `LibraryItem` Pydantic model with fields needed for embedding (tags, studios, community_rating, people) and add `get_all_items()` async iterator to `JellyfinClient` for auto-paginated library fetching. Add `LIBRARY_SYNC_PAGE_SIZE` to `Settings`.
+
+#### 1.0 Proof Artifact(s)
+- Test: `backend/tests/test_jellyfin_client.py::TestLibraryItem` — new fields parse correctly from representative Jellyfin JSON, defaults when fields absent, `Studios` validator extracts names from objects
+- Test: `backend/tests/test_jellyfin_client.py::TestGetAllItems` — mock `get_items()` returning two pages (200 + 50 items, `total_count=250`), verify iterator yields exactly two pages, stops after second page
+- Test: `backend/tests/test_jellyfin_client.py::TestGetAllItems::test_empty_library` — iterator yields one page with zero items and stops
+- Test: `backend/tests/test_jellyfin_client.py::TestGetAllItems::test_auth_error_propagates` — `JellyfinAuthError` propagates on first page
+- Test: `backend/tests/test_jellyfin_client.py::TestGetAllItems::test_mid_pagination_error` — `JellyfinConnectionError` propagates after yielding the first page
+- Verify: `_ITEM_FIELDS` in `backend/app/jellyfin/client.py` includes `Tags,Studios,CommunityRating,People`
+- Verify: `LIBRARY_SYNC_PAGE_SIZE` in `backend/app/config.py` defaults to `200`
+
+#### 1.0 Tasks
+
+**Model extensions (`backend/app/jellyfin/models.py`)**
+- [ ] 1.1 Add `tags: list[str]` field to `LibraryItem` with `Field(default_factory=list, alias="Tags")`
+- [ ] 1.2 Add `studios: list[str]` field to `LibraryItem` with `Field(default_factory=list, alias="Studios")` and a `@field_validator("studios", mode="before")` that extracts `Name` from each studio object (handles both `[{"Name": "Pixar", "Id": "..."}]` and plain `["Pixar"]` formats)
+- [ ] 1.3 Add `community_rating: float | None` field to `LibraryItem` with `Field(default=None, alias="CommunityRating")`
+- [ ] 1.4 Add `people: list[dict[str, str]]` field to `LibraryItem` with `Field(default_factory=list, alias="People")` — raw Jellyfin People array (each entry has Name, Role, Type)
+
+**Client extensions (`backend/app/jellyfin/client.py`)**
+- [ ] 1.5 Update `_ITEM_FIELDS` constant to include `Tags,Studios,CommunityRating,People` (append to existing `Overview,Genres,ProductionYear`)
+- [ ] 1.6 Add `async def get_all_items(self, token: str, user_id: str, *, item_types: list[str] | None = None, page_size: int = 200) -> AsyncIterator[PaginatedItems]` method that auto-paginates by calling `get_items()` in a loop, yielding each page, incrementing `start_index` by items received, stopping when `start_index >= total_count`
+- [ ] 1.7 Add DEBUG logging in `get_all_items()` for page number and item count per page (never log `user_id` paired with item data)
+- [ ] 1.8 Ensure `get_all_items()` propagates `JellyfinAuthError` and `JellyfinConnectionError` from underlying `get_items()` without catching them (FR-1.6)
+- [ ] 1.9 Ensure token parameter in `get_all_items()` is passed through to `get_items()` on each call, never stored as an instance attribute (FR-1.7)
+
+**Config extension (`backend/app/config.py`)**
+- [ ] 1.10 Add `library_sync_page_size: int = 200` field to `Settings` class
+
+**Unit tests — model (`backend/tests/test_jellyfin_client.py::TestLibraryItem`)**
+- [ ] 1.11 Add test: `LibraryItem` parses all new fields (tags, studios, community_rating, people) from representative Jellyfin JSON with all fields present
+- [ ] 1.12 Add test: `LibraryItem` defaults new fields correctly when absent (tags=[], studios=[], community_rating=None, people=[])
+- [ ] 1.13 Add test: `Studios` validator extracts `Name` from studio objects (`[{"Name": "Pixar", "Id": "abc"}]` -> `["Pixar"]`)
+- [ ] 1.14 Add test: `Studios` validator handles plain string list input gracefully
+- [ ] 1.15 Add test: `People` field parses raw Jellyfin People array with Name, Role, Type dicts
+
+**Unit tests — get_all_items (`backend/tests/test_jellyfin_client.py::TestGetAllItems`)**
+- [ ] 1.16 Add test: mock `get_items()` returning two pages (page 1: 200 items, page 2: 50 items, `total_count=250`), verify iterator yields exactly two `PaginatedItems`, verify it stops after second page
+- [ ] 1.17 Add test: empty library — mock `get_items()` returning `PaginatedItems(items=[], total_count=0, start_index=0)`, verify iterator yields one page and stops
+- [ ] 1.18 Add test: `JellyfinAuthError` on first page propagates immediately
+- [ ] 1.19 Add test: `JellyfinConnectionError` on second page propagates after first page was successfully yielded
+- [ ] 1.20 Add test: verify `_ITEM_FIELDS` includes `Tags`, `Studios`, `CommunityRating`, `People`
+
+**Unit test — config (`backend/tests/test_config.py`)**
+- [ ] 1.21 Add test: `library_sync_page_size` defaults to `200`
+
+---
+
+### [ ] 2.0 Library Metadata Store (SQLite Repository)
+
+Create `backend/app/library/` module with `LibraryStore` (SQLite repository following `SessionStore` pattern), `LibraryItemRow` and `UpsertResult` dataclasses, `LibraryStoreProtocol`, and placeholder content-hash function. Implements bulk upsert with created/updated/unchanged tracking, single/batch get, hash retrieval, and count.
+
+#### 2.0 Proof Artifact(s)
+- Test: `backend/tests/test_library_store.py::TestInit` — table and indexes created, WAL mode enabled, `PRAGMA foreign_keys` is ON
+- Test: `backend/tests/test_library_store.py::TestUpsertMany` — insert 3 new items yields `UpsertResult(created=3, updated=0, unchanged=0)`; re-upsert same items yields `UpsertResult(created=0, updated=0, unchanged=3)`; change one hash yields `UpsertResult(created=0, updated=1, unchanged=2)`
+- Test: `backend/tests/test_library_store.py::TestGet` — fetch existing item with all fields round-tripping correctly (including JSON arrays); fetch missing ID returns `None`
+- Test: `backend/tests/test_library_store.py::TestGetMany` — insert 5, fetch 3 by ID, verify 3 returned; mix in non-existent IDs, verify only existing returned
+- Test: `backend/tests/test_library_store.py::TestGetAllHashes` — verify returned dict maps `jellyfin_id` to `content_hash` for all items
+- Test: `backend/tests/test_library_store.py::TestCount` — empty store returns 0, after inserting 5 returns 5
+- Test: `backend/tests/test_library_store.py::TestContentHash` — deterministic output; different input produces different hash
+- Test: `backend/tests/test_library_store.py::TestPeopleFiltering` — non-Actor entries excluded from stored `people` list
+- Test: `backend/tests/test_library_store.py::TestValidation` — malformed Jellyfin item data skipped with WARNING log, valid items stored
+- File: `backend/app/library/__init__.py` exists
+- File: `backend/app/library/models.py` contains `LibraryItemRow`, `UpsertResult`, `LibraryStoreProtocol`
+- File: `backend/app/library/store.py` contains `LibraryStore`
+- File: `backend/app/library/hashing.py` contains placeholder hash function with `# TODO: Replace with text_builder from Spec 07`
+- Verify: `backend/app/config.py` includes `library_db_path` setting defaulting to `"data/library.db"`
+
+#### 2.0 Tasks
+
+**Module scaffolding**
+- [ ] 2.1 Create `backend/app/library/__init__.py` as empty module file
+- [ ] 2.2 Create `backend/app/library/models.py` with `LibraryItemRow` frozen dataclass (fields: `jellyfin_id`, `title`, `overview`, `production_year`, `genres`, `tags`, `studios`, `community_rating`, `people`, `content_hash`, `synced_at`) using `@dataclass(frozen=True, slots=True)`
+- [ ] 2.3 Add `UpsertResult` frozen dataclass to `backend/app/library/models.py` with fields: `created: int`, `updated: int`, `unchanged: int`
+- [ ] 2.4 Add `LibraryStoreProtocol` to `backend/app/library/models.py` following `SessionStoreProtocol` pattern, defining: `init()`, `close()`, `upsert_many()`, `get()`, `get_many()`, `get_all_hashes()`, `count()`
+
+**Content hashing (`backend/app/library/hashing.py`)**
+- [ ] 2.5 Create `backend/app/library/hashing.py` with `def compute_content_hash(item: LibraryItemRow) -> str` that builds a deterministic string from item fields (sorted JSON arrays, consistent field ordering, normalized whitespace) and returns `hashlib.sha256(...).hexdigest()`
+- [ ] 2.6 Add `# TODO: Replace with text_builder from Spec 07` comment in the function, documenting field ordering used
+
+**Config extension (`backend/app/config.py`)**
+- [ ] 2.7 Add `library_db_path: str = "data/library.db"` field to `Settings` class
+
+**Library store (`backend/app/library/store.py`)**
+- [ ] 2.8 Create `LibraryStore` class with `__init__(self, db_path: str)`, following `SessionStore` structural pattern
+- [ ] 2.9 Implement `async def init(self) -> None` — opens aiosqlite connection, enables WAL mode (`PRAGMA journal_mode=WAL`), enables `PRAGMA foreign_keys = ON`, creates `library_items` table with schema from FR-2.4, creates `idx_library_items_content_hash` and `idx_library_items_synced_at` indexes
+- [ ] 2.10 Implement `async def close(self) -> None` — closes the connection, sets `_db` to `None`
+- [ ] 2.11 Implement `_conn` property that raises `RuntimeError("LibraryStore not initialised — call init() first")` if `_db` is `None`
+- [ ] 2.12 Implement `async def upsert_many(self, items: list[LibraryItemRow]) -> UpsertResult` — wraps batch in single transaction, fetches existing hashes in bulk first, uses `INSERT INTO ... ON CONFLICT(jellyfin_id) DO UPDATE SET ...` (never `INSERT OR REPLACE`), serializes JSON arrays via `json.dumps()`, tracks created/updated/unchanged by comparing content_hash
+- [ ] 2.13 Implement `async def get(self, jellyfin_id: str) -> LibraryItemRow | None` — fetch single item by primary key, deserialize JSON arrays via `json.loads()`, return `None` if not found
+- [ ] 2.14 Implement `async def get_many(self, ids: list[str]) -> list[LibraryItemRow]` — fetch multiple items with `WHERE jellyfin_id IN (?, ?, ...)` using parameterized queries (no string interpolation), chunk into batches of 500 if list exceeds safe threshold, return items in no guaranteed order
+- [ ] 2.15 Implement `async def get_all_hashes(self) -> dict[str, str]` — return `{jellyfin_id: content_hash}` mapping for all items
+- [ ] 2.16 Implement `async def count(self) -> int` — return total number of items in the store
+- [ ] 2.17 Add helper `_row_to_item()` method to deserialize a database row into `LibraryItemRow`, parsing JSON text columns back to lists
+
+**Unit tests — init (`backend/tests/test_library_store.py::TestInit`)**
+- [ ] 2.18 Add test: after `init()`, `library_items` table exists (query `sqlite_master`)
+- [ ] 2.19 Add test: after `init()`, indexes `idx_library_items_content_hash` and `idx_library_items_synced_at` exist
+- [ ] 2.20 Add test: after `init()`, `PRAGMA journal_mode` returns `wal`
+- [ ] 2.21 Add test: after `init()`, `PRAGMA foreign_keys` returns `1`
+- [ ] 2.22 Add test: calling `_conn` before `init()` raises `RuntimeError`
+
+**Unit tests — upsert_many (`backend/tests/test_library_store.py::TestUpsertMany`)**
+- [ ] 2.23 Add test: insert 3 new items, verify `UpsertResult(created=3, updated=0, unchanged=0)`
+- [ ] 2.24 Add test: re-upsert same 3 items with same content_hash, verify `UpsertResult(created=0, updated=0, unchanged=3)`
+- [ ] 2.25 Add test: change one item's content_hash and re-upsert all 3, verify `UpsertResult(created=0, updated=1, unchanged=2)`
+- [ ] 2.26 Add test: upsert empty list, verify `UpsertResult(created=0, updated=0, unchanged=0)`
+
+**Unit tests — get (`backend/tests/test_library_store.py::TestGet`)**
+- [ ] 2.27 Add test: insert an item then fetch by ID, verify all fields round-trip correctly including JSON arrays (`genres`, `tags`, `studios`, `people`)
+- [ ] 2.28 Add test: fetch non-existent ID returns `None`
+
+**Unit tests — get_many (`backend/tests/test_library_store.py::TestGetMany`)**
+- [ ] 2.29 Add test: insert 5 items, fetch 3 by ID, verify exactly 3 returned with correct data
+- [ ] 2.30 Add test: fetch with mix of existing and non-existent IDs, verify only existing items returned
+- [ ] 2.31 Add test: fetch with empty ID list, verify empty list returned
+
+**Unit tests — get_all_hashes (`backend/tests/test_library_store.py::TestGetAllHashes`)**
+- [ ] 2.32 Add test: insert items, verify returned dict maps each `jellyfin_id` to its `content_hash`
+- [ ] 2.33 Add test: empty store returns empty dict
+
+**Unit tests — count (`backend/tests/test_library_store.py::TestCount`)**
+- [ ] 2.34 Add test: empty store returns `0`
+- [ ] 2.35 Add test: after inserting 5 items, returns `5`
+
+**Unit tests — content hash (`backend/tests/test_library_store.py::TestContentHash`)**
+- [ ] 2.36 Add test: same `LibraryItemRow` input always produces the same hash (deterministic)
+- [ ] 2.37 Add test: different input (e.g., changed title) produces a different hash
+
+**Unit tests — people filtering (`backend/tests/test_library_store.py::TestPeopleFiltering`)**
+- [ ] 2.38 Add test: `LibraryItemRow` with people list stores only actor names; verify non-Actor `People` entries from Jellyfin raw data are excluded when building the row (this tests the conversion logic from `LibraryItem.people` to `LibraryItemRow.people`)
+
+**Unit tests — validation (`backend/tests/test_library_store.py::TestValidation`)**
+- [ ] 2.39 Add test: malformed Jellyfin item data (missing required `Id` or `Name`) is skipped with a WARNING log (item ID only), valid items in the same batch are stored successfully
+
+**Unit test — config (`backend/tests/test_config.py`)**
+- [ ] 2.40 Add test: `library_db_path` defaults to `"data/library.db"`
+
+---
+
+### [ ] 3.0 App Wiring, Config, and Documentation
+
+Wire `LibraryStore` into `main.py` lifespan (init after `SessionStore`, close before), add `JELLYFIN_API_KEY` config with whitespace validation, create sync-dedicated `JellyfinClient` instance when API key is set, update `.env.example` and `ARCHITECTURE.md`.
+
+#### 3.0 Proof Artifact(s)
+- Test: `backend/tests/test_main.py::TestLifespan` (or equivalent) — verify `LibraryStore.init()` called after `SessionStore.init()`, `LibraryStore.close()` called before `SessionStore.close()`
+- Test: `backend/tests/test_config.py` (or equivalent) — empty/whitespace `JELLYFIN_API_KEY` treated as `None`; valid key stored in settings; API key never appears in log output
+- Test: `backend/tests/integration/test_jellyfin_library.py` — connect to test Jellyfin, call `get_all_items(item_types=["Movie"])`, verify items returned with expected fields, store in `LibraryStore`, verify `count()` matches `total_count` from Jellyfin (marked `@pytest.mark.integration`)
+- Verify: `.env.example` contains `JELLYFIN_API_KEY` with security warning comment block
+- Verify: `.env.example` contains `LIBRARY_DB_PATH` and `LIBRARY_SYNC_PAGE_SIZE` entries
+- Verify: `ARCHITECTURE.md` documents two-database strategy (`sessions.db` + `library.db`) and credential distinction (infrastructure API key vs. user tokens)
+- Verify: `backend/app/library/__init__.py` exists as module file
+- Verify: `app.state.library_store` is set during lifespan startup
+
+#### 3.0 Tasks
+
+**Config — API key (`backend/app/config.py`)**
+- [ ] 3.1 Add `jellyfin_api_key: str | None = None` field to `Settings` class, loaded from `JELLYFIN_API_KEY` env var
+- [ ] 3.2 Add `@model_validator(mode="after")` for `jellyfin_api_key` that strips whitespace and treats empty/whitespace-only values as `None`, logging a WARNING when a whitespace-only key is discarded
+- [ ] 3.3 Ensure `jellyfin_api_key` never appears in log output — no `__repr__` or `__str__` exposure (Pydantic `SecretStr` or manual exclusion from any logging)
+
+**Lifespan wiring (`backend/app/main.py`)**
+- [ ] 3.4 Import `LibraryStore` from `app.library.store` in `main.py`
+- [ ] 3.5 In lifespan startup, after `SessionStore.init()`: create `data/` directory for `library.db` if it does not exist (same pattern as session DB), instantiate `LibraryStore(settings.library_db_path)`, call `await library_store.init()`, store on `app.state.library_store`
+- [ ] 3.6 In lifespan shutdown: close `LibraryStore` before closing `SessionStore` (reverse initialization order) — `await library_store.close()` before `await store.close()`
+- [ ] 3.7 If `settings.jellyfin_api_key` is set, create a separate sync `JellyfinClient` instance using the same shared `httpx.AsyncClient` but a distinct `device_id` (e.g., `"ai-movie-suggester-sync"`), store on `app.state.sync_jellyfin_client`
+- [ ] 3.8 If `settings.jellyfin_api_key` is not set, log INFO that background sync is disabled (API key not configured)
+
+**Unit tests — config (`backend/tests/test_config.py`)**
+- [ ] 3.9 Add test: `jellyfin_api_key` defaults to `None` when env var not set
+- [ ] 3.10 Add test: valid `JELLYFIN_API_KEY` value is stored in settings
+- [ ] 3.11 Add test: empty string `JELLYFIN_API_KEY=""` is treated as `None`
+- [ ] 3.12 Add test: whitespace-only `JELLYFIN_API_KEY="   "` is treated as `None`
+- [ ] 3.13 Add test: `JELLYFIN_API_KEY` with leading/trailing whitespace is stripped (e.g., `"  key123  "` -> `"key123"`)
+
+**Unit tests — lifespan (`backend/tests/test_main.py`)**
+- [ ] 3.14 Create `backend/tests/test_main.py` with `TestLifespan` class
+- [ ] 3.15 Add test: verify `LibraryStore.init()` is called during startup (mock `LibraryStore`)
+- [ ] 3.16 Add test: verify `app.state.library_store` is set after startup
+- [ ] 3.17 Add test: verify `LibraryStore.close()` is called before `SessionStore.close()` during shutdown (use mock call ordering)
+- [ ] 3.18 Add test: verify sync `JellyfinClient` is created on `app.state.sync_jellyfin_client` when `jellyfin_api_key` is set
+- [ ] 3.19 Add test: verify `app.state.sync_jellyfin_client` is not set when `jellyfin_api_key` is `None`
+
+**Integration test (`backend/tests/integration/test_jellyfin_library.py`)**
+- [ ] 3.20 Create `backend/tests/integration/test_jellyfin_library.py` with `@pytest.mark.integration` marker
+- [ ] 3.21 Add test: authenticate as admin, call `get_all_items(token, user_id, item_types=["Movie"])`, verify items are returned (may be 0 on fresh Jellyfin — test handles both cases)
+- [ ] 3.22 Add test: fetch items via `get_all_items()`, convert to `LibraryItemRow` (using placeholder hash), store in a temporary `LibraryStore`, verify `count()` matches `total_count` from Jellyfin response
+- [ ] 3.23 Add test: verify returned `LibraryItem` objects have the extended fields populated (tags, studios, community_rating, people — at minimum, no Pydantic validation errors)
+
+**Documentation (`.env.example`)**
+- [ ] 3.24 Add `# --- Library Sync ---` section to `.env.example` with `JELLYFIN_API_KEY` entry including the security warning comment block from FR-3.4 (how to generate, treat like root password, never commit)
+- [ ] 3.25 Add `LIBRARY_DB_PATH` entry (commented out, showing default `data/library.db`)
+- [ ] 3.26 Add `LIBRARY_SYNC_PAGE_SIZE` entry (commented out, showing default `200`)
+
+**Documentation (`ARCHITECTURE.md`)**
+- [ ] 3.27 Update "SQLite-vec" component section to document the two-file database strategy: `data/sessions.db` for auth/session data, `data/library.db` for item metadata and future vector embeddings, with rationale (different access patterns, backup lifecycles, WAL mode on both)
+- [ ] 3.28 Add note under "Security Model" section distinguishing infrastructure credentials (`JELLYFIN_API_KEY` — operator-configured, server-scoped, enables background sync) from user tokens (per-session, encrypted at rest, never persisted to objects)

--- a/docs/specs/05-spec-jellyfin-library-client/05-tasks-jellyfin-library-client.md
+++ b/docs/specs/05-spec-jellyfin-library-client/05-tasks-jellyfin-library-client.md
@@ -74,7 +74,7 @@ Extend the `LibraryItem` Pydantic model with fields needed for embedding (tags, 
 
 ---
 
-### [~] 2.0 Library Metadata Store (SQLite Repository)
+### [x] 2.0 Library Metadata Store (SQLite Repository)
 
 Create `backend/app/library/` module with `LibraryStore` (SQLite repository following `SessionStore` pattern), `LibraryItemRow` and `UpsertResult` dataclasses, `LibraryStoreProtocol`, and placeholder content-hash function. Implements bulk upsert with created/updated/unchanged tracking, single/batch get, hash retrieval, and count.
 
@@ -166,7 +166,7 @@ Create `backend/app/library/` module with `LibraryStore` (SQLite repository foll
 
 ---
 
-### [ ] 3.0 App Wiring, Config, and Documentation
+### [x] 3.0 App Wiring, Config, and Documentation
 
 Wire `LibraryStore` into `main.py` lifespan (init after `SessionStore`, close before), add `JELLYFIN_API_KEY` config with whitespace validation, create sync-dedicated `JellyfinClient` instance when API key is set, update `.env.example` and `ARCHITECTURE.md`.
 

--- a/docs/specs/05-spec-jellyfin-library-client/05-tasks-jellyfin-library-client.md
+++ b/docs/specs/05-spec-jellyfin-library-client/05-tasks-jellyfin-library-client.md
@@ -24,7 +24,7 @@
 
 ## Tasks
 
-### [~] 1.0 Extended LibraryItem Model + Auto-Paginated Client
+### [x] 1.0 Extended LibraryItem Model + Auto-Paginated Client
 
 Extend the `LibraryItem` Pydantic model with fields needed for embedding (tags, studios, community_rating, people) and add `get_all_items()` async iterator to `JellyfinClient` for auto-paginated library fetching. Add `LIBRARY_SYNC_PAGE_SIZE` to `Settings`.
 
@@ -74,7 +74,7 @@ Extend the `LibraryItem` Pydantic model with fields needed for embedding (tags, 
 
 ---
 
-### [ ] 2.0 Library Metadata Store (SQLite Repository)
+### [~] 2.0 Library Metadata Store (SQLite Repository)
 
 Create `backend/app/library/` module with `LibraryStore` (SQLite repository following `SessionStore` pattern), `LibraryItemRow` and `UpsertResult` dataclasses, `LibraryStoreProtocol`, and placeholder content-hash function. Implements bulk upsert with created/updated/unchanged tracking, single/batch get, hash retrieval, and count.
 


### PR DESCRIPTION
## Summary

Epic 2 / Wave 1 — Implements Spec 05: Jellyfin Library Client + Item Metadata Store.

- Extends `LibraryItem` model with tags, studios, community rating, and people (cast) fields
- Adds auto-paginated `get_all_items()` async iterator to `JellyfinClient`
- Creates `LibraryStore` SQLite repository in `data/library.db` with bulk upsert, content hashing, and Protocol abstraction
- Adds `JELLYFIN_API_KEY` env var for optional background sync with code-path isolation
- Updates `.env.example` and `ARCHITECTURE.md` with two-database strategy and credential documentation

## Test plan

- [ ] `cd backend && python -m pytest tests/ -x -q` — 188 tests pass (33 new)
- [ ] `cd backend && python -m ruff check app/ tests/` — clean
- [ ] `make test-integration` — integration tests against real Jellyfin (optional)
- [ ] Verify `.env.example` documents `JELLYFIN_API_KEY` with security warning
- [ ] Verify `ARCHITECTURE.md` documents two-database strategy

**SDD Artifacts:** `docs/specs/05-spec-jellyfin-library-client/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #92