### PR TITLE
feat(vectors): SQLite-vec setup + vector repository abstraction (#94)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,14 @@ TMDB_ENABLED=false
 # Only needed if TMDB_ENABLED=true
 TMDB_API_KEY=
 
+# --- Library (Vector DB) ---
+
+# Path to the library SQLite database (stores embeddings + item metadata)
+# LIBRARY_DB_PATH=data/library.db
+
+# Embedding dimensions (must match the chosen OLLAMA_EMBED_MODEL output)
+# OLLAMA_EMBED_DIMENSIONS=768
+
 # --- Sessions ---
 
 # Secure cookie flag — controls the Secure attribute on session cookies.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     ollama_host: str = "http://ollama:11434"
     ollama_chat_model: str = "llama3.1:8b"
     ollama_embed_model: str = "nomic-embed-text"
+    ollama_embed_dimensions: int = 768
 
     # Optional: TMDb
     tmdb_enabled: bool = False

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -64,6 +64,9 @@ class Settings(BaseSettings):
                 raise ValueError(msg)
         return self
 
+    # Library (shared by LibraryItemStore + SqliteVecRepository)
+    library_db_path: str = "data/library.db"
+
     # Sessions
     session_secure_cookie: bool = True
     max_sessions_per_user: int = 5

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from app.middleware import SecurityHeadersMiddleware
 from app.middleware.csrf import CSRFMiddleware
 from app.middleware.rate_limit import create_limiter
 from app.models import EmbeddingsStatus, HealthResponse, ServiceStatus
+from app.vectors.repository import SqliteVecRepository
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -94,6 +95,22 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         library_store = LibraryStore(settings.library_db_path)
         await library_store.init()
         app.state.library_store = library_store
+
+        # Open vector repository (shares library.db, after library store)
+        vec_repo = SqliteVecRepository(
+            db_path=settings.library_db_path,
+            expected_model=settings.ollama_embed_model,
+            expected_dimensions=settings.ollama_embed_dimensions,
+        )
+        try:
+            await vec_repo.init()
+        except RuntimeError:
+            _logger.critical(
+                "vec_repo init failed — extension or dimension mismatch",
+                exc_info=True,
+            )
+            raise
+        app.state.vec_repo = vec_repo
 
         # Create shared HTTP client and Jellyfin client
         http_client = httpx.AsyncClient(timeout=settings.jellyfin_timeout)
@@ -173,6 +190,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         with contextlib.suppress(asyncio.CancelledError):
             await cleanup_task
         _logger.info("shutting down ai-movie-suggester backend")
+        # Shutdown: reverse init order (vec_repo → library_store → session store)
+        await vec_repo.close()
+        # TODO(Spec 07): WAL checkpoint after bulk embedding operations
         await library_store.close()
         await store.close()
         await http_client.aclose()
@@ -200,10 +220,19 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     _logger,
                 ),
             )
+        # Report real embedding count from vec_repo (if initialised)
+        try:
+            vec_repo = application.state.vec_repo
+            total = await vec_repo.count()
+        except Exception:
+            total = 0
         return HealthResponse(
             jellyfin=jf,
             ollama=ol,
-            embeddings=EmbeddingsStatus(total=0, pending=0),
+            embeddings=EmbeddingsStatus(
+                total=total,
+                pending=0,  # Updated by embedding pipeline (Spec 07)
+            ),
         )
 
     # Middleware registration order matters — FastAPI processes middleware

--- a/backend/app/vectors/__init__.py
+++ b/backend/app/vectors/__init__.py
@@ -1,0 +1,25 @@
+"""Vector storage package — Protocol, models, and SQLite-vec implementation."""
+
+from app.vectors.models import (
+    COMPLETE,
+    FAILED,
+    PENDING,
+    PROCESSING,
+    VALID_STATUSES,
+    SearchResult,
+    VectorRecord,
+    VectorRepositoryProtocol,
+)
+from app.vectors.repository import SqliteVecRepository
+
+__all__ = [
+    "COMPLETE",
+    "FAILED",
+    "PENDING",
+    "PROCESSING",
+    "SearchResult",
+    "SqliteVecRepository",
+    "VALID_STATUSES",
+    "VectorRecord",
+    "VectorRepositoryProtocol",
+]

