### PR TITLE
feat(pwa): install banner triggered by first chat exchange (Spec 21)

### DIFF
--- a/frontend/src/app/(protected)/layout.tsx
+++ b/frontend/src/app/(protected)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getProtectedLayoutData } from "@/lib/auth/get-protected-layout-data";
 import { AuthProvider } from "@/lib/auth/auth-context";
+import { InstallBanner } from "@/components/install-banner";
 
 export default async function ProtectedLayout({
   children,
@@ -20,6 +21,7 @@ export default async function ProtectedLayout({
       serverName={result.user.serverName}
     >
       {children}
+      <InstallBanner />
     </AuthProvider>
   );
 }

--- a/frontend/src/hooks/__tests__/use-chat-trigger.test.ts
+++ b/frontend/src/hooks/__tests__/use-chat-trigger.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useChat } from "../use-chat";
 import type { SSEEvent } from "@/lib/api/types";
@@ -61,12 +61,11 @@ describe("useChat — install banner trigger", () => {
 
     const { result } = renderHook(() => useChat());
 
-    await act(async () => {
+    act(() => {
       result.current.sendMessage("recommend something");
-      // Allow microtasks to flush (stream processing)
-      await vi.waitFor(() => {
-        expect(result.current.isStreaming).toBe(false);
-      });
+    });
+    await waitFor(() => {
+      expect(result.current.isStreaming).toBe(false);
     });
 
     expect(localStorage.getItem(TRIGGERED_KEY)).toBe("true");
@@ -83,11 +82,11 @@ describe("useChat — install banner trigger", () => {
 
     const { result } = renderHook(() => useChat());
 
-    await act(async () => {
+    act(() => {
       result.current.sendMessage("recommend something");
-      await vi.waitFor(() => {
-        expect(result.current.isStreaming).toBe(false);
-      });
+    });
+    await waitFor(() => {
+      expect(result.current.isStreaming).toBe(false);
     });
 
     expect(listener).toHaveBeenCalledOnce();
@@ -104,11 +103,11 @@ describe("useChat — install banner trigger", () => {
 
     const { result } = renderHook(() => useChat());
 
-    await act(async () => {
+    act(() => {
       result.current.sendMessage("first message");
-      await vi.waitFor(() => {
-        expect(result.current.isStreaming).toBe(false);
-      });
+    });
+    await waitFor(() => {
+      expect(result.current.isStreaming).toBe(false);
     });
 
     expect(localStorage.getItem(TRIGGERED_KEY)).toBe("true");
@@ -122,11 +121,11 @@ describe("useChat — install banner trigger", () => {
       { type: "done" },
     ]);
 
-    await act(async () => {
+    act(() => {
       result.current.sendMessage("second message");
-      await vi.waitFor(() => {
-        expect(result.current.isStreaming).toBe(false);
-      });
+    });
+    await waitFor(() => {
+      expect(result.current.isStreaming).toBe(false);
     });
 
     // setItem should NOT have been called with the trigger key
@@ -150,11 +149,11 @@ describe("useChat — install banner trigger", () => {
 
     const { result } = renderHook(() => useChat());
 
-    await act(async () => {
+    act(() => {
       result.current.sendMessage("recommend something");
-      await vi.waitFor(() => {
-        expect(result.current.isStreaming).toBe(false);
-      });
+    });
+    await waitFor(() => {
+      expect(result.current.isStreaming).toBe(false);
     });
 
     expect(localStorage.getItem(TRIGGERED_KEY)).toBeNull();
@@ -165,11 +164,11 @@ describe("useChat — install banner trigger", () => {
 
     const { result } = renderHook(() => useChat());
 
-    await act(async () => {
+    act(() => {
       result.current.sendMessage("recommend something");
-      await vi.waitFor(() => {
-        expect(result.current.isStreaming).toBe(false);
-      });
+    });
+    await waitFor(() => {
+      expect(result.current.isStreaming).toBe(false);
     });
 
     expect(localStorage.getItem(TRIGGERED_KEY)).toBeNull();

--- a/frontend/src/hooks/__tests__/use-chat-trigger.test.ts
+++ b/frontend/src/hooks/__tests__/use-chat-trigger.test.ts
@@ -1,0 +1,178 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useChat } from "../use-chat";
+import type { SSEEvent } from "@/lib/api/types";
+
+// Mock the chat-stream module
+vi.mock("@/lib/api/chat-stream", () => ({
+  sendChatMessage: vi.fn(),
+  parseSSEStream: vi.fn(),
+}));
+
+// Mock the client module (for clearHistory's apiDelete)
+vi.mock("@/lib/api/client", () => ({
+  apiDelete: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { sendChatMessage, parseSSEStream } from "@/lib/api/chat-stream";
+
+const TRIGGERED_KEY = "pwa-chat-triggered";
+
+/**
+ * Helper: create a mock async generator from an array of SSE events.
+ */
+async function* mockSSEGenerator(events: SSEEvent[]): AsyncGenerator<SSEEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+/**
+ * Helper: set up sendChatMessage + parseSSEStream mocks for a given event sequence.
+ */
+function mockStreamResponse(events: SSEEvent[]) {
+  const fakeStream = {} as ReadableStream<Uint8Array>;
+  vi.mocked(sendChatMessage).mockResolvedValue(fakeStream);
+  vi.mocked(parseSSEStream).mockReturnValue(mockSSEGenerator(events));
+}
+
+describe("useChat — install banner trigger", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    // Mock crypto.randomUUID for stable message IDs
+    vi.stubGlobal(
+      "crypto",
+      Object.assign({}, globalThis.crypto, {
+        randomUUID: vi
+          .fn()
+          .mockReturnValueOnce("user-1")
+          .mockReturnValueOnce("assistant-1")
+          .mockReturnValueOnce("user-2")
+          .mockReturnValueOnce("assistant-2"),
+      })
+    );
+  });
+
+  it("writes trigger flag to localStorage on first successful stream", async () => {
+    mockStreamResponse([
+      { type: "text", content: "Great movie!" },
+      { type: "done" },
+    ]);
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      result.current.sendMessage("recommend something");
+      // Allow microtasks to flush (stream processing)
+      await vi.waitFor(() => {
+        expect(result.current.isStreaming).toBe(false);
+      });
+    });
+
+    expect(localStorage.getItem(TRIGGERED_KEY)).toBe("true");
+  });
+
+  it("dispatches pwa-trigger DOM event on first successful stream", async () => {
+    mockStreamResponse([
+      { type: "text", content: "Great movie!" },
+      { type: "done" },
+    ]);
+
+    const listener = vi.fn();
+    window.addEventListener("pwa-trigger", listener);
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      result.current.sendMessage("recommend something");
+      await vi.waitFor(() => {
+        expect(result.current.isStreaming).toBe(false);
+      });
+    });
+
+    expect(listener).toHaveBeenCalledOnce();
+
+    window.removeEventListener("pwa-trigger", listener);
+  });
+
+  it("does NOT write flag again on subsequent successful streams", async () => {
+    // First stream
+    mockStreamResponse([
+      { type: "text", content: "Great movie!" },
+      { type: "done" },
+    ]);
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      result.current.sendMessage("first message");
+      await vi.waitFor(() => {
+        expect(result.current.isStreaming).toBe(false);
+      });
+    });
+
+    expect(localStorage.getItem(TRIGGERED_KEY)).toBe("true");
+
+    // Spy on setItem AFTER the first write
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+
+    // Second stream
+    mockStreamResponse([
+      { type: "text", content: "Another recommendation!" },
+      { type: "done" },
+    ]);
+
+    await act(async () => {
+      result.current.sendMessage("second message");
+      await vi.waitFor(() => {
+        expect(result.current.isStreaming).toBe(false);
+      });
+    });
+
+    // setItem should NOT have been called with the trigger key
+    const triggerCalls = setItemSpy.mock.calls.filter(
+      ([key]) => key === TRIGGERED_KEY
+    );
+    expect(triggerCalls).toHaveLength(0);
+
+    setItemSpy.mockRestore();
+  });
+
+  it("does NOT write flag when stream ends with an error event", async () => {
+    mockStreamResponse([
+      { type: "text", content: "partial..." },
+      {
+        type: "error",
+        code: "ollama_unavailable",
+        message: "Ollama is down",
+      },
+    ]);
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      result.current.sendMessage("recommend something");
+      await vi.waitFor(() => {
+        expect(result.current.isStreaming).toBe(false);
+      });
+    });
+
+    expect(localStorage.getItem(TRIGGERED_KEY)).toBeNull();
+  });
+
+  it("does NOT write flag when stream completes with empty content", async () => {
+    mockStreamResponse([{ type: "done" }]);
+
+    const { result } = renderHook(() => useChat());
+
+    await act(async () => {
+      result.current.sendMessage("recommend something");
+      await vi.waitFor(() => {
+        expect(result.current.isStreaming).toBe(false);
+      });
+    });
+
+    expect(localStorage.getItem(TRIGGERED_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/hooks/__tests__/use-chat-trigger.test.ts
+++ b/frontend/src/hooks/__tests__/use-chat-trigger.test.ts
@@ -15,8 +15,7 @@ vi.mock("@/lib/api/client", () => ({
 }));
 
 import { sendChatMessage, parseSSEStream } from "@/lib/api/chat-stream";
-
-const TRIGGERED_KEY = "pwa-chat-triggered";
+import { TRIGGERED_KEY } from "@/hooks/use-install-prompt";
 
 /**
  * Helper: create a mock async generator from an array of SSE events.

--- a/frontend/src/hooks/__tests__/use-install-prompt.test.ts
+++ b/frontend/src/hooks/__tests__/use-install-prompt.test.ts
@@ -56,6 +56,7 @@ describe("useInstallPrompt", () => {
 
   describe("Android / beforeinstallprompt", () => {
     it("captures beforeinstallprompt event and enables prompt", async () => {
+      localStorage.setItem("pwa-chat-triggered", "true");
       const { result } = renderHook(() => useInstallPrompt());
 
       // Before event fires, platform is unsupported (no proof of Android yet)
@@ -78,6 +79,7 @@ describe("useInstallPrompt", () => {
     });
 
     it("calls prompt() on the deferred event", async () => {
+      localStorage.setItem("pwa-chat-triggered", "true");
       const { result } = renderHook(() => useInstallPrompt());
 
       const promptFn = vi.fn().mockResolvedValue(undefined);
@@ -103,6 +105,7 @@ describe("useInstallPrompt", () => {
 
   describe("iOS Safari detection", () => {
     it("detects iOS Safari and sets platform to ios", () => {
+      localStorage.setItem("pwa-chat-triggered", "true");
       mockUserAgent(
         "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
       );
@@ -115,6 +118,7 @@ describe("useInstallPrompt", () => {
     });
 
     it("detects iPad with maxTouchPoints as iOS", () => {
+      localStorage.setItem("pwa-chat-triggered", "true");
       mockUserAgent(
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
       );
@@ -140,6 +144,7 @@ describe("useInstallPrompt", () => {
 
   describe("dismissal persistence", () => {
     it("persists dismissal to localStorage", async () => {
+      localStorage.setItem("pwa-chat-triggered", "true");
       mockUserAgent(
         "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
       );
@@ -181,6 +186,70 @@ describe("useInstallPrompt", () => {
 
       expect(result.current.canPrompt).toBe(false);
       expect(result.current.platform).toBe("unsupported");
+    });
+  });
+
+  describe("chat trigger gating", () => {
+    it("canPrompt is false on iOS Safari when trigger flag is absent", () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+      );
+      mockPlatform("iPhone");
+
+      const { result } = renderHook(() => useInstallPrompt());
+
+      expect(result.current.platform).toBe("ios");
+      expect(result.current.canPrompt).toBe(false);
+    });
+
+    it("canPrompt is true on iOS Safari when trigger flag is present", () => {
+      localStorage.setItem("pwa-chat-triggered", "true");
+      mockUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+      );
+      mockPlatform("iPhone");
+
+      const { result } = renderHook(() => useInstallPrompt());
+
+      expect(result.current.platform).toBe("ios");
+      expect(result.current.canPrompt).toBe(true);
+    });
+
+    it("canPrompt is false on Android when beforeinstallprompt fired but trigger flag is absent", async () => {
+      const { result } = renderHook(() => useInstallPrompt());
+
+      const mockEvent = new Event("beforeinstallprompt");
+      Object.assign(mockEvent, {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        userChoice: Promise.resolve({ outcome: "dismissed" as const }),
+      });
+
+      await act(async () => {
+        window.dispatchEvent(mockEvent);
+      });
+
+      expect(result.current.platform).toBe("android");
+      expect(result.current.canPrompt).toBe(false);
+    });
+
+    it("canPrompt transitions to true when pwa-trigger DOM event fires", async () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+      );
+      mockPlatform("iPhone");
+
+      const { result } = renderHook(() => useInstallPrompt());
+
+      // Before trigger — should be false
+      expect(result.current.canPrompt).toBe(false);
+
+      // Simulate chat page writing the flag and dispatching the event
+      localStorage.setItem("pwa-chat-triggered", "true");
+      await act(async () => {
+        window.dispatchEvent(new Event("pwa-trigger"));
+      });
+
+      expect(result.current.canPrompt).toBe(true);
     });
   });
 });

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -203,6 +203,17 @@ export function useChat(): UseChatReturn {
     };
   }, [stopFlushTimer]);
 
+  /** Write the PWA install trigger flag once on first successful chat exchange. */
+  function writeTriggerIfNeeded(): void {
+    if (!bufferRef.current || localStorage.getItem(TRIGGERED_KEY)) return;
+    try {
+      localStorage.setItem(TRIGGERED_KEY, "true");
+      window.dispatchEvent(new Event("pwa-trigger"));
+    } catch {
+      /* storage unavailable */
+    }
+  }
+
   const processStream = useCallback(
     async (
       userMessageId: string,
@@ -254,14 +265,7 @@ export function useChat(): UseChatReturn {
                   content: bufferRef.current,
                 },
               });
-              if (bufferRef.current && !localStorage.getItem(TRIGGERED_KEY)) {
-                try {
-                  localStorage.setItem(TRIGGERED_KEY, "true");
-                  window.dispatchEvent(new Event("pwa-trigger"));
-                } catch {
-                  /* storage unavailable */
-                }
-              }
+              writeTriggerIfNeeded();
               isStreamingRef.current = false;
               return;
             case "error":
@@ -298,14 +302,7 @@ export function useChat(): UseChatReturn {
             content: bufferRef.current,
           },
         });
-        if (bufferRef.current && !localStorage.getItem(TRIGGERED_KEY)) {
-          try {
-            localStorage.setItem(TRIGGERED_KEY, "true");
-            window.dispatchEvent(new Event("pwa-trigger"));
-          } catch {
-            /* storage unavailable */
-          }
-        }
+        writeTriggerIfNeeded();
         isStreamingRef.current = false;
       } catch (err) {
         stopFlushTimer();

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { sendChatMessage, parseSSEStream } from "@/lib/api/chat-stream";
 import { apiDelete } from "@/lib/api/client";
+import { TRIGGERED_KEY } from "@/hooks/use-install-prompt";
 import type {
   ChatMessage,
   SearchResultItem,
@@ -253,6 +254,14 @@ export function useChat(): UseChatReturn {
                   content: bufferRef.current,
                 },
               });
+              if (bufferRef.current && !localStorage.getItem(TRIGGERED_KEY)) {
+                try {
+                  localStorage.setItem(TRIGGERED_KEY, "true");
+                  window.dispatchEvent(new Event("pwa-trigger"));
+                } catch {
+                  /* storage unavailable */
+                }
+              }
               isStreamingRef.current = false;
               return;
             case "error":
@@ -289,6 +298,14 @@ export function useChat(): UseChatReturn {
             content: bufferRef.current,
           },
         });
+        if (bufferRef.current && !localStorage.getItem(TRIGGERED_KEY)) {
+          try {
+            localStorage.setItem(TRIGGERED_KEY, "true");
+            window.dispatchEvent(new Event("pwa-trigger"));
+          } catch {
+            /* storage unavailable */
+          }
+        }
         isStreamingRef.current = false;
       } catch (err) {
         stopFlushTimer();

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -205,8 +205,9 @@ export function useChat(): UseChatReturn {
 
   /** Write the PWA install trigger flag once on first successful chat exchange. */
   function writeTriggerIfNeeded(): void {
-    if (!bufferRef.current || localStorage.getItem(TRIGGERED_KEY)) return;
+    if (!bufferRef.current) return;
     try {
+      if (localStorage.getItem(TRIGGERED_KEY) === "true") return;
       localStorage.setItem(TRIGGERED_KEY, "true");
       window.dispatchEvent(new Event("pwa-trigger"));
     } catch {

--- a/frontend/src/hooks/use-install-prompt.ts
+++ b/frontend/src/hooks/use-install-prompt.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 const DISMISSED_KEY = "pwa-install-dismissed";
+export const TRIGGERED_KEY = "pwa-chat-triggered";
 
 type Platform = "android" | "ios" | "unsupported";
 
@@ -51,12 +52,22 @@ function isDismissed(): boolean {
   }
 }
 
+function isTriggered(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return localStorage.getItem(TRIGGERED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
 export function useInstallPrompt(): UseInstallPromptReturn {
   const [deferredPrompt, setDeferredPrompt] =
     useState<BeforeInstallPromptEvent | null>(null);
   const [dismissed, setDismissed] = useState(
     () => isStandalone() || isDismissed()
   );
+  const [triggered, setTriggered] = useState(() => isTriggered());
 
   // Platform is derived: iOS detected statically, Android confirmed by event
   const platform = useMemo<Platform>(() => {
@@ -64,6 +75,12 @@ export function useInstallPrompt(): UseInstallPromptReturn {
     if (deferredPrompt) return "android";
     return "unsupported";
   }, [deferredPrompt]);
+
+  useEffect(() => {
+    const handler = () => setTriggered(true);
+    window.addEventListener("pwa-trigger", handler);
+    return () => window.removeEventListener("pwa-trigger", handler);
+  }, []);
 
   useEffect(() => {
     if (dismissed || detectIos()) return;
@@ -102,7 +119,7 @@ export function useInstallPrompt(): UseInstallPromptReturn {
   }, []);
 
   const canPrompt =
-    !dismissed && (platform === "ios" || deferredPrompt !== null);
+    !dismissed && triggered && (platform === "ios" || deferredPrompt !== null);
 
   return { canPrompt, platform, prompt, dismiss };
 }


### PR DESCRIPTION
## Summary

- **Gate install banner on chat trigger**: `useInstallPrompt` now requires a `pwa-chat-triggered` localStorage flag before `canPrompt` is true — the banner never appears until the user has completed their first successful chat exchange
- **Write trigger from chat hook**: `useChat` sets the flag and dispatches a `pwa-trigger` DOM event after the first streaming response completes with non-empty content (write-once, error-safe)
- **Mount banner in protected layout**: `<InstallBanner />` rendered inside `<AuthProvider>` — banner's own `canPrompt` logic controls visibility

## Details

Implements Spec 21 (Install Banner Trigger). The PWA install banner was already built (Spec 14) but not mounted — it would have appeared immediately on supported platforms. This PR gates it behind a successful chat exchange so users see the banner only after experiencing the app's value.

**Key design decisions:**
- `TRIGGERED_KEY` constant shared between `use-install-prompt.ts` and `use-chat.ts` (single source of truth)
- Trigger flag is write-once: guarded by `!localStorage.getItem(TRIGGERED_KEY)` before writing
- Both the normal `done` event path and the fallback "stream ended without DONE" path write the trigger
- Error paths and empty-content completions do NOT trigger the banner

## Test plan

- [x] 4 new tests in `use-install-prompt.test.ts` for trigger gating behavior (12 total, all pass)
- [x] 5 new tests in `use-chat-trigger.test.ts` for trigger write behavior
- [x] Full frontend suite: 162/162 tests pass across 21 files
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [ ] Manual: Chrome DevTools mobile emulation — banner appears after first chat, persists on refresh, dismissal persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)