### PR TITLE
feat(jellyfin): watch history client (Spec 17)

### DIFF
--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -277,14 +277,19 @@ class JellyfinClient:
             is_favorite=user_data.get("IsFavorite", False),
         )
 
-    async def get_watched_items(
+    async def _paginate_watch_entries(
         self,
         token: str,
         user_id: str,
+        params: dict[str, str | int | bool],
+        log_prefix: str,
     ) -> list[WatchHistoryEntry]:
-        """Fetch all played items for a user, auto-paginating.
+        """Auto-paginate a watch-history style query, returning all entries.
 
-        Uses the user's own token for per-user permission enforcement.
+        Shared pagination logic for get_watched_items and get_favorite_items.
+        The caller supplies the filter-specific *params*; this method adds
+        StartIndex/Limit and drives the pagination loop.
+
         Token is passed through to _request, never stored.
         """
         page_size = 200
@@ -292,31 +297,21 @@ class JellyfinClient:
         page_number = 0
         all_entries: list[WatchHistoryEntry] = []
 
+        def _extract(data: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
+            return data["Items"], data["TotalRecordCount"]
+
         while True:
-            params: dict[str, str | int | bool] = {
-                "IsPlayed": True,
-                "IncludeItemTypes": "Movie",
-                "SortBy": "DatePlayed",
-                "SortOrder": "Descending",
-                "Recursive": True,
-                "StartIndex": start_index,
-                "Limit": page_size,
-            }
+            page_params = {**params, "StartIndex": start_index, "Limit": page_size}
             resp = await self._request(
                 "GET",
                 f"/Users/{user_id}/Items",
                 token=token,
-                params=params,
+                params=page_params,
             )
-
-            def _extract(data: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
-                return data["Items"], data["TotalRecordCount"]
 
             items, total_count = self._parse_response(resp, _extract)
             page_number += 1
-            logger.debug(
-                "watched_items_fetch page=%d items=%d", page_number, len(items)
-            )
+            logger.debug("%s page=%d items=%d", log_prefix, page_number, len(items))
 
             for item in items:
                 all_entries.append(self._parse_watch_entry(item))
@@ -329,6 +324,27 @@ class JellyfinClient:
                 break
 
         return all_entries
+
+    async def get_watched_items(
+        self,
+        token: str,
+        user_id: str,
+    ) -> list[WatchHistoryEntry]:
+        """Fetch all played items for a user, auto-paginating.
+
+        Uses the user's own token for per-user permission enforcement.
+        Token is passed through to _request, never stored.
+        """
+        params: dict[str, str | int | bool] = {
+            "IsPlayed": True,
+            "IncludeItemTypes": "Movie",
+            "SortBy": "DatePlayed",
+            "SortOrder": "Descending",
+            "Recursive": True,
+        }
+        return await self._paginate_watch_entries(
+            token, user_id, params, "watched_items_fetch"
+        )
 
     async def get_favorite_items(
         self,
@@ -340,43 +356,11 @@ class JellyfinClient:
         Uses the user's own token for per-user permission enforcement.
         Token is passed through to _request, never stored.
         """
-        page_size = 200
-        start_index = 0
-        page_number = 0
-        all_entries: list[WatchHistoryEntry] = []
-
-        while True:
-            params: dict[str, str | int | bool] = {
-                "IsFavorite": True,
-                "IncludeItemTypes": "Movie",
-                "Recursive": True,
-                "StartIndex": start_index,
-                "Limit": page_size,
-            }
-            resp = await self._request(
-                "GET",
-                f"/Users/{user_id}/Items",
-                token=token,
-                params=params,
-            )
-
-            def _extract(data: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
-                return data["Items"], data["TotalRecordCount"]
-
-            items, total_count = self._parse_response(resp, _extract)
-            page_number += 1
-            logger.debug(
-                "favorite_items_fetch page=%d items=%d", page_number, len(items)
-            )
-
-            for item in items:
-                all_entries.append(self._parse_watch_entry(item))
-
-            if not items:
-                break
-
-            start_index += len(items)
-            if start_index >= total_count:
-                break
-
-        return all_entries
+        params: dict[str, str | int | bool] = {
+            "IsFavorite": True,
+            "IncludeItemTypes": "Movie",
+            "Recursive": True,
+        }
+        return await self._paginate_watch_entries(
+            token, user_id, params, "favorite_items_fetch"
+        )

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -8,6 +8,7 @@ format (Authorization header, not X-Emby-Authorization; no quotes on Token).
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import httpx
@@ -20,7 +21,7 @@ from app.jellyfin.errors import (
     JellyfinConnectionError,
     JellyfinError,
 )
-from app.jellyfin.models import AuthResult, PaginatedItems, UserInfo
+from app.jellyfin.models import AuthResult, PaginatedItems, UserInfo, WatchHistoryEntry
 
 logger = logging.getLogger(__name__)
 
@@ -257,3 +258,125 @@ class JellyfinClient:
             start_index += len(page.items)
             if start_index >= page.total_count:
                 break
+
+    @staticmethod
+    def _parse_watch_entry(item: dict[str, Any]) -> WatchHistoryEntry:
+        """Parse a single Jellyfin item dict into a WatchHistoryEntry.
+
+        Handles missing/null UserData gracefully with safe defaults.
+        """
+        user_data = item.get("UserData") or {}
+        last_played_raw = user_data.get("LastPlayedDate")
+        last_played_date: datetime | None = None
+        if last_played_raw:
+            last_played_date = datetime.fromisoformat(last_played_raw)
+        return WatchHistoryEntry(
+            jellyfin_id=item["Id"],
+            last_played_date=last_played_date,
+            play_count=user_data.get("PlayCount", 0),
+            is_favorite=user_data.get("IsFavorite", False),
+        )
+
+    async def get_watched_items(
+        self,
+        token: str,
+        user_id: str,
+    ) -> list[WatchHistoryEntry]:
+        """Fetch all played items for a user, auto-paginating.
+
+        Uses the user's own token for per-user permission enforcement.
+        Token is passed through to _request, never stored.
+        """
+        page_size = 200
+        start_index = 0
+        page_number = 0
+        all_entries: list[WatchHistoryEntry] = []
+
+        while True:
+            params: dict[str, str | int | bool] = {
+                "IsPlayed": True,
+                "IncludeItemTypes": "Movie",
+                "SortBy": "DatePlayed",
+                "SortOrder": "Descending",
+                "Recursive": True,
+                "StartIndex": start_index,
+                "Limit": page_size,
+            }
+            resp = await self._request(
+                "GET",
+                f"/Users/{user_id}/Items",
+                token=token,
+                params=params,
+            )
+
+            def _extract(data: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
+                return data["Items"], data["TotalRecordCount"]
+
+            items, total_count = self._parse_response(resp, _extract)
+            page_number += 1
+            logger.debug(
+                "watched_items_fetch page=%d items=%d", page_number, len(items)
+            )
+
+            for item in items:
+                all_entries.append(self._parse_watch_entry(item))
+
+            if not items:
+                break
+
+            start_index += len(items)
+            if start_index >= total_count:
+                break
+
+        return all_entries
+
+    async def get_favorite_items(
+        self,
+        token: str,
+        user_id: str,
+    ) -> list[WatchHistoryEntry]:
+        """Fetch all favorited items for a user, auto-paginating.
+
+        Uses the user's own token for per-user permission enforcement.
+        Token is passed through to _request, never stored.
+        """
+        page_size = 200
+        start_index = 0
+        page_number = 0
+        all_entries: list[WatchHistoryEntry] = []
+
+        while True:
+            params: dict[str, str | int | bool] = {
+                "IsFavorite": True,
+                "IncludeItemTypes": "Movie",
+                "Recursive": True,
+                "StartIndex": start_index,
+                "Limit": page_size,
+            }
+            resp = await self._request(
+                "GET",
+                f"/Users/{user_id}/Items",
+                token=token,
+                params=params,
+            )
+
+            def _extract(data: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
+                return data["Items"], data["TotalRecordCount"]
+
+            items, total_count = self._parse_response(resp, _extract)
+            page_number += 1
+            logger.debug(
+                "favorite_items_fetch page=%d items=%d", page_number, len(items)
+            )
+
+            for item in items:
+                all_entries.append(self._parse_watch_entry(item))
+
+            if not items:
+                break
+
+            start_index += len(items)
+            if start_index >= total_count:
+                break
+
+        return all_entries

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -314,7 +314,12 @@ class JellyfinClient:
             logger.debug("%s page=%d items=%d", log_prefix, page_number, len(items))
 
             for item in items:
-                all_entries.append(self._parse_watch_entry(item))
+                try:
+                    all_entries.append(self._parse_watch_entry(item))
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise JellyfinError(
+                        "Unexpected Jellyfin response while parsing watch entry"
+                    ) from exc
 
             if not items:
                 break

--- a/backend/app/jellyfin/models.py
+++ b/backend/app/jellyfin/models.py
@@ -1,6 +1,7 @@
-"""Pydantic models for Jellyfin API responses.
+"""Pydantic models and dataclass DTOs for Jellyfin API responses.
 
 Uses Field aliases to map Jellyfin's PascalCase JSON to snake_case Python.
+Includes plain dataclass DTOs for lightweight internal transfer objects.
 """
 
 from __future__ import annotations

--- a/backend/app/jellyfin/models.py
+++ b/backend/app/jellyfin/models.py
@@ -5,9 +5,29 @@ Uses Field aliases to map Jellyfin's PascalCase JSON to snake_case Python.
 
 from __future__ import annotations
 
-from typing import Any, Self
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+@dataclass(frozen=True, slots=True)
+class WatchHistoryEntry:
+    """User-scoped activity data for a single watched/favorited item.
+
+    Slim DTO for the history-aware ranking service — contains only the
+    activity fields needed for scoring.  Does NOT extend LibraryItem:
+    catalog metadata lives in library_items from sync; this is a
+    different domain with a different lifecycle.
+    """
+
+    jellyfin_id: str
+    last_played_date: datetime | None
+    play_count: int
+    is_favorite: bool
 
 
 class AuthResult(BaseModel):

--- a/backend/tests/integration/test_jellyfin_client.py
+++ b/backend/tests/integration/test_jellyfin_client.py
@@ -14,7 +14,7 @@ import pytest_asyncio
 
 from app.jellyfin.client import JellyfinClient
 from app.jellyfin.errors import JellyfinAuthError
-from app.jellyfin.models import AuthResult, PaginatedItems, UserInfo
+from app.jellyfin.models import AuthResult, PaginatedItems, UserInfo, WatchHistoryEntry
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -114,3 +114,29 @@ async def test_get_items_pagination_params(
     )
     assert isinstance(result, PaginatedItems)
     assert result.start_index == 0
+
+
+@pytest.mark.integration
+async def test_get_watched_items_returns_list(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+) -> None:
+    """get_watched_items returns list[WatchHistoryEntry] (empty for test instance)."""
+    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    result = await jf_client.get_watched_items(auth.access_token, auth.user_id)
+    assert isinstance(result, list)
+    for entry in result:
+        assert isinstance(entry, WatchHistoryEntry)
+
+
+@pytest.mark.integration
+async def test_get_favorite_items_returns_list(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+) -> None:
+    """get_favorite_items returns list[WatchHistoryEntry] (empty for test instance)."""
+    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    result = await jf_client.get_favorite_items(auth.access_token, auth.user_id)
+    assert isinstance(result, list)
+    for entry in result:
+        assert isinstance(entry, WatchHistoryEntry)

--- a/backend/tests/test_watch_history.py
+++ b/backend/tests/test_watch_history.py
@@ -1,0 +1,486 @@
+# backend/tests/test_watch_history.py
+"""Unit tests for WatchHistoryEntry model and get_watched_items / get_favorite_items."""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from app.jellyfin.client import JellyfinClient
+from app.jellyfin.errors import (
+    JellyfinAuthError,
+    JellyfinConnectionError,
+    JellyfinError,
+)
+from app.jellyfin.models import WatchHistoryEntry
+
+
+@pytest.fixture
+def mock_http() -> AsyncMock:
+    """Mock httpx.AsyncClient for unit tests."""
+    return AsyncMock(spec=httpx.AsyncClient)
+
+
+@pytest.fixture
+def jf_client(mock_http: AsyncMock) -> JellyfinClient:
+    return JellyfinClient(
+        base_url="http://jellyfin:8096",
+        http_client=mock_http,
+    )
+
+
+_FAKE_REQUEST = httpx.Request("GET", "http://fake")
+
+
+# ---------------------------------------------------------------------------
+# WatchHistoryEntry model tests
+# ---------------------------------------------------------------------------
+
+
+class TestWatchHistoryEntry:
+    def test_watch_history_entry_is_frozen(self) -> None:
+        """WatchHistoryEntry is immutable (frozen=True)."""
+        entry = WatchHistoryEntry(
+            jellyfin_id="item-1",
+            last_played_date=None,
+            play_count=1,
+            is_favorite=False,
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            entry.jellyfin_id = "item-2"  # type: ignore[misc]
+
+    def test_watch_history_entry_fields_and_types(self) -> None:
+        """All fields have correct types; last_played_date accepts datetime and None."""
+        played_date = datetime(2025, 12, 15, 20, 30, 0, tzinfo=UTC)
+        entry = WatchHistoryEntry(
+            jellyfin_id="item-1",
+            last_played_date=played_date,
+            play_count=3,
+            is_favorite=True,
+        )
+        assert entry.jellyfin_id == "item-1"
+        assert isinstance(entry.jellyfin_id, str)
+        assert entry.last_played_date == played_date
+        assert isinstance(entry.last_played_date, datetime)
+        assert entry.play_count == 3
+        assert isinstance(entry.play_count, int)
+        assert entry.is_favorite is True
+        assert isinstance(entry.is_favorite, bool)
+
+        # last_played_date=None is valid
+        entry_none = WatchHistoryEntry(
+            jellyfin_id="item-2",
+            last_played_date=None,
+            play_count=0,
+            is_favorite=False,
+        )
+        assert entry_none.last_played_date is None
+
+
+# ---------------------------------------------------------------------------
+# get_watched_items tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetWatchedItems:
+    async def test_get_watched_items_sends_correct_request(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Correct URL, params, token header, no Fields param."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0},
+            request=_FAKE_REQUEST,
+        )
+        await jf_client.get_watched_items("tok-123", "uid-1")
+
+        mock_http.request.assert_called_once()
+        call_args = mock_http.request.call_args
+        assert call_args.args[0] == "GET"
+        assert "/Users/uid-1/Items" in call_args.args[1]
+        params = call_args.kwargs["params"]
+        assert params["IsPlayed"] is True
+        assert params["IncludeItemTypes"] == "Movie"
+        assert params["SortBy"] == "DatePlayed"
+        assert params["SortOrder"] == "Descending"
+        assert params["Recursive"] is True
+        assert "Fields" not in params
+        assert "Token=tok-123" in call_args.kwargs["headers"]["Authorization"]
+
+    async def test_get_watched_items_parses_response(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Realistic UserData parsed into correct WatchHistoryEntry fields."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={
+                "Items": [
+                    {
+                        "Id": "item-1",
+                        "Name": "Alien",
+                        "Type": "Movie",
+                        "UserData": {
+                            "PlayCount": 3,
+                            "IsFavorite": True,
+                            "Played": True,
+                            "LastPlayedDate": "2025-12-15T20:30:00.0000000Z",
+                        },
+                    },
+                    {
+                        "Id": "item-2",
+                        "Name": "Aliens",
+                        "Type": "Movie",
+                        "UserData": {
+                            "PlayCount": 1,
+                            "IsFavorite": False,
+                            "Played": True,
+                            "LastPlayedDate": "2025-11-01T10:00:00.0000000Z",
+                        },
+                    },
+                ],
+                "TotalRecordCount": 2,
+            },
+            request=_FAKE_REQUEST,
+        )
+        entries = await jf_client.get_watched_items("tok-123", "uid-1")
+        assert len(entries) == 2
+
+        assert entries[0].jellyfin_id == "item-1"
+        assert isinstance(entries[0].last_played_date, datetime)
+        assert entries[0].play_count == 3
+        assert entries[0].is_favorite is True
+
+        assert entries[1].jellyfin_id == "item-2"
+        assert isinstance(entries[1].last_played_date, datetime)
+        assert entries[1].play_count == 1
+        assert entries[1].is_favorite is False
+
+    async def test_get_watched_items_paginates_two_pages(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Auto-pagination: 200 + 50 items across two pages."""
+        page1_items = [
+            {
+                "Id": f"item-{i}",
+                "Name": f"Movie {i}",
+                "Type": "Movie",
+                "UserData": {"PlayCount": 1, "IsFavorite": False, "Played": True},
+            }
+            for i in range(200)
+        ]
+        page2_items = [
+            {
+                "Id": f"item-{i}",
+                "Name": f"Movie {i}",
+                "Type": "Movie",
+                "UserData": {"PlayCount": 1, "IsFavorite": False, "Played": True},
+            }
+            for i in range(200, 250)
+        ]
+
+        mock_http.request.side_effect = [
+            httpx.Response(
+                200,
+                json={"Items": page1_items, "TotalRecordCount": 250},
+                request=_FAKE_REQUEST,
+            ),
+            httpx.Response(
+                200,
+                json={"Items": page2_items, "TotalRecordCount": 250},
+                request=_FAKE_REQUEST,
+            ),
+        ]
+
+        entries = await jf_client.get_watched_items("tok-123", "uid-1")
+        assert len(entries) == 250
+        assert mock_http.request.call_count == 2
+
+        # Verify second call has correct StartIndex
+        second_call_params = mock_http.request.call_args_list[1].kwargs["params"]
+        assert second_call_params["StartIndex"] == 200
+
+    async def test_get_watched_items_empty_history(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Empty watch history returns []."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0},
+            request=_FAKE_REQUEST,
+        )
+        entries = await jf_client.get_watched_items("tok-123", "uid-1")
+        assert entries == []
+
+    async def test_get_watched_items_missing_user_data(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Item with no UserData key yields safe defaults."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={
+                "Items": [{"Id": "item-1", "Name": "NoData", "Type": "Movie"}],
+                "TotalRecordCount": 1,
+            },
+            request=_FAKE_REQUEST,
+        )
+        entries = await jf_client.get_watched_items("tok-123", "uid-1")
+        assert len(entries) == 1
+        assert entries[0].last_played_date is None
+        assert entries[0].play_count == 0
+        assert entries[0].is_favorite is False
+
+    async def test_get_watched_items_empty_user_data(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Item with UserData={} yields safe defaults."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={
+                "Items": [
+                    {
+                        "Id": "item-1",
+                        "Name": "EmptyUD",
+                        "Type": "Movie",
+                        "UserData": {},
+                    }
+                ],
+                "TotalRecordCount": 1,
+            },
+            request=_FAKE_REQUEST,
+        )
+        entries = await jf_client.get_watched_items("tok-123", "uid-1")
+        assert len(entries) == 1
+        assert entries[0].last_played_date is None
+        assert entries[0].play_count == 0
+        assert entries[0].is_favorite is False
+
+    async def test_get_watched_items_null_last_played_date(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """UserData present but LastPlayedDate is null -> None."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={
+                "Items": [
+                    {
+                        "Id": "item-1",
+                        "Name": "NullDate",
+                        "Type": "Movie",
+                        "UserData": {
+                            "PlayCount": 2,
+                            "IsFavorite": True,
+                            "LastPlayedDate": None,
+                        },
+                    }
+                ],
+                "TotalRecordCount": 1,
+            },
+            request=_FAKE_REQUEST,
+        )
+        entries = await jf_client.get_watched_items("tok-123", "uid-1")
+        assert entries[0].last_played_date is None
+
+    async def test_get_watched_items_auth_error(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """401 response raises JellyfinAuthError."""
+        mock_http.request.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinAuthError):
+            await jf_client.get_watched_items("bad-tok", "uid-1")
+
+    async def test_get_watched_items_connection_error(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Transport error raises JellyfinConnectionError."""
+        mock_http.request.side_effect = httpx.ConnectError("Connection refused")
+        with pytest.raises(JellyfinConnectionError):
+            await jf_client.get_watched_items("tok-123", "uid-1")
+
+    async def test_get_watched_items_unexpected_status(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """500 response raises JellyfinError."""
+        mock_http.request.return_value = httpx.Response(500, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinError):
+            await jf_client.get_watched_items("tok-123", "uid-1")
+
+
+# ---------------------------------------------------------------------------
+# get_favorite_items tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetFavoriteItems:
+    async def test_get_favorite_items_sends_correct_request(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Correct URL, params, no SortBy/SortOrder/Fields."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0},
+            request=_FAKE_REQUEST,
+        )
+        await jf_client.get_favorite_items("tok-123", "uid-1")
+
+        mock_http.request.assert_called_once()
+        call_args = mock_http.request.call_args
+        assert call_args.args[0] == "GET"
+        assert "/Users/uid-1/Items" in call_args.args[1]
+        params = call_args.kwargs["params"]
+        assert params["IsFavorite"] is True
+        assert params["IncludeItemTypes"] == "Movie"
+        assert params["Recursive"] is True
+        assert "SortBy" not in params
+        assert "SortOrder" not in params
+        assert "Fields" not in params
+        assert "Token=tok-123" in call_args.kwargs["headers"]["Authorization"]
+
+    async def test_get_favorite_items_parses_response(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Parses favorites into WatchHistoryEntry with correct fields."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={
+                "Items": [
+                    {
+                        "Id": "item-1",
+                        "Name": "Alien",
+                        "Type": "Movie",
+                        "UserData": {
+                            "PlayCount": 5,
+                            "IsFavorite": True,
+                            "Played": True,
+                            "LastPlayedDate": "2025-12-15T20:30:00.0000000Z",
+                        },
+                    },
+                    {
+                        "Id": "item-2",
+                        "Name": "Aliens",
+                        "Type": "Movie",
+                        "UserData": {
+                            "PlayCount": 2,
+                            "IsFavorite": True,
+                            "Played": True,
+                            "LastPlayedDate": "2025-10-01T08:00:00.0000000Z",
+                        },
+                    },
+                ],
+                "TotalRecordCount": 2,
+            },
+            request=_FAKE_REQUEST,
+        )
+        entries = await jf_client.get_favorite_items("tok-123", "uid-1")
+        assert len(entries) == 2
+        assert entries[0].jellyfin_id == "item-1"
+        assert entries[0].is_favorite is True
+        assert entries[1].jellyfin_id == "item-2"
+
+    async def test_get_favorite_items_paginates_two_pages(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Auto-pagination across two pages."""
+        page1_items = [
+            {
+                "Id": f"item-{i}",
+                "Name": f"Movie {i}",
+                "Type": "Movie",
+                "UserData": {"IsFavorite": True},
+            }
+            for i in range(200)
+        ]
+        page2_items = [
+            {
+                "Id": f"item-{i}",
+                "Name": f"Movie {i}",
+                "Type": "Movie",
+                "UserData": {"IsFavorite": True},
+            }
+            for i in range(200, 250)
+        ]
+
+        mock_http.request.side_effect = [
+            httpx.Response(
+                200,
+                json={"Items": page1_items, "TotalRecordCount": 250},
+                request=_FAKE_REQUEST,
+            ),
+            httpx.Response(
+                200,
+                json={"Items": page2_items, "TotalRecordCount": 250},
+                request=_FAKE_REQUEST,
+            ),
+        ]
+
+        entries = await jf_client.get_favorite_items("tok-123", "uid-1")
+        assert len(entries) == 250
+        assert mock_http.request.call_count == 2
+
+    async def test_get_favorite_items_empty_favorites(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """No favorites returns []."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0},
+            request=_FAKE_REQUEST,
+        )
+        entries = await jf_client.get_favorite_items("tok-123", "uid-1")
+        assert entries == []
+
+    async def test_get_favorite_items_unplayed_favorite(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Favorite that was never played: last_played_date=None, play_count=0."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={
+                "Items": [
+                    {
+                        "Id": "item-1",
+                        "Name": "Unplayed Fave",
+                        "Type": "Movie",
+                        "UserData": {
+                            "IsFavorite": True,
+                            "Played": False,
+                            "PlayCount": 0,
+                        },
+                    }
+                ],
+                "TotalRecordCount": 1,
+            },
+            request=_FAKE_REQUEST,
+        )
+        entries = await jf_client.get_favorite_items("tok-123", "uid-1")
+        assert len(entries) == 1
+        assert entries[0].is_favorite is True
+        assert entries[0].last_played_date is None
+        assert entries[0].play_count == 0
+
+    async def test_get_favorite_items_auth_error(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """401 response raises JellyfinAuthError."""
+        mock_http.request.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinAuthError):
+            await jf_client.get_favorite_items("bad-tok", "uid-1")
+
+    async def test_get_favorite_items_connection_error(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Transport error raises JellyfinConnectionError."""
+        mock_http.request.side_effect = httpx.ConnectError("Connection refused")
+        with pytest.raises(JellyfinConnectionError):
+            await jf_client.get_favorite_items("tok-123", "uid-1")
+
+    async def test_get_favorite_items_unexpected_status(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """500 response raises JellyfinError."""
+        mock_http.request.return_value = httpx.Response(500, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinError):
+            await jf_client.get_favorite_items("tok-123", "uid-1")

--- a/docs/specs/17-spec-watch-history-client/17-proofs/unit-tests.md
+++ b/docs/specs/17-spec-watch-history-client/17-proofs/unit-tests.md
@@ -1,0 +1,62 @@
+# Spec 17 — Unit Test Proof Artifact
+
+## Test Run: `uv run pytest tests/test_watch_history.py -v`
+
+**Date:** 2026-04-06
+**Result:** 20 passed in 0.03s
+
+### Test Results
+
+```
+tests/test_watch_history.py::TestWatchHistoryEntry::test_watch_history_entry_is_frozen PASSED
+tests/test_watch_history.py::TestWatchHistoryEntry::test_watch_history_entry_fields_and_types PASSED
+tests/test_watch_history.py::TestGetWatchedItems::test_get_watched_items_sends_correct_request PASSED
+tests/test_watch_history.py::TestGetWatchedItems::test_get_watched_items_parses_response PASSED
+tests/test_watch_history.py::TestGetWatchedItems::test_get_watched_items_paginates_two_pages PASSED
+tests/test_watch_history.py::TestGetWatchedItems::test_get_watched_items_empty_history PASSED
+tests/test_watch_history.py::TestGetWatchedItems::test_get_watched_items_missing_user_data PASSED
+tests/test_watch_history.py::TestGetWatchedItems::test_get_watched_items_empty_user_data PASSED
+tests/test_watch_history.py::TestGetWatchedItems::test_get_watched_items_null_last_played_date PASSED
+tests/test_watch_history.py::TestGetWatchedItems::test_get_watched_items_auth_error PASSED
+tests/test_watch_history.py::TestGetWatchedItems::test_get_watched_items_connection_error PASSED
+tests/test_watch_history.py::TestGetWatchedItems::test_get_watched_items_unexpected_status PASSED
+tests/test_watch_history.py::TestGetFavoriteItems::test_get_favorite_items_sends_correct_request PASSED
+tests/test_watch_history.py::TestGetFavoriteItems::test_get_favorite_items_parses_response PASSED
+tests/test_watch_history.py::TestGetFavoriteItems::test_get_favorite_items_paginates_two_pages PASSED
+tests/test_watch_history.py::TestGetFavoriteItems::test_get_favorite_items_empty_favorites PASSED
+tests/test_watch_history.py::TestGetFavoriteItems::test_get_favorite_items_unplayed_favorite PASSED
+tests/test_watch_history.py::TestGetFavoriteItems::test_get_favorite_items_auth_error PASSED
+tests/test_watch_history.py::TestGetFavoriteItems::test_get_favorite_items_connection_error PASSED
+tests/test_watch_history.py::TestGetFavoriteItems::test_get_favorite_items_unexpected_status PASSED
+```
+
+### Lint Check: `uv run ruff check app/ tests/`
+
+**Result:** All checks passed!
+
+### Coverage Map
+
+| Spec Requirement | Test(s) | Status |
+|---|---|---|
+| FR-1.1: WatchHistoryEntry frozen dataclass | test_watch_history_entry_is_frozen, test_watch_history_entry_fields_and_types | PASS |
+| FR-1.2: get_watched_items signature | test_get_watched_items_sends_correct_request | PASS |
+| FR-1.3: Correct query params (IsPlayed, SortBy, etc.) | test_get_watched_items_sends_correct_request | PASS |
+| FR-1.4: Auto-pagination | test_get_watched_items_paginates_two_pages | PASS |
+| FR-1.5: _parse_watch_entry | test_get_watched_items_parses_response, missing/empty/null UserData tests | PASS |
+| FR-1.6: Error contract | test_get_watched_items_auth_error, _connection_error, _unexpected_status | PASS |
+| FR-1.7: DEBUG logging | Verified in implementation (no PII logged) | N/A |
+| FR-2.1: get_favorite_items signature | test_get_favorite_items_sends_correct_request | PASS |
+| FR-2.2: Correct query params (IsFavorite, no SortBy) | test_get_favorite_items_sends_correct_request | PASS |
+| FR-2.3: Auto-pagination | test_get_favorite_items_paginates_two_pages | PASS |
+| FR-2.4: Reuses _parse_watch_entry | test_get_favorite_items_parses_response, _unplayed_favorite | PASS |
+| FR-2.5: Error contract | test_get_favorite_items_auth_error, _connection_error, _unexpected_status | PASS |
+| FR-2.6: DEBUG logging | Verified in implementation (no PII logged) | N/A |
+| No Fields param sent | Both _sends_correct_request tests assert "Fields" not in params | PASS |
+
+### Integration Tests
+
+Integration tests written in `backend/tests/integration/test_jellyfin_client.py`:
+- `test_get_watched_items_returns_list` — authenticates as alice, verifies `list[WatchHistoryEntry]`
+- `test_get_favorite_items_returns_list` — authenticates as alice, verifies `list[WatchHistoryEntry]`
+
+**Note:** Integration tests require `make jellyfin-up` (disposable Jellyfin container). Not run in this session as no Jellyfin container was available.

--- a/docs/specs/17-spec-watch-history-client/17-questions-1-watch-history-client.md
+++ b/docs/specs/17-spec-watch-history-client/17-questions-1-watch-history-client.md
@@ -1,0 +1,77 @@
+# 17 Questions Round 1 - Watch History Client
+
+Please answer each question below (select one or more options, or add your own notes). Feel free to add additional context under any question.
+
+## 1. Return Model and Watch-Specific Fields
+
+The issue says the methods return `list[LibraryItem]`, but the downstream consumer (#119 history-aware ranking) will need temporal data like when an item was last played, how many times it was played, and whether it was marked as a favorite. The current `LibraryItem` model has no fields for `DatePlayed`, `PlayCount`, or `IsFavorite`.
+
+**Should the methods return the existing `LibraryItem` or a new model that includes watch-specific metadata?**
+
+- [ ] (A) Return `list[LibraryItem]` as-is — ranking in #119 only needs the item IDs, not temporal data
+- [ ] (B) Add optional fields to `LibraryItem` (e.g. `last_played_date`, `play_count`, `is_favorite`) that are `None` when not relevant — keeps one model, avoids proliferation
+- [ ] (C) Create a new `WatchedItem` model that wraps or extends `LibraryItem` with watch-specific fields (`last_played_date: datetime | None`, `play_count: int`, `is_favorite: bool`) — clean separation between library sync data and user activity data
+- [ ] (D) Return a slim DTO with just the fields ranking needs (item ID, last played date, play count) — the full metadata is already in the local `library_items` table from sync
+
+Notes:
+
+## 2. Jellyfin Fields to Request
+
+The existing `get_items` method requests `_ITEM_FIELDS` (Overview, Genres, ProductionYear, Tags, Studios, CommunityRating, People) which is optimised for embedding/display. Watch history queries may not need all that metadata (especially if items are already synced locally), but Jellyfin's `UserData` object (containing `PlayCount`, `LastPlayedDate`, `IsFavorite`, `Played`) comes back automatically without requesting it — it just needs to not be stripped.
+
+**Should the watch history methods request the full `_ITEM_FIELDS`, a minimal set, or just rely on UserData?**
+
+- [ ] (A) Request full `_ITEM_FIELDS` — same as sync, keeps things consistent, data is there if we need it
+- [ ] (B) Request minimal fields (just `UserData`) since the purpose is activity tracking, not metadata — full metadata is already in local SQLite from sync
+- [ ] (C) Let this decision follow from Q1 — if we return `LibraryItem`, use `_ITEM_FIELDS`; if we return a slim DTO, use minimal fields
+
+Notes:
+
+## 3. Pagination Strategy
+
+The issue says "Paginated fetching with existing `get_all_items` pattern" but also specifies a `limit=50` default parameter. The `get_all_items` method auto-paginates through ALL items. For a user who has watched hundreds of movies, these two patterns are contradictory.
+
+**Should the limit be a hard cap (fetch at most N items) or should the methods auto-paginate through all history?**
+
+- [ ] (A) Hard cap — `limit` is the maximum number of items returned. If a user watched 500 movies, `limit=50` returns the 50 most recent. Simple, bounded, predictable cost
+- [ ] (B) Auto-paginate all — use the `get_all_items` pattern to fetch everything, ignore the limit param. Downstream ranking can decide how many to use
+- [ ] (C) Default hard cap (e.g. 50), but accept `limit=None` to mean "fetch all" for cases where the caller explicitly wants everything
+
+Notes:
+
+## 4. Integration Test Strategy
+
+The existing integration tests run against a disposable Jellyfin container with provisioned test users (alice, bob). To test `get_watched_items` and `get_favorite_items`, we need items that are actually marked as played/favorited. The test Jellyfin currently has no library content.
+
+**How should integration tests handle the need for watched/favorited items?**
+
+- [ ] (A) Use Jellyfin's API to mark items as played/favorited during test setup — but this requires library items to exist first. Add a fixture that creates dummy items or imports a small test library
+- [ ] (B) Test only the "no history" empty-list case in integration tests — the API shape and error handling are the important things to verify against real Jellyfin. Unit tests cover the parsing with mocked responses
+- [ ] (C) Skip integration tests for now — unit tests with mocked HTTP responses are sufficient for a 2-point client method. Add integration tests when #119 (ranking) needs end-to-end verification
+- [ ] (D) Provision a small test media library (a few public-domain clips or dummy items) in the test Jellyfin, then mark some as played/favorited in test setup
+
+Notes:
+
+## 5. Favorites Sort Order
+
+For watched items, the issue specifies `SortBy=DatePlayed&SortOrder=Descending` (most recently played first), which is clear. For favorites, no sort order is specified.
+
+**What sort order should `get_favorite_items` use?**
+
+- [ ] (A) `SortBy=DateCreated&SortOrder=Descending` — most recently added favorites first
+- [ ] (B) `SortBy=SortName` — alphabetical, matching Jellyfin's default
+- [ ] (C) `SortBy=DatePlayed&SortOrder=Descending` — same as watched items, so recently-played favorites surface first (useful for ranking)
+- [ ] (D) No explicit sort — let Jellyfin decide the default, since ranking in #119 will re-order anyway
+
+Notes:
+
+## 6. Method Placement
+
+The issue specifies these as `JellyfinClient` methods, which is consistent with the existing pattern (all Jellyfin HTTP calls live in `client.py`). However, the permission service shows an alternative pattern where a higher-level service wraps the client.
+
+**Confirm: should `get_watched_items` and `get_favorite_items` be methods directly on `JellyfinClient`?**
+
+- [ ] (A) Yes, on `JellyfinClient` — they are thin HTTP wrappers, same as `get_items`. Keep the client as the single place for all Jellyfin API calls
+- [ ] (B) Create a separate `WatchHistoryService` that wraps `JellyfinClient` — adds a layer for future caching, combining watched + favorites, etc. Client stays focused on raw HTTP
+
+Notes:

--- a/docs/specs/17-spec-watch-history-client/17-spec-watch-history-client.md
+++ b/docs/specs/17-spec-watch-history-client/17-spec-watch-history-client.md
@@ -188,6 +188,7 @@ This is a backend-only spec. No API endpoints, no frontend changes, no new servi
   - `LastPlayedDate` is null/absent: `last_played_date=None`.
   - `PlayCount` is absent: `play_count=0`.
   - `IsFavorite` is absent: `is_favorite=False`.
+  - `UserData` is present but an empty dict `{}`: `last_played_date=None`, `play_count=0`, `is_favorite=False`.
 
 - FR-3.7: The system shall add one integration test in `backend/tests/integration/test_jellyfin_client.py` (or a new `test_watch_history.py` in the integration directory) that:
   - Authenticates as test user `alice` against the real Jellyfin instance.

--- a/docs/specs/17-spec-watch-history-client/17-spec-watch-history-client.md
+++ b/docs/specs/17-spec-watch-history-client/17-spec-watch-history-client.md
@@ -1,0 +1,297 @@
+# 17-spec-watch-history-client
+
+## Introduction/Overview
+
+This spec adds two methods to the existing `JellyfinClient` for retrieving a user's watch history and favorite items. These are thin HTTP wrappers — consistent with the existing `get_items` and `get_all_items` patterns — that call Jellyfin's `/Users/{userId}/Items` endpoint with `IsPlayed=true` and `IsFavorite=true` filters respectively. The methods return a slim `WatchHistoryEntry` dataclass (not the full `LibraryItem`) containing only the user-scoped activity fields that the downstream history-aware ranking service (#119) needs: item ID, last played date, play count, and favorite status.
+
+This is a backend-only spec. No API endpoints, no frontend changes, no new services. The methods are consumed internally by the ranking service in #119.
+
+## Goals
+
+- **Watched items retrieval**: Fetch all items a user has marked as played in Jellyfin, sorted by most recently played, returning only the activity metadata needed for ranking.
+- **Favorite items retrieval**: Fetch all items a user has marked as favorite in Jellyfin, returning the same slim activity metadata.
+- **Slim return type**: Return `WatchHistoryEntry` dataclasses with only the fields ranking needs (`jellyfin_id`, `last_played_date`, `play_count`, `is_favorite`), since full item metadata is already available in the local `library_items` table from sync.
+- **Complete data**: Fetch ALL matching items with no hard cap, following the `PermissionService._fetch_permitted_ids` pattern. A limit would be a correctness bug for ranking — the ranker needs the full picture.
+- **Consistent client patterns**: Reuse the existing `_request`, `_parse_response`, and `_headers` infrastructure in `JellyfinClient`. No new HTTP clients, no new service classes.
+
+## User Stories
+
+- **As the history-aware ranking service** (#119), I need the full list of a user's watched movies with temporal metadata (when played, how many times) so I can boost or penalize recommendations based on viewing history.
+- **As the history-aware ranking service** (#119), I need the full list of a user's favorited movies so I can boost recommendations that are similar to the user's explicitly preferred content.
+- **As a developer building #119**, I want watch history and favorites to come from dedicated `JellyfinClient` methods with a clean return type, so that the ranking service does not need to understand Jellyfin query parameters or parse raw API responses.
+
+## Demoable Units of Work
+
+### Unit 1: WatchHistoryEntry Model + get_watched_items Method
+
+**Purpose:** Define the slim `WatchHistoryEntry` dataclass for user activity data and add a `get_watched_items` method to `JellyfinClient` that fetches all played items for a user, auto-paginating through the full result set.
+
+**Functional Requirements:**
+
+- FR-1.1: The system shall define a `WatchHistoryEntry` dataclass in `backend/app/jellyfin/models.py`:
+  ```python
+  @dataclass(frozen=True, slots=True)
+  class WatchHistoryEntry:
+      jellyfin_id: str
+      last_played_date: datetime | None
+      play_count: int
+      is_favorite: bool
+  ```
+  This is a plain dataclass, not a Pydantic model. It does not extend `LibraryItem`. The separation is intentional: `LibraryItem` represents library-scoped catalog metadata (used for sync and embedding), while `WatchHistoryEntry` represents user-scoped activity data (used for ranking). These are different domains with different lifecycles and access patterns.
+
+- FR-1.2: The system shall add a `get_watched_items` method to `JellyfinClient` in `backend/app/jellyfin/client.py` with this signature:
+  ```python
+  async def get_watched_items(
+      self,
+      token: str,
+      user_id: str,
+  ) -> list[WatchHistoryEntry]:
+  ```
+  The method accepts the user's Jellyfin token and user ID as parameters. The token is passed through to `_request` — never stored on the instance or logged.
+
+- FR-1.3: The `get_watched_items` method shall call `GET /Users/{user_id}/Items` with these query parameters:
+  - `IsPlayed=true` — filter to watched items only.
+  - `IncludeItemTypes=Movie` — filter to movies only (consistent with all other item queries in the codebase).
+  - `SortBy=DatePlayed` — sort by most recently played.
+  - `SortOrder=Descending` — most recent first.
+  - `Recursive=true` — search all libraries.
+  - No `Fields` parameter — the method does not need full metadata fields (Overview, Genres, etc.) since the purpose is activity tracking. Jellyfin includes `UserData` (containing `PlayCount`, `LastPlayedDate`, `IsFavorite`, `Played`) by default without requesting it.
+  - Pagination parameters `StartIndex` and `Limit` — the method auto-paginates through all results.
+
+- FR-1.4: The method shall auto-paginate through all results, following the same loop pattern as `get_all_items`: start at `StartIndex=0`, request pages of 200 items, increment `StartIndex` by the number of items received, stop when `StartIndex >= TotalRecordCount` or an empty page is received. There is no hard cap on the number of items returned — a limit would be a correctness bug for the downstream ranking service, which needs the complete watch history.
+
+- FR-1.5: The method shall parse each item in the paginated response into a `WatchHistoryEntry` using a static parser method:
+  ```python
+  @staticmethod
+  def _parse_watch_entry(item: dict[str, Any]) -> WatchHistoryEntry:
+  ```
+  The parser extracts:
+  - `jellyfin_id` from `item["Id"]`.
+  - `last_played_date` from `item["UserData"]["LastPlayedDate"]` — parsed as ISO 8601 datetime. `None` if the field is absent or null.
+  - `play_count` from `item["UserData"]["PlayCount"]` — defaults to `0` if absent.
+  - `is_favorite` from `item["UserData"]["IsFavorite"]` — defaults to `False` if absent.
+
+- FR-1.6: The method shall use `_request` and `_parse_response` for HTTP communication and error handling, consistent with `get_items`. It shall raise `JellyfinAuthError` on 401, `JellyfinConnectionError` on transport failure, and `JellyfinError` on other non-2xx responses — the same error contract as all existing client methods.
+
+- FR-1.7: The method shall log at DEBUG: page number and item count per page (e.g., `"watched_items_fetch page=%d items=%d"`). It shall never log the token, user_id paired with item data, or any PII.
+
+**Proof Artifacts:**
+
+- **Unit test**: `WatchHistoryEntry` dataclass is immutable (`frozen=True`) — verify that assigning to a field raises `FrozenInstanceError`.
+- **Unit test**: `WatchHistoryEntry` fields have correct types and defaults are not applied (all fields are required except `last_played_date` which is `datetime | None`).
+- **Unit test**: `get_watched_items` sends correct URL (`/Users/{user_id}/Items`), correct query parameters (`IsPlayed=true`, `IncludeItemTypes=Movie`, `SortBy=DatePlayed`, `SortOrder=Descending`, `Recursive=true`), and no `Fields` parameter. Mock `httpx.AsyncClient.request`.
+- **Unit test**: `get_watched_items` parses a mock Jellyfin response into `list[WatchHistoryEntry]` with correct field values, including `last_played_date` as a `datetime` object.
+- **Unit test**: `get_watched_items` auto-paginates — mock two pages (e.g., 200 + 50 items, `TotalRecordCount=250`), verify all 250 entries are returned.
+- **Unit test**: `get_watched_items` returns an empty list for a user with no watch history (mock response: `Items=[], TotalRecordCount=0`).
+- **Unit test**: `get_watched_items` handles missing `UserData` gracefully — `last_played_date=None`, `play_count=0`, `is_favorite=False`.
+- **Unit test**: `get_watched_items` raises `JellyfinAuthError` on 401 response.
+- **Unit test**: `get_watched_items` raises `JellyfinConnectionError` on transport error.
+- **Unit test**: `get_watched_items` raises `JellyfinError` on 500 response.
+
+---
+
+### Unit 2: get_favorite_items Method
+
+**Purpose:** Add a `get_favorite_items` method to `JellyfinClient` that fetches all favorited items for a user, using the same `WatchHistoryEntry` return type and auto-pagination pattern.
+
+**Functional Requirements:**
+
+- FR-2.1: The system shall add a `get_favorite_items` method to `JellyfinClient` with this signature:
+  ```python
+  async def get_favorite_items(
+      self,
+      token: str,
+      user_id: str,
+  ) -> list[WatchHistoryEntry]:
+  ```
+  Same parameter and token-handling discipline as `get_watched_items`.
+
+- FR-2.2: The method shall call `GET /Users/{user_id}/Items` with these query parameters:
+  - `IsFavorite=true` — filter to favorited items only.
+  - `IncludeItemTypes=Movie` — movies only.
+  - `Recursive=true` — search all libraries.
+  - No explicit `SortBy` or `SortOrder` — Jellyfin applies its default sort order. The downstream ranking service (#119) will re-order results based on its own scoring, so the API sort order is irrelevant.
+  - No `Fields` parameter — same rationale as `get_watched_items`.
+  - Pagination parameters `StartIndex` and `Limit` for auto-pagination.
+
+- FR-2.3: The method shall auto-paginate through all results using the same loop pattern as `get_watched_items` (FR-1.4). No hard cap.
+
+- FR-2.4: The method shall parse each item into a `WatchHistoryEntry` using the same `_parse_watch_entry` static method (FR-1.5). For favorited items that have not been played, `last_played_date` will be `None` and `play_count` will be `0` — this is expected and correct.
+
+- FR-2.5: The method shall use `_request` and `_parse_response` for HTTP communication and error handling, with the same error contract as all existing client methods (FR-1.6).
+
+- FR-2.6: The method shall log at DEBUG: page number and item count per page (e.g., `"favorite_items_fetch page=%d items=%d"`). Same logging discipline as FR-1.7.
+
+**Proof Artifacts:**
+
+- **Unit test**: `get_favorite_items` sends correct URL and query parameters (`IsFavorite=true`, `IncludeItemTypes=Movie`, `Recursive=true`). Verify no `SortBy` or `SortOrder` parameters are sent. Verify no `Fields` parameter is sent.
+- **Unit test**: `get_favorite_items` parses a mock response into `list[WatchHistoryEntry]` with correct field values.
+- **Unit test**: `get_favorite_items` auto-paginates — mock two pages, verify all entries returned.
+- **Unit test**: `get_favorite_items` returns an empty list for a user with no favorites.
+- **Unit test**: `get_favorite_items` correctly parses a favorite item that has never been played (`last_played_date=None`, `play_count=0`, `is_favorite=True`).
+- **Unit test**: `get_favorite_items` raises `JellyfinAuthError` on 401.
+- **Unit test**: `get_favorite_items` raises `JellyfinConnectionError` on transport error.
+- **Unit test**: `get_favorite_items` raises `JellyfinError` on 500.
+
+---
+
+### Unit 3: Test Suite
+
+**Purpose:** Comprehensive unit tests and one integration test verifying the watch history client methods against both mocked and real Jellyfin instances.
+
+**Functional Requirements:**
+
+- FR-3.1: The system shall add unit tests in `backend/tests/test_watch_history.py` covering all proof artifacts from Units 1 and 2. Tests shall use the existing `mock_http` / `jf_client` fixture pattern from `test_jellyfin_client.py`:
+  ```python
+  @pytest.fixture
+  def mock_http() -> AsyncMock:
+      return AsyncMock(spec=httpx.AsyncClient)
+
+  @pytest.fixture
+  def jf_client(mock_http: AsyncMock) -> JellyfinClient:
+      return JellyfinClient(
+          base_url="http://jellyfin:8096",
+          http_client=mock_http,
+      )
+  ```
+
+- FR-3.2: Unit tests shall verify HTTP request construction by inspecting `mock_http.request.call_args`:
+  - Correct HTTP method (`GET`).
+  - Correct URL path (`/Users/{user_id}/Items`).
+  - Correct query parameters for each method.
+  - Token passed in the Authorization header via `_headers`.
+
+- FR-3.3: Unit tests shall verify response parsing with representative Jellyfin JSON fixtures. The fixture data shall include realistic `UserData` objects:
+  ```json
+  {
+    "Id": "item-1",
+    "Name": "Alien",
+    "Type": "Movie",
+    "UserData": {
+      "PlayCount": 3,
+      "IsFavorite": true,
+      "Played": true,
+      "LastPlayedDate": "2025-12-15T20:30:00.0000000Z"
+    }
+  }
+  ```
+
+- FR-3.4: Unit tests shall verify error handling: 401 -> `JellyfinAuthError`, transport error -> `JellyfinConnectionError`, 500 -> `JellyfinError`. These follow the exact same test patterns as `TestGetItems` and `TestGetUser` in `test_jellyfin_client.py`.
+
+- FR-3.5: Unit tests shall verify pagination by mocking multiple sequential responses from `mock_http.request`, verifying that:
+  - The method makes the correct number of HTTP calls.
+  - `StartIndex` increments correctly across pages.
+  - All items from all pages are collected into the returned list.
+
+- FR-3.6: Unit tests shall verify edge cases:
+  - Empty `UserData` or missing `UserData` key on an item: `last_played_date=None`, `play_count=0`, `is_favorite=False`.
+  - `LastPlayedDate` is null/absent: `last_played_date=None`.
+  - `PlayCount` is absent: `play_count=0`.
+  - `IsFavorite` is absent: `is_favorite=False`.
+
+- FR-3.7: The system shall add one integration test in `backend/tests/integration/test_jellyfin_client.py` (or a new `test_watch_history.py` in the integration directory) that:
+  - Authenticates as test user `alice` against the real Jellyfin instance.
+  - Calls `get_watched_items` and verifies it returns `list[WatchHistoryEntry]` (the list will be empty since the test Jellyfin has no library content — this verifies the API shape and empty-list handling against real Jellyfin).
+  - Calls `get_favorite_items` and verifies the same.
+  - Uses the `@pytest.mark.integration` marker.
+
+- FR-3.8: All tests shall pass with `make test` (unit) and `make test-integration` (integration, requires `make jellyfin-up`).
+
+- FR-3.9: All new code shall pass `make lint` (ruff).
+
+**Proof Artifacts:**
+
+- `make test` passes with all new unit tests.
+- `make test-integration` passes with the empty-list integration test (requires `make jellyfin-up`).
+- `make lint` passes with all new modules.
+- Test coverage for `get_watched_items` and `get_favorite_items` includes: success path, pagination, empty list, missing UserData fields, auth error, connection error, unexpected status.
+
+## Non-Goals (Out of Scope)
+
+1. **Ranking logic** — This spec provides the raw data. How watch history and favorites influence recommendation ranking is #119's concern.
+2. **Caching** — No in-memory caching of watch history or favorites. The ranking service (#119) will decide if caching is needed and at what layer. Adding premature caching here adds complexity for no demonstrated benefit.
+3. **Service wrapper** — No `WatchHistoryService` class. The methods live directly on `JellyfinClient` as thin HTTP wrappers. A service layer is deferred to #119 if it needs to combine watched + favorites, apply caching, or orchestrate multiple calls.
+4. **API endpoints** — No REST endpoints for watch history. These are internal client methods consumed by the ranking service, not exposed to the frontend.
+5. **Watch history persistence** — Watch history is fetched live from Jellyfin on each ranking request. It is not stored in `library.db` or any local database. Jellyfin is the source of truth for user activity data.
+6. **Series/episode support** — Only `Movie` items are fetched. Series and episode watch history is out of scope for the movie recommendation engine.
+7. **Full metadata in return type** — `WatchHistoryEntry` deliberately excludes title, overview, genres, and other catalog metadata. That data is already in `library_items` from sync. Fetching it again in the watch history call would be redundant network and memory overhead.
+
+## Design Considerations
+
+No UI/UX considerations. This is a backend-only spec adding internal client methods with no user-facing interface.
+
+### Return Type Design
+
+`WatchHistoryEntry` is a `@dataclass(frozen=True, slots=True)` — not a Pydantic model. This follows the precedent set by `_CacheEntry` in `PermissionService` and `LibraryItemRow` in the library store: internal data transfer objects that don't need Pydantic's validation overhead. The Jellyfin response is validated structurally by the parser; the dataclass provides type safety for downstream consumers.
+
+The model intentionally does NOT extend `LibraryItem`. These represent different domains:
+- `LibraryItem` = library-scoped catalog metadata (titles, genres, studios) used for sync and embedding.
+- `WatchHistoryEntry` = user-scoped activity metadata (play count, last played date) used for ranking.
+
+Mixing them would create a model that is sometimes partially populated depending on the call context, which is an antipattern.
+
+### Pagination Strategy
+
+Both methods fetch ALL matching items with no limit parameter. This matches the `PermissionService._fetch_permitted_ids` pattern, which also consumes the full `get_all_items` iterator to build a complete set. The rationale: a hard cap on watch history would be a correctness bug for ranking. If a user has watched 500 movies and we only fetch 50, the ranker cannot distinguish "unwatched" from "watched but not in the top 50." The ranking service needs the full picture.
+
+### Jellyfin Fields Strategy
+
+The methods do not send a `Fields` parameter. Jellyfin's `/Users/{userId}/Items` endpoint includes `UserData` (containing `PlayCount`, `LastPlayedDate`, `IsFavorite`, `Played`) by default without requesting it. Since `WatchHistoryEntry` only needs fields from `UserData` plus the item `Id`, there is no reason to request the full metadata fields (`Overview`, `Genres`, `ProductionYear`, etc.) that `get_items` requests via `_ITEM_FIELDS`.
+
+## Repository Standards
+
+### Existing Patterns This Implementation Must Follow
+
+- **`_request` / `_parse_response` / `_headers`**: All HTTP communication goes through the existing helper methods in `JellyfinClient` (lines 65-114 of `client.py`). New methods do not create their own HTTP calls or headers.
+- **Token as parameter, never stored**: Matches `get_items(token, user_id, ...)`, `get_all_items(token, user_id, ...)`, and `get_user(token)` — tokens are call parameters, never instance state.
+- **Per-user endpoint**: Uses `/Users/{user_id}/Items` so Jellyfin enforces per-user permissions and returns user-specific `UserData`, matching `get_items`.
+- **Error contract**: Same three-tier error hierarchy as all existing client methods: `JellyfinAuthError` (401), `JellyfinConnectionError` (transport), `JellyfinError` (other non-2xx).
+- **Test fixtures**: Unit tests use the `mock_http` / `jf_client` / `_FAKE_REQUEST` pattern from `test_jellyfin_client.py`. Integration tests use the `jellyfin` / `jf_client` / `test_users` fixture chain from `tests/integration/conftest.py`.
+- **Conventional commits**: `feat(jellyfin):`, `test(jellyfin):`.
+
+### File Organization
+
+```
+backend/app/
+└── jellyfin/
+    ├── client.py      # + get_watched_items(), get_favorite_items()
+    └── models.py      # + WatchHistoryEntry dataclass
+
+backend/tests/
+├── test_watch_history.py                    # Unit tests (new file)
+└── integration/
+    └── test_jellyfin_client.py              # + empty-list integration tests
+```
+
+## Technical Considerations
+
+- **Dependency on existing `JellyfinClient` infrastructure**: Both methods reuse `_request`, `_parse_response`, `_headers`, and the error handling from `client.py`. No new HTTP client instances or connection pools.
+- **`UserData` availability**: Jellyfin automatically includes `UserData` on items fetched via `/Users/{userId}/Items` without needing to request it via the `Fields` parameter. This has been verified by inspecting Jellyfin's API behavior and is consistent with how `IsPlayed` and `IsFavorite` filters work (they filter on `UserData` fields, which implies `UserData` is present in the response).
+- **ISO 8601 datetime parsing**: `LastPlayedDate` from Jellyfin is an ISO 8601 string (e.g., `"2025-12-15T20:30:00.0000000Z"`). The parser shall use `datetime.fromisoformat()` (Python 3.11+), which handles the `Z` suffix and fractional seconds. If the field is absent or null, `last_played_date` is `None`.
+- **Pagination page size**: Uses 200 items per page, matching the default `page_size` in `get_all_items`. This is not configurable — it is an internal implementation detail, not a user-facing setting.
+- **Memory footprint**: `WatchHistoryEntry` has 4 fields (~100 bytes per entry). A user with 1,000 watched movies produces ~100 KB of entries. Negligible.
+- **Feeds into #119**: The history-aware ranking service will call both `get_watched_items` and `get_favorite_items` with the user's session token, then use the returned entries to adjust vector search result scores. The slim DTO avoids fetching redundant metadata that is already in `library_items`.
+
+## Security Considerations
+
+- **Token passed as parameter, never stored**: Both methods accept `token` as a call parameter, pass it to `_request` via `_headers`, and never store it on `self`, in a cache, or in a log message. Identical discipline to `get_items`, `get_user`, and all other client methods.
+- **Per-user endpoint**: Using `/Users/{user_id}/Items` ensures Jellyfin enforces that user's specific library access and parental restrictions. The response only contains items the authenticated user is permitted to see.
+- **No PII in logs**: Log messages include page numbers and item counts only. Never log token values, user_id paired with item data, or item metadata.
+- **No token in error messages**: Exception messages from `_request` do not include the token value (verified by the existing `_request` implementation).
+- **No admin API key usage**: Watch history is inherently per-user data. These methods always use the user's own session token, never `JELLYFIN_API_KEY`.
+
+## Success Metrics
+
+1. `get_watched_items` returns a complete `list[WatchHistoryEntry]` for a user's played items, auto-paginating through all pages — verified by unit test with mocked multi-page responses.
+2. `get_favorite_items` returns a complete `list[WatchHistoryEntry]` for a user's favorited items — verified by unit test.
+3. `WatchHistoryEntry` correctly captures `jellyfin_id`, `last_played_date` (as `datetime | None`), `play_count` (as `int`), and `is_favorite` (as `bool`) — verified by unit tests with representative Jellyfin JSON.
+4. Both methods handle missing/null `UserData` fields gracefully with safe defaults — verified by unit tests.
+5. Both methods raise the correct domain exceptions (`JellyfinAuthError`, `JellyfinConnectionError`, `JellyfinError`) — verified by unit tests.
+6. Both methods send correct Jellyfin query parameters — verified by unit tests inspecting `mock_http.request.call_args`.
+7. Neither method sends a `Fields` parameter (no unnecessary metadata fetching) — verified by unit test.
+8. Integration test confirms both methods return `list[WatchHistoryEntry]` (empty list) against a real Jellyfin instance — verified by `make test-integration`.
+9. `make test` and `make lint` pass with all new code.
+
+## Open Questions
+
+None. All six design questions were resolved in the decision packet before spec generation (documented in `17-questions-1-watch-history-client.md`).

--- a/docs/specs/17-spec-watch-history-client/17-tasks-watch-history-client.md
+++ b/docs/specs/17-spec-watch-history-client/17-tasks-watch-history-client.md
@@ -18,7 +18,7 @@
 
 ## Tasks
 
-### [ ] 1.0 WatchHistoryEntry Model + get_watched_items with Unit Tests
+### [x] 1.0 WatchHistoryEntry Model + get_watched_items with Unit Tests
 
 Add the `WatchHistoryEntry` frozen dataclass to `models.py` and the `get_watched_items` method (with `_parse_watch_entry` static parser) to `client.py`. Write the full unit test suite for both the model and the method in `test_watch_history.py`.
 
@@ -38,47 +38,47 @@ Add the `WatchHistoryEntry` frozen dataclass to `models.py` and the `get_watched
 #### 1.0 Tasks
 
 ##### Model (FR-1.1)
-- [ ] 1.1 Add `WatchHistoryEntry` frozen dataclass to `models.py` with fields: `jellyfin_id: str`, `last_played_date: datetime | None`, `play_count: int`, `is_favorite: bool`. Use `@dataclass(frozen=True, slots=True)`. Add the `datetime` import at the top of the file. (file: `backend/app/jellyfin/models.py`)
-- [ ] 1.2 Add import of `WatchHistoryEntry` to the `from app.jellyfin.models import ...` line in `client.py`. (file: `backend/app/jellyfin/client.py`)
+- [x] 1.1 Add `WatchHistoryEntry` frozen dataclass to `models.py` with fields: `jellyfin_id: str`, `last_played_date: datetime | None`, `play_count: int`, `is_favorite: bool`. Use `@dataclass(frozen=True, slots=True)`. Add the `datetime` import at the top of the file. (file: `backend/app/jellyfin/models.py`)
+- [x] 1.2 Add import of `WatchHistoryEntry` to the `from app.jellyfin.models import ...` line in `client.py`. (file: `backend/app/jellyfin/client.py`)
 
 ##### Parser (FR-1.5)
-- [ ] 1.3 Add `_parse_watch_entry` static method to `JellyfinClient` that extracts `jellyfin_id` from `item["Id"]`, `last_played_date` from `item["UserData"]["LastPlayedDate"]` (parsed via `datetime.fromisoformat()`, `None` if absent/null), `play_count` from `item["UserData"]["PlayCount"]` (default `0`), and `is_favorite` from `item["UserData"]["IsFavorite"]` (default `False`). Handle missing `UserData` key and empty `UserData` dict gracefully. Add `from datetime import datetime` import. (file: `backend/app/jellyfin/client.py`)
+- [x] 1.3 Add `_parse_watch_entry` static method to `JellyfinClient` that extracts `jellyfin_id` from `item["Id"]`, `last_played_date` from `item["UserData"]["LastPlayedDate"]` (parsed via `datetime.fromisoformat()`, `None` if absent/null), `play_count` from `item["UserData"]["PlayCount"]` (default `0`), and `is_favorite` from `item["UserData"]["IsFavorite"]` (default `False`). Handle missing `UserData` key and empty `UserData` dict gracefully. Add `from datetime import datetime` import. (file: `backend/app/jellyfin/client.py`)
 
 ##### Method (FR-1.2 through FR-1.4, FR-1.6, FR-1.7)
-- [ ] 1.4 Add `get_watched_items(self, token: str, user_id: str) -> list[WatchHistoryEntry]` method to `JellyfinClient`. Build params dict with `IsPlayed=true`, `IncludeItemTypes=Movie`, `SortBy=DatePlayed`, `SortOrder=Descending`, `Recursive=true`, `StartIndex`, and `Limit=200`. Do NOT include a `Fields` parameter. (file: `backend/app/jellyfin/client.py`)
-- [ ] 1.5 Implement auto-pagination loop inside `get_watched_items`: start at `StartIndex=0`, call `_request("GET", f"/Users/{user_id}/Items", token=token, params=params)`, parse response via `_parse_response` with a lambda that extracts `Items` list and `TotalRecordCount`, map each item through `_parse_watch_entry`, increment `StartIndex` by items received, stop when `StartIndex >= TotalRecordCount` or page is empty. Collect all entries into a single `list[WatchHistoryEntry]`. (file: `backend/app/jellyfin/client.py`)
-- [ ] 1.6 Add DEBUG logging inside the pagination loop: `logger.debug("watched_items_fetch page=%d items=%d", page_number, len(items))`. Never log token, user_id paired with item data, or any PII. (file: `backend/app/jellyfin/client.py`)
+- [x] 1.4 Add `get_watched_items(self, token: str, user_id: str) -> list[WatchHistoryEntry]` method to `JellyfinClient`. Build params dict with `IsPlayed=true`, `IncludeItemTypes=Movie`, `SortBy=DatePlayed`, `SortOrder=Descending`, `Recursive=true`, `StartIndex`, and `Limit=200`. Do NOT include a `Fields` parameter. (file: `backend/app/jellyfin/client.py`)
+- [x] 1.5 Implement auto-pagination loop inside `get_watched_items`: start at `StartIndex=0`, call `_request("GET", f"/Users/{user_id}/Items", token=token, params=params)`, parse response via `_parse_response` with a lambda that extracts `Items` list and `TotalRecordCount`, map each item through `_parse_watch_entry`, increment `StartIndex` by items received, stop when `StartIndex >= TotalRecordCount` or page is empty. Collect all entries into a single `list[WatchHistoryEntry]`. (file: `backend/app/jellyfin/client.py`)
+- [x] 1.6 Add DEBUG logging inside the pagination loop: `logger.debug("watched_items_fetch page=%d items=%d", page_number, len(items))`. Never log token, user_id paired with item data, or any PII. (file: `backend/app/jellyfin/client.py`)
 
 ##### Unit Tests — Model
-- [ ] 1.7 Create `backend/tests/test_watch_history.py` with imports: `WatchHistoryEntry` from `models`, `JellyfinClient` from `client`, `JellyfinAuthError`/`JellyfinConnectionError`/`JellyfinError` from `errors`, `AsyncMock` from `unittest.mock`, `httpx`, `pytest`. Add `mock_http` and `jf_client` fixtures matching the pattern in `test_jellyfin_client.py`. Add `_FAKE_REQUEST = httpx.Request("GET", "http://fake")`. (file: `backend/tests/test_watch_history.py`)
-- [ ] 1.8 Add test `test_watch_history_entry_is_frozen` — create a `WatchHistoryEntry`, assert assigning to `jellyfin_id` raises `dataclasses.FrozenInstanceError`. (file: `backend/tests/test_watch_history.py`)
-- [ ] 1.9 Add test `test_watch_history_entry_fields_and_types` — create a `WatchHistoryEntry` with all fields populated (including a real `datetime` for `last_played_date`), assert each field value and type. Verify `last_played_date=None` is accepted. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.7 Create `backend/tests/test_watch_history.py` with imports: `WatchHistoryEntry` from `models`, `JellyfinClient` from `client`, `JellyfinAuthError`/`JellyfinConnectionError`/`JellyfinError` from `errors`, `AsyncMock` from `unittest.mock`, `httpx`, `pytest`. Add `mock_http` and `jf_client` fixtures matching the pattern in `test_jellyfin_client.py`. Add `_FAKE_REQUEST = httpx.Request("GET", "http://fake")`. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.8 Add test `test_watch_history_entry_is_frozen` — create a `WatchHistoryEntry`, assert assigning to `jellyfin_id` raises `dataclasses.FrozenInstanceError`. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.9 Add test `test_watch_history_entry_fields_and_types` — create a `WatchHistoryEntry` with all fields populated (including a real `datetime` for `last_played_date`), assert each field value and type. Verify `last_played_date=None` is accepted. (file: `backend/tests/test_watch_history.py`)
 
 ##### Unit Tests — get_watched_items Success Path
-- [ ] 1.10 Add test `test_get_watched_items_sends_correct_request` — mock `mock_http.request` to return a 200 response with `{"Items": [], "TotalRecordCount": 0}`. Call `get_watched_items("tok-123", "uid-1")`. Inspect `mock_http.request.call_args`: assert method is `GET`, URL contains `/Users/uid-1/Items`, params include `IsPlayed=true`, `IncludeItemTypes=Movie`, `SortBy=DatePlayed`, `SortOrder=Descending`, `Recursive=true`. Assert `Fields` is NOT in params. Assert `Token=tok-123` is in the Authorization header. (file: `backend/tests/test_watch_history.py`)
-- [ ] 1.11 Add test `test_get_watched_items_parses_response` — mock response with 2 items including realistic `UserData` objects (one with `LastPlayedDate: "2025-12-15T20:30:00.0000000Z"`, `PlayCount: 3`, `IsFavorite: true`; one with `LastPlayedDate: "2025-11-01T10:00:00.0000000Z"`, `PlayCount: 1`, `IsFavorite: false`). Assert returned list has 2 `WatchHistoryEntry` objects with correct field values. Assert `last_played_date` is a `datetime` instance. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.10 Add test `test_get_watched_items_sends_correct_request` — mock `mock_http.request` to return a 200 response with `{"Items": [], "TotalRecordCount": 0}`. Call `get_watched_items("tok-123", "uid-1")`. Inspect `mock_http.request.call_args`: assert method is `GET`, URL contains `/Users/uid-1/Items`, params include `IsPlayed=true`, `IncludeItemTypes=Movie`, `SortBy=DatePlayed`, `SortOrder=Descending`, `Recursive=true`. Assert `Fields` is NOT in params. Assert `Token=tok-123` is in the Authorization header. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.11 Add test `test_get_watched_items_parses_response` — mock response with 2 items including realistic `UserData` objects (one with `LastPlayedDate: "2025-12-15T20:30:00.0000000Z"`, `PlayCount: 3`, `IsFavorite: true`; one with `LastPlayedDate: "2025-11-01T10:00:00.0000000Z"`, `PlayCount: 1`, `IsFavorite: false`). Assert returned list has 2 `WatchHistoryEntry` objects with correct field values. Assert `last_played_date` is a `datetime` instance. (file: `backend/tests/test_watch_history.py`)
 
 ##### Unit Tests — Pagination
-- [ ] 1.12 Add test `test_get_watched_items_paginates_two_pages` — mock `mock_http.request` with `side_effect` returning two sequential responses: page 1 with 200 items and `TotalRecordCount=250`, page 2 with 50 items and `TotalRecordCount=250`. Assert returned list has 250 entries. Assert `mock_http.request.call_count == 2`. Assert second call's params have `StartIndex=200`. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.12 Add test `test_get_watched_items_paginates_two_pages` — mock `mock_http.request` with `side_effect` returning two sequential responses: page 1 with 200 items and `TotalRecordCount=250`, page 2 with 50 items and `TotalRecordCount=250`. Assert returned list has 250 entries. Assert `mock_http.request.call_count == 2`. Assert second call's params have `StartIndex=200`. (file: `backend/tests/test_watch_history.py`)
 
 ##### Unit Tests — Empty / Edge Cases
-- [ ] 1.13 Add test `test_get_watched_items_empty_history` — mock response with `{"Items": [], "TotalRecordCount": 0}`. Assert returns empty list `[]`. (file: `backend/tests/test_watch_history.py`)
-- [ ] 1.14 Add test `test_get_watched_items_missing_user_data` — mock response with an item that has no `UserData` key at all. Assert the parsed entry has `last_played_date=None`, `play_count=0`, `is_favorite=False`. (file: `backend/tests/test_watch_history.py`)
-- [ ] 1.15 Add test `test_get_watched_items_empty_user_data` — mock response with an item where `UserData` is `{}`. Assert same safe defaults as 1.14. (file: `backend/tests/test_watch_history.py`)
-- [ ] 1.16 Add test `test_get_watched_items_null_last_played_date` — mock response with `UserData` present but `LastPlayedDate` is `null`. Assert `last_played_date=None`. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.13 Add test `test_get_watched_items_empty_history` — mock response with `{"Items": [], "TotalRecordCount": 0}`. Assert returns empty list `[]`. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.14 Add test `test_get_watched_items_missing_user_data` — mock response with an item that has no `UserData` key at all. Assert the parsed entry has `last_played_date=None`, `play_count=0`, `is_favorite=False`. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.15 Add test `test_get_watched_items_empty_user_data` — mock response with an item where `UserData` is `{}`. Assert same safe defaults as 1.14. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.16 Add test `test_get_watched_items_null_last_played_date` — mock response with `UserData` present but `LastPlayedDate` is `null`. Assert `last_played_date=None`. (file: `backend/tests/test_watch_history.py`)
 
 ##### Unit Tests — Error Paths
-- [ ] 1.17 Add test `test_get_watched_items_auth_error` — mock `mock_http.request` returning 401 response. Assert `get_watched_items` raises `JellyfinAuthError`. (file: `backend/tests/test_watch_history.py`)
-- [ ] 1.18 Add test `test_get_watched_items_connection_error` — mock `mock_http.request.side_effect = httpx.ConnectError("Connection refused")`. Assert raises `JellyfinConnectionError`. (file: `backend/tests/test_watch_history.py`)
-- [ ] 1.19 Add test `test_get_watched_items_unexpected_status` — mock `mock_http.request` returning 500 response. Assert raises `JellyfinError`. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.17 Add test `test_get_watched_items_auth_error` — mock `mock_http.request` returning 401 response. Assert `get_watched_items` raises `JellyfinAuthError`. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.18 Add test `test_get_watched_items_connection_error` — mock `mock_http.request.side_effect = httpx.ConnectError("Connection refused")`. Assert raises `JellyfinConnectionError`. (file: `backend/tests/test_watch_history.py`)
+- [x] 1.19 Add test `test_get_watched_items_unexpected_status` — mock `mock_http.request` returning 500 response. Assert raises `JellyfinError`. (file: `backend/tests/test_watch_history.py`)
 
 ##### Validation
-- [ ] 1.20 Run `make lint` — all new code in `models.py`, `client.py`, and `test_watch_history.py` passes ruff. (file: N/A)
-- [ ] 1.21 Run `make test` — all new unit tests pass. (file: N/A)
+- [x] 1.20 Run `make lint` — all new code in `models.py`, `client.py`, and `test_watch_history.py` passes ruff. (file: N/A)
+- [x] 1.21 Run `make test` — all new unit tests pass. (file: N/A)
 
 ---
 
-### [ ] 2.0 get_favorite_items Method with Unit Tests
+### [x] 2.0 get_favorite_items Method with Unit Tests
 
 Add the `get_favorite_items` method to `client.py`, reusing `_parse_watch_entry` from Task 1.0. Write the full unit test suite for the method in the same `test_watch_history.py` file.
 
@@ -97,33 +97,33 @@ Add the `get_favorite_items` method to `client.py`, reusing `_parse_watch_entry`
 #### 2.0 Tasks
 
 ##### Method (FR-2.1 through FR-2.6)
-- [ ] 2.1 Add `get_favorite_items(self, token: str, user_id: str) -> list[WatchHistoryEntry]` method to `JellyfinClient`. Build params dict with `IsFavorite=true`, `IncludeItemTypes=Movie`, `Recursive=true`, `StartIndex`, and `Limit=200`. Do NOT include `SortBy`, `SortOrder`, or `Fields` parameters. (file: `backend/app/jellyfin/client.py`)
-- [ ] 2.2 Implement auto-pagination loop inside `get_favorite_items` using the same pattern as `get_watched_items` (1.5): call `_request`, parse via `_parse_response`, map items through `_parse_watch_entry`, increment `StartIndex`, stop when done. Reuse the same `_parse_watch_entry` static method from Task 1.3. (file: `backend/app/jellyfin/client.py`)
-- [ ] 2.3 Add DEBUG logging inside the pagination loop: `logger.debug("favorite_items_fetch page=%d items=%d", page_number, len(items))`. Same PII discipline as 1.6. (file: `backend/app/jellyfin/client.py`)
+- [x] 2.1 Add `get_favorite_items(self, token: str, user_id: str) -> list[WatchHistoryEntry]` method to `JellyfinClient`. Build params dict with `IsFavorite=true`, `IncludeItemTypes=Movie`, `Recursive=true`, `StartIndex`, and `Limit=200`. Do NOT include `SortBy`, `SortOrder`, or `Fields` parameters. (file: `backend/app/jellyfin/client.py`)
+- [x] 2.2 Implement auto-pagination loop inside `get_favorite_items` using the same pattern as `get_watched_items` (1.5): call `_request`, parse via `_parse_response`, map items through `_parse_watch_entry`, increment `StartIndex`, stop when done. Reuse the same `_parse_watch_entry` static method from Task 1.3. (file: `backend/app/jellyfin/client.py`)
+- [x] 2.3 Add DEBUG logging inside the pagination loop: `logger.debug("favorite_items_fetch page=%d items=%d", page_number, len(items))`. Same PII discipline as 1.6. (file: `backend/app/jellyfin/client.py`)
 
 ##### Unit Tests — get_favorite_items Success Path
-- [ ] 2.4 Add test `test_get_favorite_items_sends_correct_request` — mock `mock_http.request` to return a 200 response with `{"Items": [], "TotalRecordCount": 0}`. Call `get_favorite_items("tok-123", "uid-1")`. Inspect `mock_http.request.call_args`: assert method is `GET`, URL contains `/Users/uid-1/Items`, params include `IsFavorite=true`, `IncludeItemTypes=Movie`, `Recursive=true`. Assert `SortBy` is NOT in params. Assert `SortOrder` is NOT in params. Assert `Fields` is NOT in params. Assert `Token=tok-123` is in the Authorization header. (file: `backend/tests/test_watch_history.py`)
-- [ ] 2.5 Add test `test_get_favorite_items_parses_response` — mock response with 2 items including `UserData` with `IsFavorite: true`. Assert returned list has 2 `WatchHistoryEntry` objects with correct field values. (file: `backend/tests/test_watch_history.py`)
+- [x] 2.4 Add test `test_get_favorite_items_sends_correct_request` — mock `mock_http.request` to return a 200 response with `{"Items": [], "TotalRecordCount": 0}`. Call `get_favorite_items("tok-123", "uid-1")`. Inspect `mock_http.request.call_args`: assert method is `GET`, URL contains `/Users/uid-1/Items`, params include `IsFavorite=true`, `IncludeItemTypes=Movie`, `Recursive=true`. Assert `SortBy` is NOT in params. Assert `SortOrder` is NOT in params. Assert `Fields` is NOT in params. Assert `Token=tok-123` is in the Authorization header. (file: `backend/tests/test_watch_history.py`)
+- [x] 2.5 Add test `test_get_favorite_items_parses_response` — mock response with 2 items including `UserData` with `IsFavorite: true`. Assert returned list has 2 `WatchHistoryEntry` objects with correct field values. (file: `backend/tests/test_watch_history.py`)
 
 ##### Unit Tests — Pagination
-- [ ] 2.6 Add test `test_get_favorite_items_paginates_two_pages` — mock `mock_http.request` with `side_effect` returning two sequential responses: page 1 with 200 items and `TotalRecordCount=250`, page 2 with 50 items and `TotalRecordCount=250`. Assert returned list has 250 entries. Assert `mock_http.request.call_count == 2`. (file: `backend/tests/test_watch_history.py`)
+- [x] 2.6 Add test `test_get_favorite_items_paginates_two_pages` — mock `mock_http.request` with `side_effect` returning two sequential responses: page 1 with 200 items and `TotalRecordCount=250`, page 2 with 50 items and `TotalRecordCount=250`. Assert returned list has 250 entries. Assert `mock_http.request.call_count == 2`. (file: `backend/tests/test_watch_history.py`)
 
 ##### Unit Tests — Empty / Edge Cases
-- [ ] 2.7 Add test `test_get_favorite_items_empty_favorites` — mock response with `{"Items": [], "TotalRecordCount": 0}`. Assert returns empty list `[]`. (file: `backend/tests/test_watch_history.py`)
-- [ ] 2.8 Add test `test_get_favorite_items_unplayed_favorite` — mock response with one item where `UserData` has `IsFavorite: true`, `Played: false`, no `LastPlayedDate`, `PlayCount: 0`. Assert parsed entry has `is_favorite=True`, `last_played_date=None`, `play_count=0`. (file: `backend/tests/test_watch_history.py`)
+- [x] 2.7 Add test `test_get_favorite_items_empty_favorites` — mock response with `{"Items": [], "TotalRecordCount": 0}`. Assert returns empty list `[]`. (file: `backend/tests/test_watch_history.py`)
+- [x] 2.8 Add test `test_get_favorite_items_unplayed_favorite` — mock response with one item where `UserData` has `IsFavorite: true`, `Played: false`, no `LastPlayedDate`, `PlayCount: 0`. Assert parsed entry has `is_favorite=True`, `last_played_date=None`, `play_count=0`. (file: `backend/tests/test_watch_history.py`)
 
 ##### Unit Tests — Error Paths
-- [ ] 2.9 Add test `test_get_favorite_items_auth_error` — mock `mock_http.request` returning 401 response. Assert `get_favorite_items` raises `JellyfinAuthError`. (file: `backend/tests/test_watch_history.py`)
-- [ ] 2.10 Add test `test_get_favorite_items_connection_error` — mock `mock_http.request.side_effect = httpx.ConnectError("Connection refused")`. Assert raises `JellyfinConnectionError`. (file: `backend/tests/test_watch_history.py`)
-- [ ] 2.11 Add test `test_get_favorite_items_unexpected_status` — mock `mock_http.request` returning 500 response. Assert raises `JellyfinError`. (file: `backend/tests/test_watch_history.py`)
+- [x] 2.9 Add test `test_get_favorite_items_auth_error` — mock `mock_http.request` returning 401 response. Assert `get_favorite_items` raises `JellyfinAuthError`. (file: `backend/tests/test_watch_history.py`)
+- [x] 2.10 Add test `test_get_favorite_items_connection_error` — mock `mock_http.request.side_effect = httpx.ConnectError("Connection refused")`. Assert raises `JellyfinConnectionError`. (file: `backend/tests/test_watch_history.py`)
+- [x] 2.11 Add test `test_get_favorite_items_unexpected_status` — mock `mock_http.request` returning 500 response. Assert raises `JellyfinError`. (file: `backend/tests/test_watch_history.py`)
 
 ##### Validation
-- [ ] 2.12 Run `make lint` — all new code passes ruff. (file: N/A)
-- [ ] 2.13 Run `make test` — all unit tests from Tasks 1.0 and 2.0 pass. (file: N/A)
+- [x] 2.12 Run `make lint` — all new code passes ruff. (file: N/A)
+- [x] 2.13 Run `make test` — all unit tests from Tasks 1.0 and 2.0 pass. (file: N/A)
 
 ---
 
-### [ ] 3.0 Integration Tests + Final Validation
+### [x] 3.0 Integration Tests + Final Validation
 
 Add integration tests in `backend/tests/integration/` that call both `get_watched_items` and `get_favorite_items` against the real disposable Jellyfin instance. Run full validation suite.
 
@@ -140,11 +140,11 @@ Add integration tests in `backend/tests/integration/` that call both `get_watche
 #### 3.0 Tasks
 
 ##### Integration Tests (FR-3.7)
-- [ ] 3.1 Add `WatchHistoryEntry` import to `backend/tests/integration/test_jellyfin_client.py`. (file: `backend/tests/integration/test_jellyfin_client.py`)
-- [ ] 3.2 Add integration test `test_get_watched_items_returns_list` — authenticate as `TEST_USER_ALICE` via `jf_client.authenticate()`, call `get_watched_items(auth.access_token, auth.user_id)`, assert return type is `list`, assert all elements (if any) are `WatchHistoryEntry` instances. The test Jellyfin has no library content, so an empty list is the expected result. Mark with `@pytest.mark.integration`. (file: `backend/tests/integration/test_jellyfin_client.py`)
-- [ ] 3.3 Add integration test `test_get_favorite_items_returns_list` — same pattern as 3.2 but calling `get_favorite_items`. Assert return type is `list`, assert all elements (if any) are `WatchHistoryEntry` instances. Mark with `@pytest.mark.integration`. (file: `backend/tests/integration/test_jellyfin_client.py`)
+- [x] 3.1 Add `WatchHistoryEntry` import to `backend/tests/integration/test_jellyfin_client.py`. (file: `backend/tests/integration/test_jellyfin_client.py`)
+- [x] 3.2 Add integration test `test_get_watched_items_returns_list` — authenticate as `TEST_USER_ALICE` via `jf_client.authenticate()`, call `get_watched_items(auth.access_token, auth.user_id)`, assert return type is `list`, assert all elements (if any) are `WatchHistoryEntry` instances. The test Jellyfin has no library content, so an empty list is the expected result. Mark with `@pytest.mark.integration`. (file: `backend/tests/integration/test_jellyfin_client.py`)
+- [x] 3.3 Add integration test `test_get_favorite_items_returns_list` — same pattern as 3.2 but calling `get_favorite_items`. Assert return type is `list`, assert all elements (if any) are `WatchHistoryEntry` instances. Mark with `@pytest.mark.integration`. (file: `backend/tests/integration/test_jellyfin_client.py`)
 
 ##### Final Validation (FR-3.8, FR-3.9)
-- [ ] 3.4 Run `make test` — all unit tests from Tasks 1.0 and 2.0 still green. (file: N/A)
-- [ ] 3.5 Run `make lint` — all new and modified modules pass ruff. (file: N/A)
+- [x] 3.4 Run `make test` — all unit tests from Tasks 1.0 and 2.0 still green. (file: N/A)
+- [x] 3.5 Run `make lint` — all new and modified modules pass ruff. (file: N/A)
 - [ ] 3.6 Run `make test-integration` (requires `make jellyfin-up`) — both new integration tests pass. (file: N/A)

--- a/docs/specs/17-spec-watch-history-client/17-tasks-watch-history-client.md
+++ b/docs/specs/17-spec-watch-history-client/17-tasks-watch-history-client.md
@@ -1,0 +1,63 @@
+# 17 Tasks - Watch History Client
+
+## Tasks
+
+### [ ] 1.0 WatchHistoryEntry Model + get_watched_items with Unit Tests
+
+Add the `WatchHistoryEntry` frozen dataclass to `models.py` and the `get_watched_items` method (with `_parse_watch_entry` static parser) to `client.py`. Write the full unit test suite for both the model and the method in `test_watch_history.py`.
+
+**Scope:** FR-1.1 through FR-1.7 from Demoable Unit 1, plus FR-3.1 through FR-3.6 unit tests for `get_watched_items` and model tests from Demoable Unit 3.
+
+**Why tests are bundled here:** The spec is TDD-friendly — the proof artifacts for Unit 1 are all unit tests. Writing model + method + tests together produces a single demoable increment: "the watched-items path works end-to-end in unit tests."
+
+#### 1.0 Proof Artifact(s)
+- `make test` passes: `WatchHistoryEntry` is frozen/immutable, fields have correct types
+- `make test` passes: `get_watched_items` sends correct URL, query params (`IsPlayed=true`, `IncludeItemTypes=Movie`, `SortBy=DatePlayed`, `SortOrder=Descending`, `Recursive=true`), no `Fields` param
+- `make test` passes: `get_watched_items` parses mock Jellyfin JSON into `list[WatchHistoryEntry]` with correct field values including `last_played_date` as `datetime`
+- `make test` passes: `get_watched_items` auto-paginates (two-page mock: 200 + 50 items, all 250 returned)
+- `make test` passes: empty watch history returns `[]`; missing/empty `UserData` yields safe defaults (`last_played_date=None`, `play_count=0`, `is_favorite=False`)
+- `make test` passes: error paths — 401 raises `JellyfinAuthError`, transport error raises `JellyfinConnectionError`, 500 raises `JellyfinError`
+- `make lint` passes with all new code
+
+#### 1.0 Tasks
+TBD
+
+---
+
+### [ ] 2.0 get_favorite_items Method with Unit Tests
+
+Add the `get_favorite_items` method to `client.py`, reusing `_parse_watch_entry` from Task 1.0. Write the full unit test suite for the method in the same `test_watch_history.py` file.
+
+**Scope:** FR-2.1 through FR-2.6 from Demoable Unit 2, plus FR-3.1 through FR-3.6 unit tests for `get_favorite_items` from Demoable Unit 3.
+
+**Why this is separate from 1.0:** Different query parameters (no `SortBy`/`SortOrder`, `IsFavorite=true` instead of `IsPlayed=true`) and independent proof artifacts. Keeps PRs reviewable and each task independently demoable.
+
+#### 2.0 Proof Artifact(s)
+- `make test` passes: `get_favorite_items` sends correct URL, query params (`IsFavorite=true`, `IncludeItemTypes=Movie`, `Recursive=true`), no `SortBy`/`SortOrder`, no `Fields` param
+- `make test` passes: `get_favorite_items` parses mock response into `list[WatchHistoryEntry]` with correct field values
+- `make test` passes: `get_favorite_items` auto-paginates (two-page mock, all entries returned)
+- `make test` passes: empty favorites returns `[]`; unplayed favorite parsed correctly (`last_played_date=None`, `play_count=0`, `is_favorite=True`)
+- `make test` passes: error paths — 401 raises `JellyfinAuthError`, transport error raises `JellyfinConnectionError`, 500 raises `JellyfinError`
+- `make lint` passes with all new code
+
+#### 2.0 Tasks
+TBD
+
+---
+
+### [ ] 3.0 Integration Tests + Final Validation
+
+Add integration tests in `backend/tests/integration/` that call both `get_watched_items` and `get_favorite_items` against the real disposable Jellyfin instance. Run full validation suite.
+
+**Scope:** FR-3.7 through FR-3.9 from Demoable Unit 3 — the integration test and final lint/test gate.
+
+**Why this is a separate task:** Integration tests require `make jellyfin-up` and exercise the real Jellyfin API shape (empty-list response from a test instance with no library content). This is a distinct verification step from the mock-based unit tests in Tasks 1.0 and 2.0.
+
+#### 3.0 Proof Artifact(s)
+- `make test-integration` passes: `get_watched_items` returns `list[WatchHistoryEntry]` (empty list) against real Jellyfin
+- `make test-integration` passes: `get_favorite_items` returns `list[WatchHistoryEntry]` (empty list) against real Jellyfin
+- `make test` passes: all unit tests from Tasks 1.0 and 2.0 still green
+- `make lint` passes: all new modules clean
+
+#### 3.0 Tasks
+TBD

--- a/docs/specs/17-spec-watch-history-client/17-tasks-watch-history-client.md
+++ b/docs/specs/17-spec-watch-history-client/17-tasks-watch-history-client.md
@@ -1,5 +1,21 @@
 # 17 Tasks - Watch History Client
 
+## Relevant Files
+
+### Files to Create
+- `backend/tests/test_watch_history.py` — Unit tests for `WatchHistoryEntry`, `get_watched_items`, `get_favorite_items`
+
+### Files to Modify
+- `backend/app/jellyfin/models.py` — Add `WatchHistoryEntry` frozen dataclass
+- `backend/app/jellyfin/client.py` — Add `_parse_watch_entry`, `get_watched_items`, `get_favorite_items` methods to `JellyfinClient`
+- `backend/tests/integration/test_jellyfin_client.py` — Add integration tests for both new methods
+
+### Files to Reference (read-only)
+- `backend/app/jellyfin/errors.py` — `JellyfinAuthError`, `JellyfinConnectionError`, `JellyfinError`
+- `backend/app/permissions/service.py` — `_CacheEntry` dataclass pattern, `_fetch_permitted_ids` pagination pattern
+- `backend/tests/test_jellyfin_client.py` — `mock_http`, `jf_client`, `_FAKE_REQUEST` fixtures and test patterns
+- `backend/tests/integration/conftest.py` — `JellyfinInstance`, `jellyfin`, `test_users`, `TEST_USER_ALICE`, `TEST_USER_ALICE_PASS` fixtures
+
 ## Tasks
 
 ### [ ] 1.0 WatchHistoryEntry Model + get_watched_items with Unit Tests
@@ -20,7 +36,45 @@ Add the `WatchHistoryEntry` frozen dataclass to `models.py` and the `get_watched
 - `make lint` passes with all new code
 
 #### 1.0 Tasks
-TBD
+
+##### Model (FR-1.1)
+- [ ] 1.1 Add `WatchHistoryEntry` frozen dataclass to `models.py` with fields: `jellyfin_id: str`, `last_played_date: datetime | None`, `play_count: int`, `is_favorite: bool`. Use `@dataclass(frozen=True, slots=True)`. Add the `datetime` import at the top of the file. (file: `backend/app/jellyfin/models.py`)
+- [ ] 1.2 Add import of `WatchHistoryEntry` to the `from app.jellyfin.models import ...` line in `client.py`. (file: `backend/app/jellyfin/client.py`)
+
+##### Parser (FR-1.5)
+- [ ] 1.3 Add `_parse_watch_entry` static method to `JellyfinClient` that extracts `jellyfin_id` from `item["Id"]`, `last_played_date` from `item["UserData"]["LastPlayedDate"]` (parsed via `datetime.fromisoformat()`, `None` if absent/null), `play_count` from `item["UserData"]["PlayCount"]` (default `0`), and `is_favorite` from `item["UserData"]["IsFavorite"]` (default `False`). Handle missing `UserData` key and empty `UserData` dict gracefully. Add `from datetime import datetime` import. (file: `backend/app/jellyfin/client.py`)
+
+##### Method (FR-1.2 through FR-1.4, FR-1.6, FR-1.7)
+- [ ] 1.4 Add `get_watched_items(self, token: str, user_id: str) -> list[WatchHistoryEntry]` method to `JellyfinClient`. Build params dict with `IsPlayed=true`, `IncludeItemTypes=Movie`, `SortBy=DatePlayed`, `SortOrder=Descending`, `Recursive=true`, `StartIndex`, and `Limit=200`. Do NOT include a `Fields` parameter. (file: `backend/app/jellyfin/client.py`)
+- [ ] 1.5 Implement auto-pagination loop inside `get_watched_items`: start at `StartIndex=0`, call `_request("GET", f"/Users/{user_id}/Items", token=token, params=params)`, parse response via `_parse_response` with a lambda that extracts `Items` list and `TotalRecordCount`, map each item through `_parse_watch_entry`, increment `StartIndex` by items received, stop when `StartIndex >= TotalRecordCount` or page is empty. Collect all entries into a single `list[WatchHistoryEntry]`. (file: `backend/app/jellyfin/client.py`)
+- [ ] 1.6 Add DEBUG logging inside the pagination loop: `logger.debug("watched_items_fetch page=%d items=%d", page_number, len(items))`. Never log token, user_id paired with item data, or any PII. (file: `backend/app/jellyfin/client.py`)
+
+##### Unit Tests — Model
+- [ ] 1.7 Create `backend/tests/test_watch_history.py` with imports: `WatchHistoryEntry` from `models`, `JellyfinClient` from `client`, `JellyfinAuthError`/`JellyfinConnectionError`/`JellyfinError` from `errors`, `AsyncMock` from `unittest.mock`, `httpx`, `pytest`. Add `mock_http` and `jf_client` fixtures matching the pattern in `test_jellyfin_client.py`. Add `_FAKE_REQUEST = httpx.Request("GET", "http://fake")`. (file: `backend/tests/test_watch_history.py`)
+- [ ] 1.8 Add test `test_watch_history_entry_is_frozen` — create a `WatchHistoryEntry`, assert assigning to `jellyfin_id` raises `dataclasses.FrozenInstanceError`. (file: `backend/tests/test_watch_history.py`)
+- [ ] 1.9 Add test `test_watch_history_entry_fields_and_types` — create a `WatchHistoryEntry` with all fields populated (including a real `datetime` for `last_played_date`), assert each field value and type. Verify `last_played_date=None` is accepted. (file: `backend/tests/test_watch_history.py`)
+
+##### Unit Tests — get_watched_items Success Path
+- [ ] 1.10 Add test `test_get_watched_items_sends_correct_request` — mock `mock_http.request` to return a 200 response with `{"Items": [], "TotalRecordCount": 0}`. Call `get_watched_items("tok-123", "uid-1")`. Inspect `mock_http.request.call_args`: assert method is `GET`, URL contains `/Users/uid-1/Items`, params include `IsPlayed=true`, `IncludeItemTypes=Movie`, `SortBy=DatePlayed`, `SortOrder=Descending`, `Recursive=true`. Assert `Fields` is NOT in params. Assert `Token=tok-123` is in the Authorization header. (file: `backend/tests/test_watch_history.py`)
+- [ ] 1.11 Add test `test_get_watched_items_parses_response` — mock response with 2 items including realistic `UserData` objects (one with `LastPlayedDate: "2025-12-15T20:30:00.0000000Z"`, `PlayCount: 3`, `IsFavorite: true`; one with `LastPlayedDate: "2025-11-01T10:00:00.0000000Z"`, `PlayCount: 1`, `IsFavorite: false`). Assert returned list has 2 `WatchHistoryEntry` objects with correct field values. Assert `last_played_date` is a `datetime` instance. (file: `backend/tests/test_watch_history.py`)
+
+##### Unit Tests — Pagination
+- [ ] 1.12 Add test `test_get_watched_items_paginates_two_pages` — mock `mock_http.request` with `side_effect` returning two sequential responses: page 1 with 200 items and `TotalRecordCount=250`, page 2 with 50 items and `TotalRecordCount=250`. Assert returned list has 250 entries. Assert `mock_http.request.call_count == 2`. Assert second call's params have `StartIndex=200`. (file: `backend/tests/test_watch_history.py`)
+
+##### Unit Tests — Empty / Edge Cases
+- [ ] 1.13 Add test `test_get_watched_items_empty_history` — mock response with `{"Items": [], "TotalRecordCount": 0}`. Assert returns empty list `[]`. (file: `backend/tests/test_watch_history.py`)
+- [ ] 1.14 Add test `test_get_watched_items_missing_user_data` — mock response with an item that has no `UserData` key at all. Assert the parsed entry has `last_played_date=None`, `play_count=0`, `is_favorite=False`. (file: `backend/tests/test_watch_history.py`)
+- [ ] 1.15 Add test `test_get_watched_items_empty_user_data` — mock response with an item where `UserData` is `{}`. Assert same safe defaults as 1.14. (file: `backend/tests/test_watch_history.py`)
+- [ ] 1.16 Add test `test_get_watched_items_null_last_played_date` — mock response with `UserData` present but `LastPlayedDate` is `null`. Assert `last_played_date=None`. (file: `backend/tests/test_watch_history.py`)
+
+##### Unit Tests — Error Paths
+- [ ] 1.17 Add test `test_get_watched_items_auth_error` — mock `mock_http.request` returning 401 response. Assert `get_watched_items` raises `JellyfinAuthError`. (file: `backend/tests/test_watch_history.py`)
+- [ ] 1.18 Add test `test_get_watched_items_connection_error` — mock `mock_http.request.side_effect = httpx.ConnectError("Connection refused")`. Assert raises `JellyfinConnectionError`. (file: `backend/tests/test_watch_history.py`)
+- [ ] 1.19 Add test `test_get_watched_items_unexpected_status` — mock `mock_http.request` returning 500 response. Assert raises `JellyfinError`. (file: `backend/tests/test_watch_history.py`)
+
+##### Validation
+- [ ] 1.20 Run `make lint` — all new code in `models.py`, `client.py`, and `test_watch_history.py` passes ruff. (file: N/A)
+- [ ] 1.21 Run `make test` — all new unit tests pass. (file: N/A)
 
 ---
 
@@ -41,7 +95,31 @@ Add the `get_favorite_items` method to `client.py`, reusing `_parse_watch_entry`
 - `make lint` passes with all new code
 
 #### 2.0 Tasks
-TBD
+
+##### Method (FR-2.1 through FR-2.6)
+- [ ] 2.1 Add `get_favorite_items(self, token: str, user_id: str) -> list[WatchHistoryEntry]` method to `JellyfinClient`. Build params dict with `IsFavorite=true`, `IncludeItemTypes=Movie`, `Recursive=true`, `StartIndex`, and `Limit=200`. Do NOT include `SortBy`, `SortOrder`, or `Fields` parameters. (file: `backend/app/jellyfin/client.py`)
+- [ ] 2.2 Implement auto-pagination loop inside `get_favorite_items` using the same pattern as `get_watched_items` (1.5): call `_request`, parse via `_parse_response`, map items through `_parse_watch_entry`, increment `StartIndex`, stop when done. Reuse the same `_parse_watch_entry` static method from Task 1.3. (file: `backend/app/jellyfin/client.py`)
+- [ ] 2.3 Add DEBUG logging inside the pagination loop: `logger.debug("favorite_items_fetch page=%d items=%d", page_number, len(items))`. Same PII discipline as 1.6. (file: `backend/app/jellyfin/client.py`)
+
+##### Unit Tests — get_favorite_items Success Path
+- [ ] 2.4 Add test `test_get_favorite_items_sends_correct_request` — mock `mock_http.request` to return a 200 response with `{"Items": [], "TotalRecordCount": 0}`. Call `get_favorite_items("tok-123", "uid-1")`. Inspect `mock_http.request.call_args`: assert method is `GET`, URL contains `/Users/uid-1/Items`, params include `IsFavorite=true`, `IncludeItemTypes=Movie`, `Recursive=true`. Assert `SortBy` is NOT in params. Assert `SortOrder` is NOT in params. Assert `Fields` is NOT in params. Assert `Token=tok-123` is in the Authorization header. (file: `backend/tests/test_watch_history.py`)
+- [ ] 2.5 Add test `test_get_favorite_items_parses_response` — mock response with 2 items including `UserData` with `IsFavorite: true`. Assert returned list has 2 `WatchHistoryEntry` objects with correct field values. (file: `backend/tests/test_watch_history.py`)
+
+##### Unit Tests — Pagination
+- [ ] 2.6 Add test `test_get_favorite_items_paginates_two_pages` — mock `mock_http.request` with `side_effect` returning two sequential responses: page 1 with 200 items and `TotalRecordCount=250`, page 2 with 50 items and `TotalRecordCount=250`. Assert returned list has 250 entries. Assert `mock_http.request.call_count == 2`. (file: `backend/tests/test_watch_history.py`)
+
+##### Unit Tests — Empty / Edge Cases
+- [ ] 2.7 Add test `test_get_favorite_items_empty_favorites` — mock response with `{"Items": [], "TotalRecordCount": 0}`. Assert returns empty list `[]`. (file: `backend/tests/test_watch_history.py`)
+- [ ] 2.8 Add test `test_get_favorite_items_unplayed_favorite` — mock response with one item where `UserData` has `IsFavorite: true`, `Played: false`, no `LastPlayedDate`, `PlayCount: 0`. Assert parsed entry has `is_favorite=True`, `last_played_date=None`, `play_count=0`. (file: `backend/tests/test_watch_history.py`)
+
+##### Unit Tests — Error Paths
+- [ ] 2.9 Add test `test_get_favorite_items_auth_error` — mock `mock_http.request` returning 401 response. Assert `get_favorite_items` raises `JellyfinAuthError`. (file: `backend/tests/test_watch_history.py`)
+- [ ] 2.10 Add test `test_get_favorite_items_connection_error` — mock `mock_http.request.side_effect = httpx.ConnectError("Connection refused")`. Assert raises `JellyfinConnectionError`. (file: `backend/tests/test_watch_history.py`)
+- [ ] 2.11 Add test `test_get_favorite_items_unexpected_status` — mock `mock_http.request` returning 500 response. Assert raises `JellyfinError`. (file: `backend/tests/test_watch_history.py`)
+
+##### Validation
+- [ ] 2.12 Run `make lint` — all new code passes ruff. (file: N/A)
+- [ ] 2.13 Run `make test` — all unit tests from Tasks 1.0 and 2.0 pass. (file: N/A)
 
 ---
 
@@ -60,4 +138,13 @@ Add integration tests in `backend/tests/integration/` that call both `get_watche
 - `make lint` passes: all new modules clean
 
 #### 3.0 Tasks
-TBD
+
+##### Integration Tests (FR-3.7)
+- [ ] 3.1 Add `WatchHistoryEntry` import to `backend/tests/integration/test_jellyfin_client.py`. (file: `backend/tests/integration/test_jellyfin_client.py`)
+- [ ] 3.2 Add integration test `test_get_watched_items_returns_list` — authenticate as `TEST_USER_ALICE` via `jf_client.authenticate()`, call `get_watched_items(auth.access_token, auth.user_id)`, assert return type is `list`, assert all elements (if any) are `WatchHistoryEntry` instances. The test Jellyfin has no library content, so an empty list is the expected result. Mark with `@pytest.mark.integration`. (file: `backend/tests/integration/test_jellyfin_client.py`)
+- [ ] 3.3 Add integration test `test_get_favorite_items_returns_list` — same pattern as 3.2 but calling `get_favorite_items`. Assert return type is `list`, assert all elements (if any) are `WatchHistoryEntry` instances. Mark with `@pytest.mark.integration`. (file: `backend/tests/integration/test_jellyfin_client.py`)
+
+##### Final Validation (FR-3.8, FR-3.9)
+- [ ] 3.4 Run `make test` — all unit tests from Tasks 1.0 and 2.0 still green. (file: N/A)
+- [ ] 3.5 Run `make lint` — all new and modified modules pass ruff. (file: N/A)
+- [ ] 3.6 Run `make test-integration` (requires `make jellyfin-up`) — both new integration tests pass. (file: N/A)


### PR DESCRIPTION
## Summary
- Add `WatchHistoryEntry` frozen dataclass to `models.py` — slim DTO with `jellyfin_id`, `last_played_date`, `play_count`, `is_favorite`
- Add `get_watched_items()` and `get_favorite_items()` methods to `JellyfinClient` — auto-paginating, no hard cap, minimal Jellyfin fields
- Add `_parse_watch_entry()` static parser with graceful handling of missing/null/empty `UserData`
- 20 unit tests, 2 integration tests (empty-list verification against real Jellyfin)

## Design Decisions (Council-reviewed)
- **Slim DTO** over LibraryItem — library-scoped vs user-scoped data separation (Granny + Vimes)
- **Fetch all, no limit** — hard cap would be a correctness bug for ranking (Granny)
- **No Fields parameter** — UserData included by default, full metadata already in local SQLite
- **On JellyfinClient** — thin HTTP wrappers, service layer deferred to #119

## Spec Artifacts
- Spec: `docs/specs/17-spec-watch-history-client/17-spec-watch-history-client.md`
- Tasks: `docs/specs/17-spec-watch-history-client/17-tasks-watch-history-client.md`
- Proofs: `docs/specs/17-spec-watch-history-client/17-proofs/`

## Test plan
- [x] `make test` — 20/20 new unit tests passing
- [x] `make lint` — zero ruff violations
- [ ] `make test-integration` — requires `make jellyfin-up` (integration tests verify empty-list shape against real Jellyfin)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)