--- a/backend/app/vectors/models.py
+++ b/backend/app/vectors/models.py
@@ -1,0 +1,67 @@
+"""Data models for vector repository.
+
+Defines the VectorRepositoryProtocol (structural subtyping), dataclasses
+for vector records and search results, and embedding status constants.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+# Embedding status constants
+PENDING = "pending"
+PROCESSING = "processing"
+COMPLETE = "complete"
+FAILED = "failed"
+VALID_STATUSES: frozenset[str] = frozenset({PENDING, PROCESSING, COMPLETE, FAILED})
+
+
+@dataclass(frozen=True, slots=True)
+class VectorRecord:
+    """Metadata for a stored vector (excludes the embedding itself)."""
+
+    jellyfin_id: str
+    content_hash: str
+    embedded_at: int
+    embedding_status: str
+
+
+@dataclass(frozen=True, slots=True)
+class SearchResult:
+    """A single result from a cosine-similarity search."""
+
+    jellyfin_id: str
+    distance: float
+    content_hash: str
+
+
+@runtime_checkable
+class VectorRepositoryProtocol(Protocol):
+    """Structural interface for vector storage backends."""
+
+    async def init(self) -> None: ...
+
+    async def close(self) -> None: ...
+
+    async def upsert(
+        self, jellyfin_id: str, embedding: list[float], content_hash: str
+    ) -> None: ...
+
+    async def get(self, jellyfin_id: str) -> VectorRecord | None: ...
+
+    async def get_many(self, ids: list[str]) -> list[VectorRecord]: ...
+
+    async def delete(self, jellyfin_id: str) -> None: ...
+
+    async def delete_many(self, ids: list[str]) -> None: ...
+
+    async def search(
+        self, query_embedding: list[float], limit: int = 20
+    ) -> list[SearchResult]: ...
+
+    async def count(self) -> int: ...
+
+    async def get_embedding_status(self, jellyfin_id: str) -> str | None: ...
+
+    async def set_embedding_status(self, jellyfin_id: str, status: str) -> None: ...

--- a/backend/app/vectors/repository.py
+++ b/backend/app/vectors/repository.py
@@ -69,10 +69,18 @@ class SqliteVecRepository:
         return self._reader_db
 
     async def _load_vec0(self, conn: aiosqlite.Connection) -> None:
-        """Load the vec0 extension on an aiosqlite connection."""
+        """Load the vec0 extension on an aiosqlite connection.
+
+        Extension loading is disabled immediately after vec0 is loaded
+        to reduce the attack surface — no further extensions can be
+        injected via this connection.
+        """
         try:
             await conn.enable_load_extension(True)
             await conn.load_extension(sqlite_vec.loadable_path())
+            # Close extension loading capability now that vec0 is loaded
+            await conn.enable_load_extension(False)
+            _logger.info("sqlite-vec extension loaded: %s", sqlite_vec.loadable_path())
         except Exception as exc:
             msg = (
                 "Failed to load sqlite-vec extension (vec0). "
@@ -86,6 +94,10 @@ class SqliteVecRepository:
         await self._load_vec0(conn)
         await conn.execute("PRAGMA journal_mode=WAL")
         await conn.execute("PRAGMA foreign_keys=ON")
+        # Prevent "database is locked" errors when reader and writer
+        # contend — wait up to 5 s before raising instead of failing
+        # immediately.
+        await conn.execute("PRAGMA busy_timeout=5000")
 
     async def init(self) -> None:
         """Open connections, load vec0, create schema, validate metadata."""
@@ -161,19 +173,28 @@ class SqliteVecRepository:
     async def upsert(
         self, jellyfin_id: str, embedding: list[float], content_hash: str
     ) -> None:
-        """Insert or update a vector (DELETE + INSERT pattern)."""
+        """Insert or update a vector (DELETE + INSERT pattern).
+
+        Wrapped in an explicit transaction so a crash between DELETE and
+        INSERT rolls back cleanly — no data loss.
+        """
         serialized = _serialize_f32(embedding)
-        await self._writer.execute(
-            "DELETE FROM item_vectors WHERE jellyfin_id = ?",
-            (jellyfin_id,),
-        )
-        await self._writer.execute(
-            "INSERT INTO item_vectors "
-            "(jellyfin_id, embedding, content_hash, embedded_at, embedding_status) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (jellyfin_id, serialized, content_hash, int(time.time()), COMPLETE),
-        )
-        await self._writer.commit()
+        try:
+            await self._writer.execute("BEGIN")
+            await self._writer.execute(
+                "DELETE FROM item_vectors WHERE jellyfin_id = ?",
+                (jellyfin_id,),
+            )
+            await self._writer.execute(
+                "INSERT INTO item_vectors "
+                "(jellyfin_id, embedding, content_hash, embedded_at, embedding_status) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (jellyfin_id, serialized, content_hash, int(time.time()), COMPLETE),
+            )
+            await self._writer.commit()
+        except Exception:
+            await self._writer.rollback()
+            raise
 
     async def get(self, jellyfin_id: str) -> VectorRecord | None:
         """Retrieve a single record's metadata (not the embedding)."""
@@ -273,6 +294,7 @@ class SqliteVecRepository:
         """Update the embedding status for an item.
 
         Raises ValueError for invalid status strings.
+        Raises KeyError if no vector record exists for the given jellyfin_id.
         """
         if status not in VALID_STATUSES:
             msg = (
@@ -280,10 +302,13 @@ class SqliteVecRepository:
                 f"Must be one of: {', '.join(sorted(VALID_STATUSES))}"
             )
             raise ValueError(msg)
-        await self._writer.execute(
+        cursor = await self._writer.execute(
             "UPDATE item_vectors SET embedding_status = ? WHERE jellyfin_id = ?",
             (status, jellyfin_id),
         )
+        if cursor.rowcount == 0:
+            msg = f"No vector record for jellyfin_id={jellyfin_id}"
+            raise KeyError(msg)
         await self._writer.commit()
 
     async def close(self) -> None:

--- a/backend/app/vectors/repository.py
+++ b/backend/app/vectors/repository.py
@@ -1,0 +1,296 @@
+"""SQLite-vec vector repository implementation.
+
+Stores 768-dimensional (or configurable) float vectors using the vec0
+virtual table extension. Provides cosine-similarity search, CRUD
+operations, and embedding status tracking.
+
+Uses separate reader/writer aiosqlite connections in WAL mode for
+concurrent search-while-embedding without write lock contention.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+import time
+
+import aiosqlite
+import sqlite_vec
+
+from app.vectors.models import (
+    COMPLETE,
+    VALID_STATUSES,
+    SearchResult,
+    VectorRecord,
+)
+
+_logger = logging.getLogger(__name__)
+
+_CREATE_VEC_META = """
+CREATE TABLE IF NOT EXISTS _vec_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+)
+"""
+
+
+def _serialize_f32(vector: list[float]) -> bytes:
+    """Serialize a list of floats to compact binary format for sqlite-vec."""
+    return struct.pack(f"{len(vector)}f", *vector)
+
+
+class SqliteVecRepository:
+    """Async vector repository backed by SQLite-vec (vec0 extension)."""
+
+    def __init__(
+        self,
+        db_path: str,
+        expected_model: str,
+        expected_dimensions: int,
+    ) -> None:
+        self._db_path = db_path
+        self._expected_model = expected_model
+        self._expected_dimensions = expected_dimensions
+        self._writer_db: aiosqlite.Connection | None = None
+        self._reader_db: aiosqlite.Connection | None = None
+
+    @property
+    def _writer(self) -> aiosqlite.Connection:
+        if self._writer_db is None:
+            msg = "SqliteVecRepository not initialised — call init() first"
+            raise RuntimeError(msg)
+        return self._writer_db
+
+    @property
+    def _reader(self) -> aiosqlite.Connection:
+        if self._reader_db is None:
+            msg = "SqliteVecRepository not initialised — call init() first"
+            raise RuntimeError(msg)
+        return self._reader_db
+
+    async def _load_vec0(self, conn: aiosqlite.Connection) -> None:
+        """Load the vec0 extension on an aiosqlite connection."""
+        try:
+            await conn.enable_load_extension(True)
+            await conn.load_extension(sqlite_vec.loadable_path())
+        except Exception as exc:
+            msg = (
+                "Failed to load sqlite-vec extension (vec0). "
+                "Ensure the sqlite-vec package is installed: "
+                "pip install sqlite-vec"
+            )
+            raise RuntimeError(msg) from exc
+
+    async def _setup_connection(self, conn: aiosqlite.Connection) -> None:
+        """Apply standard pragmas and load vec0 on a connection."""
+        await self._load_vec0(conn)
+        await conn.execute("PRAGMA journal_mode=WAL")
+        await conn.execute("PRAGMA foreign_keys=ON")
+
+    async def init(self) -> None:
+        """Open connections, load vec0, create schema, validate metadata."""
+        # Open writer connection
+        self._writer_db = await aiosqlite.connect(self._db_path)
+        await self._setup_connection(self._writer)
+
+        # Open reader connection
+        self._reader_db = await aiosqlite.connect(self._db_path)
+        await self._setup_connection(self._reader)
+
+        # Create _vec_meta table
+        await self._writer.execute(_CREATE_VEC_META)
+        await self._writer.commit()
+
+        # Validate or store model/dimension metadata
+        await self._validate_or_store_meta()
+
+        # Create vec0 virtual table for vectors
+        create_vec_table = (
+            "CREATE VIRTUAL TABLE IF NOT EXISTS item_vectors USING vec0("
+            "    jellyfin_id TEXT PRIMARY KEY,"
+            f"    embedding float[{self._expected_dimensions}] distance_metric=cosine,"
+            "    content_hash TEXT,"
+            "    embedded_at INTEGER,"
+            "    embedding_status TEXT"
+            ")"
+        )
+        await self._writer.execute(create_vec_table)
+        await self._writer.commit()
+
+    async def _validate_or_store_meta(self) -> None:
+        """Check _vec_meta for model/dimensions; store on first run."""
+        cursor = await self._writer.execute(
+            "SELECT key, value FROM _vec_meta WHERE key IN ('model_name', 'dimensions')"
+        )
+        rows = await cursor.fetchall()
+        stored: dict[str, str] = {row[0]: row[1] for row in rows}
+
+        if not stored:
+            # First run — insert metadata
+            await self._writer.execute(
+                "INSERT INTO _vec_meta (key, value) VALUES (?, ?)",
+                ("model_name", self._expected_model),
+            )
+            await self._writer.execute(
+                "INSERT INTO _vec_meta (key, value) VALUES (?, ?)",
+                ("dimensions", str(self._expected_dimensions)),
+            )
+            await self._writer.commit()
+            return
+
+        # Subsequent run — validate
+        stored_model = stored.get("model_name", "")
+        stored_dims = stored.get("dimensions", "")
+
+        if stored_dims != str(self._expected_dimensions):
+            msg = (
+                f"Dimension mismatch: DB has {stored_dims} ({stored_model}), "
+                f"expected {self._expected_dimensions} ({self._expected_model}). "
+                "Re-embed or use a new DB."
+            )
+            raise RuntimeError(msg)
+
+        if stored_model != self._expected_model:
+            msg = (
+                f"Model mismatch: DB has '{stored_model}', "
+                f"expected '{self._expected_model}'. "
+                "Re-embed or use a new DB."
+            )
+            raise RuntimeError(msg)
+
+    async def upsert(
+        self, jellyfin_id: str, embedding: list[float], content_hash: str
+    ) -> None:
+        """Insert or update a vector (DELETE + INSERT pattern)."""
+        serialized = _serialize_f32(embedding)
+        await self._writer.execute(
+            "DELETE FROM item_vectors WHERE jellyfin_id = ?",
+            (jellyfin_id,),
+        )
+        await self._writer.execute(
+            "INSERT INTO item_vectors "
+            "(jellyfin_id, embedding, content_hash, embedded_at, embedding_status) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (jellyfin_id, serialized, content_hash, int(time.time()), COMPLETE),
+        )
+        await self._writer.commit()
+
+    async def get(self, jellyfin_id: str) -> VectorRecord | None:
+        """Retrieve a single record's metadata (not the embedding)."""
+        cursor = await self._reader.execute(
+            "SELECT jellyfin_id, content_hash, embedded_at, embedding_status "
+            "FROM item_vectors WHERE jellyfin_id = ?",
+            (jellyfin_id,),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return VectorRecord(
+            jellyfin_id=row[0],
+            content_hash=row[1],
+            embedded_at=row[2],
+            embedding_status=row[3],
+        )
+
+    async def get_many(self, ids: list[str]) -> list[VectorRecord]:
+        """Retrieve multiple records by jellyfin IDs. Missing IDs are omitted."""
+        if not ids:
+            return []
+        placeholders = ",".join("?" for _ in ids)
+        cursor = await self._reader.execute(
+            "SELECT jellyfin_id, content_hash, embedded_at, embedding_status "
+            f"FROM item_vectors WHERE jellyfin_id IN ({placeholders})",
+            ids,
+        )
+        rows = await cursor.fetchall()
+        return [
+            VectorRecord(
+                jellyfin_id=row[0],
+                content_hash=row[1],
+                embedded_at=row[2],
+                embedding_status=row[3],
+            )
+            for row in rows
+        ]
+
+    async def delete(self, jellyfin_id: str) -> None:
+        """Remove a single vector by jellyfin ID."""
+        await self._writer.execute(
+            "DELETE FROM item_vectors WHERE jellyfin_id = ?",
+            (jellyfin_id,),
+        )
+        await self._writer.commit()
+
+    async def delete_many(self, ids: list[str]) -> None:
+        """Remove multiple vectors in a single transaction."""
+        if not ids:
+            return
+        placeholders = ",".join("?" for _ in ids)
+        await self._writer.execute(
+            f"DELETE FROM item_vectors WHERE jellyfin_id IN ({placeholders})",
+            ids,
+        )
+        await self._writer.commit()
+
+    async def search(
+        self, query_embedding: list[float], limit: int = 20
+    ) -> list[SearchResult]:
+        """Cosine similarity search, returning top-N results."""
+        serialized = _serialize_f32(query_embedding)
+        cursor = await self._reader.execute(
+            "SELECT jellyfin_id, distance, content_hash "
+            "FROM item_vectors "
+            "WHERE embedding MATCH ? AND k = ? "
+            "ORDER BY distance",
+            (serialized, limit),
+        )
+        rows = await cursor.fetchall()
+        return [
+            SearchResult(
+                jellyfin_id=row[0],
+                distance=row[1],
+                content_hash=row[2],
+            )
+            for row in rows
+        ]
+
+    async def count(self) -> int:
+        """Return total number of stored vectors."""
+        cursor = await self._reader.execute("SELECT COUNT(*) FROM item_vectors")
+        row = await cursor.fetchone()
+        return row[0] if row else 0
+
+    async def get_embedding_status(self, jellyfin_id: str) -> str | None:
+        """Return the embedding status for an item, or None if not found."""
+        cursor = await self._reader.execute(
+            "SELECT embedding_status FROM item_vectors WHERE jellyfin_id = ?",
+            (jellyfin_id,),
+        )
+        row = await cursor.fetchone()
+        return row[0] if row else None
+
+    async def set_embedding_status(self, jellyfin_id: str, status: str) -> None:
+        """Update the embedding status for an item.
+
+        Raises ValueError for invalid status strings.
+        """
+        if status not in VALID_STATUSES:
+            msg = (
+                f"Invalid embedding status '{status}'. "
+                f"Must be one of: {', '.join(sorted(VALID_STATUSES))}"
+            )
+            raise ValueError(msg)
+        await self._writer.execute(
+            "UPDATE item_vectors SET embedding_status = ? WHERE jellyfin_id = ?",
+            (status, jellyfin_id),
+        )
+        await self._writer.commit()
+
+    async def close(self) -> None:
+        """Close both connections. Safe to call multiple times."""
+        if self._writer_db:
+            await self._writer_db.close()
+            self._writer_db = None
+        if self._reader_db:
+            await self._reader_db.close()
+            self._reader_db = None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "cryptography>=44.0.0",
     "aiosqlite>=0.20.0",
     "slowapi>=0.1.9",
+    "sqlite-vec>=0.1.6",
 ]
 
 [project.optional-dependencies]
@@ -37,6 +38,7 @@ addopts = "--strict-markers"
 strict_markers = true
 markers = [
     "integration: marks tests as requiring a live Jellyfin instance (deselect with '-m \"not integration\"')",
+    "requires_sqlite_vec: marks tests that need the sqlite-vec extension",
 ]
 
 [tool.pyright]

--- a/backend/tests/test_vec_lifespan.py
+++ b/backend/tests/test_vec_lifespan.py
@@ -1,0 +1,158 @@
+"""Integration tests for SqliteVecRepository lifespan wiring."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.vectors.repository import SqliteVecRepository
+
+if TYPE_CHECKING:
+    import pathlib
+
+pytestmark = pytest.mark.requires_sqlite_vec
+
+
+class TestLifespanIntegration:
+    """Verify vec_repo is wired into app lifespan."""
+
+    def test_startup_initialises_vec_repo_on_app_state(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Application startup places SqliteVecRepository on app.state."""
+        from app.main import create_app
+        from tests.conftest import make_test_settings
+
+        settings = make_test_settings(
+            library_db_path=str(tmp_path / "library.db"),
+            session_db_path=str(tmp_path / "sessions.db"),
+        )
+        app = create_app(settings)
+        with TestClient(app):
+            vec_repo = app.state.vec_repo
+            assert isinstance(vec_repo, SqliteVecRepository)
+
+    def test_health_endpoint_returns_embeddings_total(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """/health returns embeddings.total reflecting actual vector count."""
+        from app.main import create_app
+        from tests.conftest import make_test_settings
+
+        settings = make_test_settings(
+            library_db_path=str(tmp_path / "library.db"),
+            session_db_path=str(tmp_path / "sessions.db"),
+        )
+        app = create_app(settings)
+        with TestClient(app) as client:
+            resp = client.get("/health")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "embeddings" in data
+            assert data["embeddings"]["total"] == 0
+            assert data["embeddings"]["pending"] == 0
+
+    def test_shutdown_closes_vec_repo_before_session_store(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Shutdown closes vec_repo before session store (reverse init)."""
+        from app.auth.session_store import SessionStore
+        from app.main import create_app
+        from tests.conftest import make_test_settings
+
+        call_order: list[str] = []
+
+        settings = make_test_settings(
+            library_db_path=str(tmp_path / "library.db"),
+            session_db_path=str(tmp_path / "sessions.db"),
+        )
+        app = create_app(settings)
+
+        original_vec_close = SqliteVecRepository.close
+        original_store_close = SessionStore.close
+
+        async def tracked_vec_close(self: SqliteVecRepository) -> None:
+            call_order.append("vec_repo.close")
+            await original_vec_close(self)
+
+        async def tracked_store_close(self: SessionStore) -> None:
+            call_order.append("store.close")
+            await original_store_close(self)
+
+        with (
+            patch.object(SqliteVecRepository, "close", tracked_vec_close),
+            patch.object(SessionStore, "close", tracked_store_close),
+            TestClient(app),
+        ):
+            pass  # Startup + shutdown happen in context
+
+        assert "vec_repo.close" in call_order
+        assert "store.close" in call_order
+        assert call_order.index("vec_repo.close") < call_order.index("store.close"), (
+            f"Expected vec_repo.close before store.close, got: {call_order}"
+        )
+
+
+class TestStartupFailures:
+    """Verify startup fails clearly on vec_repo errors."""
+
+    def test_startup_fails_on_extension_load_failure(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Startup raises RuntimeError when vec0 extension fails to load."""
+        from app.main import create_app
+        from tests.conftest import make_test_settings
+
+        settings = make_test_settings(
+            library_db_path=str(tmp_path / "library.db"),
+            session_db_path=str(tmp_path / "sessions.db"),
+        )
+        app = create_app(settings)
+
+        with (
+            patch.object(
+                SqliteVecRepository,
+                "init",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("Failed to load sqlite-vec extension"),
+            ),
+            pytest.raises(RuntimeError, match="Failed to load sqlite-vec"),
+            TestClient(app),
+        ):
+            pass
+
+    def test_startup_fails_on_dimension_mismatch(self, tmp_path: pathlib.Path) -> None:
+        """Startup raises RuntimeError on dimension mismatch."""
+        import asyncio
+
+        from app.main import create_app
+        from tests.conftest import make_test_settings
+
+        db_path = tmp_path / "library.db"
+
+        # Pre-populate with different dimensions
+        async def prepopulate() -> None:
+            repo = SqliteVecRepository(
+                db_path=str(db_path),
+                expected_model="nomic-embed-text",
+                expected_dimensions=384,
+            )
+            await repo.init()
+            await repo.close()
+
+        asyncio.get_event_loop().run_until_complete(prepopulate())
+
+        settings = make_test_settings(
+            library_db_path=str(db_path),
+            session_db_path=str(tmp_path / "sessions.db"),
+        )
+        app = create_app(settings)
+
+        with (
+            pytest.raises(RuntimeError, match="Dimension mismatch"),
+            TestClient(app),
+        ):
+            pass

--- a/backend/tests/test_vec_lifespan.py
+++ b/backend/tests/test_vec_lifespan.py
@@ -143,7 +143,7 @@ class TestStartupFailures:
             await repo.init()
             await repo.close()
 
-        asyncio.get_event_loop().run_until_complete(prepopulate())
+        asyncio.run(prepopulate())
 
         settings = make_test_settings(
             library_db_path=str(db_path),

--- a/backend/tests/test_vec_repository.py
+++ b/backend/tests/test_vec_repository.py
@@ -1,0 +1,365 @@
+"""Unit tests for the SQLite-vec vector repository."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from app.vectors.models import (
+    FAILED,
+    PENDING,
+    PROCESSING,
+    VectorRepositoryProtocol,
+)
+from app.vectors.repository import SqliteVecRepository, _serialize_f32
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import AsyncIterator
+
+pytestmark = pytest.mark.requires_sqlite_vec
+
+_MODEL = "nomic-embed-text"
+_DIMS = 4  # Small dimension for fast tests
+
+
+def _make_embedding(seed: float, dims: int = _DIMS) -> list[float]:
+    """Create a deterministic embedding from a seed value."""
+    return [seed + i * 0.1 for i in range(dims)]
+
+
+@pytest.fixture
+async def vec_repo(tmp_path: pathlib.Path) -> AsyncIterator[SqliteVecRepository]:
+    """Provide a fresh SqliteVecRepository backed by a temp DB."""
+    db_path = tmp_path / "test_library.db"
+    repo = SqliteVecRepository(
+        db_path=str(db_path),
+        expected_model=_MODEL,
+        expected_dimensions=_DIMS,
+    )
+    await repo.init()
+    yield repo
+    await repo.close()
+
+
+class TestExtensionAndInit:
+    """Extension loading and init() behaviour."""
+
+    async def test_extension_loads_and_vec0_available(
+        self, vec_repo: SqliteVecRepository
+    ) -> None:
+        """sqlite-vec extension loads and vec0 is functional."""
+        # If init() succeeded, vec0 is loaded. Verify by inserting
+        # and querying a trivial vector.
+        embedding = _make_embedding(0.5)
+        await vec_repo.upsert("test-item", embedding, "hash-1")
+        record = await vec_repo.get("test-item")
+        assert record is not None
+        assert record.jellyfin_id == "test-item"
+
+    async def test_init_creates_vec_meta_with_correct_values(
+        self, vec_repo: SqliteVecRepository
+    ) -> None:
+        """init() populates _vec_meta with model name and dimensions."""
+        cursor = await vec_repo._reader.execute(
+            "SELECT key, value FROM _vec_meta ORDER BY key"
+        )
+        rows = await cursor.fetchall()
+        meta = {row[0]: row[1] for row in rows}
+        assert meta["model_name"] == _MODEL
+        assert meta["dimensions"] == str(_DIMS)
+
+    async def test_init_idempotent(self, tmp_path: pathlib.Path) -> None:
+        """init() succeeds on second call with matching params."""
+        db_path = str(tmp_path / "idempotent.db")
+        repo = SqliteVecRepository(
+            db_path=db_path, expected_model=_MODEL, expected_dimensions=_DIMS
+        )
+        await repo.init()
+        await repo.close()
+
+        # Second init with same params
+        repo2 = SqliteVecRepository(
+            db_path=db_path, expected_model=_MODEL, expected_dimensions=_DIMS
+        )
+        await repo2.init()  # Should not raise
+        await repo2.close()
+
+    async def test_init_raises_on_dimension_mismatch(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """init() raises RuntimeError when dimensions mismatch."""
+        db_path = str(tmp_path / "dim_mismatch.db")
+        repo = SqliteVecRepository(
+            db_path=db_path, expected_model=_MODEL, expected_dimensions=_DIMS
+        )
+        await repo.init()
+        await repo.close()
+
+        repo2 = SqliteVecRepository(
+            db_path=db_path, expected_model=_MODEL, expected_dimensions=768
+        )
+        with pytest.raises(RuntimeError, match="Dimension mismatch"):
+            await repo2.init()
+        await repo2.close()
+
+    async def test_init_raises_on_model_mismatch(self, tmp_path: pathlib.Path) -> None:
+        """init() raises RuntimeError when model name mismatches."""
+        db_path = str(tmp_path / "model_mismatch.db")
+        repo = SqliteVecRepository(
+            db_path=db_path, expected_model=_MODEL, expected_dimensions=_DIMS
+        )
+        await repo.init()
+        await repo.close()
+
+        repo2 = SqliteVecRepository(
+            db_path=db_path,
+            expected_model="different-model",
+            expected_dimensions=_DIMS,
+        )
+        with pytest.raises(RuntimeError, match="Model mismatch"):
+            await repo2.init()
+        await repo2.close()
+
+    async def test_init_raises_on_extension_load_failure(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """init() raises RuntimeError when vec0 extension cannot load."""
+        db_path = str(tmp_path / "no_ext.db")
+        repo = SqliteVecRepository(
+            db_path=db_path, expected_model=_MODEL, expected_dimensions=_DIMS
+        )
+        with (
+            patch.object(
+                repo,
+                "_load_vec0",
+                side_effect=RuntimeError("Failed to load sqlite-vec extension"),
+            ),
+            pytest.raises(RuntimeError, match="Failed to load sqlite-vec"),
+        ):
+            await repo.init()
+        await repo.close()
+
+    async def test_protocol_structural_check(self) -> None:
+        """SqliteVecRepository satisfies VectorRepositoryProtocol."""
+        assert issubclass(SqliteVecRepository, VectorRepositoryProtocol)
+
+
+class TestConnectionGuards:
+    """Property guards for _writer and _reader before init()."""
+
+    async def test_writer_raises_before_init(self, tmp_path: pathlib.Path) -> None:
+        """_writer property raises RuntimeError before init()."""
+        repo = SqliteVecRepository(
+            db_path=str(tmp_path / "guard.db"),
+            expected_model=_MODEL,
+            expected_dimensions=_DIMS,
+        )
+        with pytest.raises(RuntimeError, match="not initialised"):
+            _ = repo._writer
+
+    async def test_reader_raises_before_init(self, tmp_path: pathlib.Path) -> None:
+        """_reader property raises RuntimeError before init()."""
+        repo = SqliteVecRepository(
+            db_path=str(tmp_path / "guard.db"),
+            expected_model=_MODEL,
+            expected_dimensions=_DIMS,
+        )
+        with pytest.raises(RuntimeError, match="not initialised"):
+            _ = repo._reader
+
+    async def test_close_safe_to_call_twice(self, tmp_path: pathlib.Path) -> None:
+        """close() is safe to call multiple times without error."""
+        db_path = str(tmp_path / "close_twice.db")
+        repo = SqliteVecRepository(
+            db_path=db_path, expected_model=_MODEL, expected_dimensions=_DIMS
+        )
+        await repo.init()
+        await repo.close()
+        await repo.close()  # Should not raise
+
+    async def test_writer_and_reader_independent(
+        self, vec_repo: SqliteVecRepository
+    ) -> None:
+        """Writer and reader are independent connections."""
+        # Insert via writer (without committing to test independence)
+        embedding = _make_embedding(1.0)
+        await vec_repo._writer.execute(
+            "DELETE FROM item_vectors WHERE jellyfin_id = ?", ("indep-test",)
+        )
+        await vec_repo._writer.execute(
+            "INSERT INTO item_vectors "
+            "(jellyfin_id, embedding, content_hash, embedded_at, embedding_status) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                "indep-test",
+                _serialize_f32(embedding),
+                "hash",
+                int(time.time()),
+                "complete",
+            ),
+        )
+        # Reader should still be functional even while writer has uncommitted data
+        cursor = await vec_repo._reader.execute(
+            "SELECT COUNT(*) FROM item_vectors WHERE jellyfin_id = 'indep-test'"
+        )
+        row = await cursor.fetchone()
+        # WAL mode: reader sees committed state, not uncommitted writer data
+        assert row is not None
+        # Commit to clean up
+        await vec_repo._writer.commit()
+
+
+class TestCRUD:
+    """CRUD operations: upsert, get, get_many, delete, delete_many."""
+
+    async def test_upsert_and_get(self, vec_repo: SqliteVecRepository) -> None:
+        """upsert() inserts a new vector; get() retrieves it."""
+        embedding = _make_embedding(0.5)
+        await vec_repo.upsert("movie-1", embedding, "hash-abc")
+
+        record = await vec_repo.get("movie-1")
+        assert record is not None
+        assert record.jellyfin_id == "movie-1"
+        assert record.content_hash == "hash-abc"
+        assert record.embedding_status == "complete"
+        assert record.embedded_at > 0
+
+    async def test_upsert_replaces_existing(
+        self, vec_repo: SqliteVecRepository
+    ) -> None:
+        """upsert() on existing ID replaces the record."""
+        embedding = _make_embedding(0.5)
+        await vec_repo.upsert("movie-1", embedding, "hash-v1")
+
+        embedding2 = _make_embedding(0.6)
+        await vec_repo.upsert("movie-1", embedding2, "hash-v2")
+
+        record = await vec_repo.get("movie-1")
+        assert record is not None
+        assert record.content_hash == "hash-v2"
+
+    async def test_get_returns_none_for_missing(
+        self, vec_repo: SqliteVecRepository
+    ) -> None:
+        """get() returns None for a nonexistent ID."""
+        assert await vec_repo.get("nonexistent") is None
+
+    async def test_get_many(self, vec_repo: SqliteVecRepository) -> None:
+        """get_many() returns found records and omits missing IDs."""
+        for i in range(3):
+            await vec_repo.upsert(f"item-{i}", _make_embedding(float(i)), f"hash-{i}")
+
+        results = await vec_repo.get_many(
+            ["item-0", "item-1", "item-2", "missing-item"]
+        )
+        found_ids = {r.jellyfin_id for r in results}
+        assert found_ids == {"item-0", "item-1", "item-2"}
+        assert len(results) == 3
+
+    async def test_delete(self, vec_repo: SqliteVecRepository) -> None:
+        """delete() removes a record."""
+        await vec_repo.upsert("to-delete", _make_embedding(1.0), "hash")
+        assert await vec_repo.get("to-delete") is not None
+
+        await vec_repo.delete("to-delete")
+        assert await vec_repo.get("to-delete") is None
+
+    async def test_delete_many(self, vec_repo: SqliteVecRepository) -> None:
+        """delete_many() removes multiple records."""
+        for i in range(5):
+            await vec_repo.upsert(f"bulk-{i}", _make_embedding(float(i)), f"hash-{i}")
+        assert await vec_repo.count() == 5
+
+        await vec_repo.delete_many(["bulk-0", "bulk-1", "bulk-2"])
+        assert await vec_repo.count() == 2
+
+
+class TestSearch:
+    """Cosine similarity search."""
+
+    async def test_search_returns_ordered_by_distance(
+        self, vec_repo: SqliteVecRepository
+    ) -> None:
+        """search() returns results ordered by cosine distance (ascending)."""
+        # Insert vectors at known positions
+        # Query will be close to vec_a, far from vec_c
+        vec_a = [1.0, 0.0, 0.0, 0.0]
+        vec_b = [0.7, 0.7, 0.0, 0.0]
+        vec_c = [0.0, 0.0, 0.0, 1.0]
+
+        await vec_repo.upsert("close", vec_a, "h1")
+        await vec_repo.upsert("medium", vec_b, "h2")
+        await vec_repo.upsert("far", vec_c, "h3")
+
+        query = [1.0, 0.0, 0.0, 0.0]
+        results = await vec_repo.search(query, limit=3)
+
+        assert len(results) == 3
+        assert results[0].jellyfin_id == "close"
+        assert results[-1].jellyfin_id == "far"
+        # Distances should be ascending
+        assert results[0].distance <= results[1].distance <= results[2].distance
+
+    async def test_search_respects_limit(self, vec_repo: SqliteVecRepository) -> None:
+        """search() returns at most `limit` results."""
+        for i in range(5):
+            await vec_repo.upsert(
+                f"item-{i}", _make_embedding(float(i) * 0.1), f"hash-{i}"
+            )
+
+        results = await vec_repo.search(_make_embedding(0.5), limit=2)
+        assert len(results) == 2
+
+    async def test_search_empty_table(self, vec_repo: SqliteVecRepository) -> None:
+        """search() returns empty list when no vectors are stored."""
+        results = await vec_repo.search(_make_embedding(0.5), limit=10)
+        assert results == []
+
+
+class TestCountAndStatus:
+    """count() and embedding status operations."""
+
+    async def test_count_empty_and_after_inserts(
+        self, vec_repo: SqliteVecRepository
+    ) -> None:
+        """count() returns 0 on empty table, correct count after inserts."""
+        assert await vec_repo.count() == 0
+
+        for i in range(3):
+            await vec_repo.upsert(f"item-{i}", _make_embedding(float(i)), f"hash-{i}")
+        assert await vec_repo.count() == 3
+
+    async def test_set_and_get_embedding_status(
+        self, vec_repo: SqliteVecRepository
+    ) -> None:
+        """set_embedding_status() updates; get_embedding_status() reads back."""
+        await vec_repo.upsert("status-test", _make_embedding(0.5), "hash")
+        assert await vec_repo.get_embedding_status("status-test") == "complete"
+
+        await vec_repo.set_embedding_status("status-test", PENDING)
+        assert await vec_repo.get_embedding_status("status-test") == PENDING
+
+        await vec_repo.set_embedding_status("status-test", PROCESSING)
+        assert await vec_repo.get_embedding_status("status-test") == PROCESSING
+
+        await vec_repo.set_embedding_status("status-test", FAILED)
+        assert await vec_repo.get_embedding_status("status-test") == FAILED
+
+    async def test_set_embedding_status_invalid_raises(
+        self, vec_repo: SqliteVecRepository
+    ) -> None:
+        """set_embedding_status() raises ValueError for invalid status."""
+        await vec_repo.upsert("bad-status", _make_embedding(0.5), "hash")
+
+        with pytest.raises(ValueError, match="Invalid embedding status"):
+            await vec_repo.set_embedding_status("bad-status", "banana")
+
+    async def test_get_embedding_status_nonexistent(
+        self, vec_repo: SqliteVecRepository
+    ) -> None:
+        """get_embedding_status() returns None for nonexistent ID."""
+        assert await vec_repo.get_embedding_status("nonexistent") is None

--- a/backend/tests/test_vec_repository.py
+++ b/backend/tests/test_vec_repository.py
@@ -358,6 +358,13 @@ class TestCountAndStatus:
         with pytest.raises(ValueError, match="Invalid embedding status"):
             await vec_repo.set_embedding_status("bad-status", "banana")
 
+    async def test_set_embedding_status_nonexistent_raises_key_error(
+        self, vec_repo: SqliteVecRepository
+    ) -> None:
+        """set_embedding_status() raises KeyError for nonexistent ID."""
+        with pytest.raises(KeyError, match="No vector record for jellyfin_id="):
+            await vec_repo.set_embedding_status("nonexistent", PENDING)
+
     async def test_get_embedding_status_nonexistent(
         self, vec_repo: SqliteVecRepository
     ) -> None:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -14,6 +14,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "slowapi" },
+    { name = "sqlite-vec" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -40,6 +41,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
+    { name = "sqlite-vec", specifier = ">=0.1.6" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
 provides-extras = ["dev"]
@@ -725,6 +727,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/50/7ad59cfd3003a2110cc366e526293de4c2520486f5ddaa8dc78b265f8d3e/sqlite_vec-0.1.7-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:c34a136caecff4ae17d4c0cc268fcda89764ee870039caa21431e8e3fb2f4d48", size = 131171, upload-time = "2026-03-17T07:42:50.438Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/c9/1cd2f59b539096cd2ce6b540247b2dfe3c47ba04d9368b5e8e3dc86498d4/sqlite_vec-0.1.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6d272593d1b45ec7ea289b160ee6e5fafbaa6e1f5ba15f1305c012b0bda43653", size = 165434, upload-time = "2026-03-17T07:42:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/75/91/30c3c382140dcc7bc6e3a07eac7ca610a2b5b70eb9bc7066dc3e7f748d58/sqlite_vec-0.1.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d27746d8e254a390bd15574aed899a0b9bb915b5321eb130a9c09722898cc03", size = 160076, upload-time = "2026-03-17T07:42:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/59/56/6ff304d917ee79da769708dad0aed5fd34c72cbd0ae5e38bcc56cdc652a4/sqlite_vec-0.1.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:ad654283cb9c059852ce2d82018c757b06a705ada568f8b126022a131189818e", size = 163388, upload-time = "2026-03-17T07:42:53.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/27/fb1b6e3f9072854fe405f7aa99c46d4b465e84c9cec2ff7778edf29ecbbd/sqlite_vec-0.1.7-py3-none-win_amd64.whl", hash = "sha256:0c67877a87cb49426237b950237e82dbeb77778ab2ba89bea859f391fd169382", size = 292804, upload-time = "2026-03-17T07:42:54.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Epic 2 / Wave 1 — Implements Spec 06: SQLite-vec Setup + Vector Repository Abstraction.

- Adds `sqlite-vec>=0.1.6` dependency with extension loading and fail-fast on missing extension
- Creates `VectorRepositoryProtocol` (structural subtyping) for future Qdrant swap
- Implements `SqliteVecRepository` with read/write connection split, vec0 virtual table, and cosine similarity search
- Adds `_vec_meta` table for embedding model name + dimension validation at startup (refuses to start on mismatch)
- Wires repository into FastAPI lifespan and updates `/health` endpoint with real embedding counts
- Registers `@pytest.mark.requires_sqlite_vec` test marker

## Test plan

- [ ] `cd backend && python -m pytest tests/ -x -q` — 173 tests pass (29 new)
- [ ] `cd backend && python -m ruff check app/ tests/` — clean
- [ ] Verify `/health` endpoint returns real `embeddings.total` count
- [ ] Verify startup fails with clear error on dimension mismatch

**SDD Artifacts:** `docs/specs/06-spec-sqlite-vec-repository/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #94