### PR TITLE
feat(test): pipeline validation with real Ollama inference (Spec 23)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-full dev-ui build test lint ci clean logs health hooks jellyfin-up jellyfin-down test-integration test-integration-full test-injection validate-pipeline
+.PHONY: dev dev-full dev-ui build test lint ci clean logs health hooks jellyfin-up jellyfin-down test-integration test-integration-full test-injection validate-pipeline pipeline-up pipeline-down
 
 # Default dev target — full stack with Ollama
 dev: dev-full
@@ -82,10 +82,27 @@ test-integration-full:
 # Pipeline validation (requires Ollama running locally)
 # ---------------------------------------------------------------------------
 
+# Start pipeline infrastructure: Jellyfin test container + Ollama health check
+# Ollama must be started separately (ollama serve, or Docker sidecar on Linux)
+pipeline-up:
+	@$(MAKE) jellyfin-up
+	@echo "Checking Ollama at http://localhost:11434/ ..."
+	@curl -sf http://localhost:11434/ > /dev/null 2>&1 \
+		&& echo "Ollama is running" \
+		|| { echo "WARNING: Ollama not reachable at http://localhost:11434/"; \
+		     echo "  macOS:  ollama serve"; \
+		     echo "  Linux:  docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d ollama"; \
+		     echo "Start Ollama, then run: make validate-pipeline"; exit 1; }
+	@echo "Pipeline infrastructure ready — run: make validate-pipeline"
+
+# Stop pipeline infrastructure
+pipeline-down:
+	@$(MAKE) jellyfin-down
+
 # Full RAG pipeline validation: embed → search → chat against real Ollama
 # Checks Ollama health BEFORE starting Jellyfin to fail fast
 validate-pipeline:
-	@curl -sf http://localhost:11434/ > /dev/null 2>&1 || { echo "ERROR: Ollama not reachable at http://localhost:11434/"; echo "Start Ollama with: ollama serve"; exit 1; }
+	@curl -sf http://localhost:11434/ > /dev/null 2>&1 || { echo "ERROR: Ollama not reachable at http://localhost:11434/"; echo "Start Ollama first, or run: make pipeline-up"; exit 1; }
 	@$(MAKE) jellyfin-up && cd backend && JELLYFIN_TEST_URL=http://localhost:8096 uv run pytest -m pipeline -v ; ret=$$?; cd .. && $(MAKE) jellyfin-down; exit $$ret
 
 # ---------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-full dev-ui build test lint ci clean logs health hooks jellyfin-up jellyfin-down test-integration test-integration-full test-injection
+.PHONY: dev dev-full dev-ui build test lint ci clean logs health hooks jellyfin-up jellyfin-down test-integration test-integration-full test-injection validate-pipeline
 
 # Default dev target — full stack with Ollama
 dev: dev-full
@@ -17,7 +17,7 @@ build:
 
 # Run all tests
 test:
-	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend pytest -m "not integration"
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend pytest -m "not integration and not pipeline"
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm frontend npm test
 
 # Lint both runtimes
@@ -70,13 +70,23 @@ jellyfin-down:
 # Run integration tests (requires Jellyfin via jellyfin-up)
 # Runs on host (same as CI) — Jellyfin is on localhost:8096
 test-integration:
-	cd backend && JELLYFIN_TEST_URL=http://localhost:8096 uv run pytest -m integration -v
+	cd backend && JELLYFIN_TEST_URL=http://localhost:8096 uv run pytest -m "integration and not pipeline" -v
 
 # Full cycle: start Jellyfin, run integration tests, teardown (unconditional)
 # WARNING: This MUST remain a single logical line. Make runs each recipe line
 # in a separate shell — splitting this would break unconditional teardown.
 test-integration-full:
 	@$(MAKE) jellyfin-up && $(MAKE) test-integration; ret=$$?; $(MAKE) jellyfin-down; exit $$ret
+
+# ---------------------------------------------------------------------------
+# Pipeline validation (requires Ollama running locally)
+# ---------------------------------------------------------------------------
+
+# Full RAG pipeline validation: embed → search → chat against real Ollama
+# Checks Ollama health BEFORE starting Jellyfin to fail fast
+validate-pipeline:
+	@curl -sf http://localhost:11434/ > /dev/null 2>&1 || { echo "ERROR: Ollama not reachable at http://localhost:11434/"; echo "Start Ollama with: ollama serve"; exit 1; }
+	@$(MAKE) jellyfin-up && cd backend && JELLYFIN_TEST_URL=http://localhost:8096 uv run pytest -m pipeline -v ; ret=$$?; cd .. && $(MAKE) jellyfin-down; exit $$ret
 
 # ---------------------------------------------------------------------------
 # Adversarial injection test harness

--- a/Makefile
+++ b/Makefile
@@ -101,9 +101,11 @@ pipeline-down:
 
 # Full RAG pipeline validation: embed → search → chat against real Ollama
 # Checks Ollama health BEFORE starting Jellyfin to fail fast
+# WARNING: This MUST remain a single logical line. Make runs each recipe line
+# in a separate shell — splitting this would break unconditional teardown.
 validate-pipeline:
 	@curl -sf http://localhost:11434/ > /dev/null 2>&1 || { echo "ERROR: Ollama not reachable at http://localhost:11434/"; echo "Start Ollama first, or run: make pipeline-up"; exit 1; }
-	@$(MAKE) jellyfin-up && cd backend && JELLYFIN_TEST_URL=http://localhost:8096 uv run pytest -m pipeline -v ; ret=$$?; cd .. && $(MAKE) jellyfin-down; exit $$ret
+	@$(MAKE) jellyfin-up && JELLYFIN_TEST_URL=http://localhost:8096 uv run --directory backend pytest -m pipeline -v ; ret=$$?; $(MAKE) jellyfin-down; exit $$ret
 
 # ---------------------------------------------------------------------------
 # Adversarial injection test harness

--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Jellyfin must be configured with a session timeout (Jellyfin Settings > Networki
 
 ## Development
 
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose v2
+- [uv](https://docs.astral.sh/uv/) — Python package manager (for running backend tests on host)
+- [Ollama](https://ollama.ai/) — required for pipeline validation tests (`brew install ollama` on macOS)
+
+### Commands
+
 ```bash
 # Full stack with hot reload
 make dev
@@ -102,6 +110,27 @@ make test
 
 # Lint
 make lint
+```
+
+### Integration Tests
+
+```bash
+make test-integration-full   # start Jellyfin, run tests, teardown
+```
+
+### Pipeline Validation
+
+Validates the full RAG pipeline (embed → search → chat) with real Ollama inference against 35 fixture items. Requires Ollama running locally — models are auto-pulled on first run (~4 GB).
+
+```bash
+# One-shot: checks Ollama, starts Jellyfin, runs tests, tears down
+ollama serve                 # in another terminal (or already running)
+make validate-pipeline
+
+# Or manage infrastructure separately for iterative development
+make pipeline-up             # start Jellyfin + check Ollama
+make validate-pipeline       # run pipeline tests
+make pipeline-down           # tear down Jellyfin
 ```
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for system design and data flow diagrams.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "integration: marks tests as requiring a live Jellyfin instance (deselect with '-m \"not integration\"')",
     "requires_sqlite_vec: marks tests that need the sqlite-vec extension",
     "ollama_integration: marks tests as requiring a live Ollama instance (not run in standard CI)",
+    "pipeline: marks tests requiring Ollama inference (run via 'make validate-pipeline', not in CI)",
 ]
 
 [tool.pyright]

--- a/backend/tests/pipeline/conftest.py
+++ b/backend/tests/pipeline/conftest.py
@@ -1,0 +1,226 @@
+"""Pipeline validation fixtures — Ollama pre-flight, embedding, shared DB.
+
+Pipeline tests validate the full RAG pipeline (embed → search → chat)
+against real Ollama inference and Jellyfin test fixtures from Spec 22.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+import pytest_asyncio
+from pydantic import SecretStr
+
+from app.config import Settings
+from app.embedding.worker import EmbeddingWorker
+from app.jellyfin.client import JellyfinClient
+from app.library.store import LibraryStore
+from app.ollama.client import OllamaEmbeddingClient
+from app.sync.engine import SyncEngine
+from app.vectors.repository import SqliteVecRepository
+
+# Import fixtures from integration conftest — pytest needs module-level names
+# to discover fixtures from sibling directories.
+from tests.integration.conftest import (  # noqa: F401
+    TEST_ADMIN_PASS,
+)
+from tests.integration.conftest import (
+    admin_auth_token as admin_auth_token,
+)
+from tests.integration.conftest import (
+    jellyfin as jellyfin,
+)
+from tests.integration.conftest import (
+    populated_library as populated_library,
+)
+from tests.integration.conftest import (
+    test_users as test_users,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+    from pathlib import Path
+
+    from tests.integration.conftest import JellyfinInstance
+
+_logger = logging.getLogger(__name__)
+
+OLLAMA_HOST = "http://localhost:11434"
+EMBED_MODEL = "nomic-embed-text"
+CHAT_MODEL = "llama3.1:8b"
+REQUIRED_MODELS = [EMBED_MODEL, CHAT_MODEL]
+
+# Safety cap for embedding loop — prevent infinite loops
+_MAX_EMBED_CYCLES = 20
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped autouse: skip entire session if Ollama is unreachable
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture(scope="session", autouse=True)
+async def _check_ollama() -> None:
+    """Skip the entire pipeline session if Ollama is not reachable."""
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        try:
+            resp = await client.get(f"{OLLAMA_HOST}/")
+            if resp.status_code != 200:
+                pytest.skip("Ollama not reachable — run 'ollama serve' first")
+        except httpx.TransportError:
+            pytest.skip("Ollama not reachable — run 'ollama serve' first")
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped: ensure required models are pulled
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture(scope="session")
+async def _ensure_models(_check_ollama: None) -> None:
+    """Pull missing models before tests run."""
+    async with httpx.AsyncClient(timeout=300.0) as client:
+        resp = await client.get(f"{OLLAMA_HOST}/api/tags")
+        resp.raise_for_status()
+        available = {m["name"] for m in resp.json().get("models", [])}
+
+        for model in REQUIRED_MODELS:
+            # Check both exact name and name with :latest suffix
+            if model in available or f"{model}:latest" in available:
+                _logger.info("Model %s already available", model)
+                continue
+
+            _logger.info("Pulling model %s (this may take a while)...", model)
+            pull_resp = await client.post(
+                f"{OLLAMA_HOST}/api/pull",
+                json={"name": model},
+                timeout=600.0,
+            )
+            pull_resp.raise_for_status()
+            _logger.info("Model %s pulled successfully", model)
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped: shared database path for all pipeline fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def pipeline_db_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Shared temp directory for pipeline database files."""
+    return tmp_path_factory.mktemp("pipeline")
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped: LibraryStore and SqliteVecRepository sharing one DB
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture(scope="session")
+async def pipeline_library_store(
+    pipeline_db_path: Path,
+) -> AsyncGenerator[LibraryStore, None]:
+    """Session-scoped LibraryStore for the pipeline database."""
+    db_path = str(pipeline_db_path / "pipeline_library.db")
+    store = LibraryStore(db_path)
+    await store.init()
+    yield store
+    await store.close()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def pipeline_vec_repo(
+    pipeline_db_path: Path,
+) -> AsyncGenerator[SqliteVecRepository, None]:
+    """Session-scoped SqliteVecRepository for the pipeline database."""
+    db_path = str(pipeline_db_path / "pipeline_library.db")
+    repo = SqliteVecRepository(
+        db_path=db_path,
+        expected_model=EMBED_MODEL,
+        expected_dimensions=768,
+    )
+    await repo.init()
+    yield repo
+    await repo.close()
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped: sync + embed all fixtures into the pipeline database
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture(scope="session")
+async def embedded_library(
+    populated_library: int,  # noqa: ARG001 — forces Jellyfin scan completion
+    admin_auth_token: str,
+    jellyfin: JellyfinInstance,
+    pipeline_library_store: LibraryStore,
+    pipeline_vec_repo: SqliteVecRepository,
+    _ensure_models: None,
+) -> SqliteVecRepository:
+    """Sync from Jellyfin and embed all items with real Ollama inference.
+
+    Returns the vec_repo with all fixture items embedded.
+    """
+    # Build Settings for sync
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        jf_client = JellyfinClient(base_url=jellyfin.url, http_client=http)
+        auth = await jf_client.authenticate(jellyfin.admin_user, TEST_ADMIN_PASS)
+        admin_user_id = auth.user_id
+
+    settings = Settings(
+        jellyfin_url=jellyfin.url,
+        session_secret="a" * 32 + "-test-not-real-secret-12345678",
+        session_secure_cookie=False,
+        jellyfin_api_key=SecretStr(admin_auth_token),
+        jellyfin_admin_user_id=admin_user_id,
+        ollama_host=OLLAMA_HOST,
+        log_level="debug",
+    )  # type: ignore[call-arg]
+
+    # Run sync
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        jf_client = JellyfinClient(base_url=jellyfin.url, http_client=http)
+        engine = SyncEngine(
+            library_store=pipeline_library_store,
+            jellyfin_client=jf_client,
+            settings=settings,
+            vector_repository=pipeline_vec_repo,
+        )
+        result = await engine.run_sync()
+        _logger.info(
+            "Sync complete: %d created, %d updated, %d failed",
+            result.items_created,
+            result.items_updated,
+            result.items_failed,
+        )
+
+    # Embed all items
+    async with httpx.AsyncClient(timeout=120.0) as http:
+        embed_client = OllamaEmbeddingClient(
+            base_url=OLLAMA_HOST,
+            http_client=http,
+            embed_model=EMBED_MODEL,
+        )
+        sync_event = asyncio.Event()
+        worker = EmbeddingWorker(
+            library_store=pipeline_library_store,
+            vec_repo=pipeline_vec_repo,
+            ollama_client=embed_client,
+            settings=settings,
+            sync_event=sync_event,
+        )
+
+        for cycle in range(_MAX_EMBED_CYCLES):
+            pending = await pipeline_library_store.count_pending_embeddings()
+            if pending == 0:
+                _logger.info("Embedding complete after %d cycles", cycle)
+                break
+            _logger.info("Embedding cycle %d: %d items pending", cycle + 1, pending)
+            await worker.process_cycle()
+        else:
+            pending = await pipeline_library_store.count_pending_embeddings()
+            if pending > 0:
+                pytest.fail(
+                    f"Embedding did not complete after {_MAX_EMBED_CYCLES} "
+                    f"cycles ({pending} items still pending)"
+                )
+
+    vec_count = await pipeline_vec_repo.count()
+    _logger.info("Pipeline database: %d vectors stored", vec_count)
+
+    return pipeline_vec_repo

--- a/backend/tests/pipeline/conftest.py
+++ b/backend/tests/pipeline/conftest.py
@@ -25,6 +25,7 @@ from app.vectors.repository import SqliteVecRepository
 
 # Import fixtures from integration conftest — pytest needs module-level names
 # to discover fixtures from sibling directories.
+from tests.conftest import TEST_SECRET
 from tests.integration.conftest import (  # noqa: F401
     TEST_ADMIN_PASS,
 )
@@ -93,7 +94,7 @@ async def _ensure_models(_check_ollama: None) -> None:
             _logger.info("Pulling model %s (this may take a while)...", model)
             pull_resp = await client.post(
                 f"{OLLAMA_HOST}/api/pull",
-                json={"name": model},
+                json={"name": model, "stream": False},
                 timeout=600.0,
             )
             pull_resp.raise_for_status()
@@ -141,6 +142,30 @@ async def pipeline_vec_repo(
 
 
 # ---------------------------------------------------------------------------
+# Shared helper: build Settings for pipeline tests
+# ---------------------------------------------------------------------------
+def make_pipeline_settings(
+    jellyfin_url: str,
+    admin_token: str,
+    admin_user_id: str,
+) -> Settings:
+    """Build minimal Settings for pipeline tests.
+
+    Shared between the embedded_library fixture and chat round-trip test
+    to avoid divergent Settings construction.
+    """
+    return Settings(
+        jellyfin_url=jellyfin_url,
+        session_secret=TEST_SECRET,
+        session_secure_cookie=False,
+        jellyfin_api_key=SecretStr(admin_token),
+        jellyfin_admin_user_id=admin_user_id,
+        ollama_host=OLLAMA_HOST,
+        log_level="debug",
+    )  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
 # Session-scoped: sync + embed all fixtures into the pipeline database
 # ---------------------------------------------------------------------------
 @pytest_asyncio.fixture(scope="session")
@@ -162,15 +187,7 @@ async def embedded_library(
         auth = await jf_client.authenticate(jellyfin.admin_user, TEST_ADMIN_PASS)
         admin_user_id = auth.user_id
 
-    settings = Settings(
-        jellyfin_url=jellyfin.url,
-        session_secret="a" * 32 + "-test-not-real-secret-12345678",
-        session_secure_cookie=False,
-        jellyfin_api_key=SecretStr(admin_auth_token),
-        jellyfin_admin_user_id=admin_user_id,
-        ollama_host=OLLAMA_HOST,
-        log_level="debug",
-    )  # type: ignore[call-arg]
+    settings = make_pipeline_settings(jellyfin.url, admin_auth_token, admin_user_id)
 
     # Run sync
     async with httpx.AsyncClient(timeout=30.0) as http:

--- a/backend/tests/pipeline/test_chat_round_trip.py
+++ b/backend/tests/pipeline/test_chat_round_trip.py
@@ -21,10 +21,14 @@ from app.ollama.chat_client import OllamaChatClient
 from app.ollama.client import OllamaEmbeddingClient
 from app.search.service import SearchService
 from tests.integration.conftest import JELLYFIN_TEST_URL
-from tests.pipeline.conftest import CHAT_MODEL, EMBED_MODEL, OLLAMA_HOST
+from tests.pipeline.conftest import (
+    CHAT_MODEL,
+    EMBED_MODEL,
+    OLLAMA_HOST,
+    make_pipeline_settings,
+)
 
 if TYPE_CHECKING:
-    from app.config import Settings
     from app.library.store import LibraryStore
     from app.vectors.repository import SqliteVecRepository
 
@@ -63,24 +67,6 @@ def _make_permit_all_permission_service() -> AsyncMock:
     return mock
 
 
-def _make_pipeline_settings(jellyfin_url: str) -> Settings:
-    """Minimal Settings for ChatService (no real Jellyfin calls needed)."""
-    from pydantic import SecretStr
-
-    from app.config import Settings
-
-    return Settings(
-        jellyfin_url=jellyfin_url,
-        session_secret="a" * 32 + "-test-not-real-secret-12345678",
-        session_secure_cookie=False,
-        jellyfin_api_key=SecretStr("not-used-in-chat"),
-        jellyfin_admin_user_id="not-used-in-chat",
-        ollama_host=OLLAMA_HOST,
-        ollama_chat_model=CHAT_MODEL,
-        log_level="debug",
-    )  # type: ignore[call-arg]
-
-
 @pytest.mark.pipeline
 async def test_chat_round_trip_references_fixtures(
     embedded_library: SqliteVecRepository,
@@ -91,7 +77,9 @@ async def test_chat_round_trip_references_fixtures(
         "No fixture titles found — is tests/fixtures/media/ populated?"
     )
 
-    settings = _make_pipeline_settings(JELLYFIN_TEST_URL)
+    settings = make_pipeline_settings(
+        JELLYFIN_TEST_URL, "not-used-in-chat", "not-used-in-chat"
+    )
 
     async with httpx.AsyncClient(timeout=300.0) as http:
         embed_client = OllamaEmbeddingClient(

--- a/backend/tests/pipeline/test_chat_round_trip.py
+++ b/backend/tests/pipeline/test_chat_round_trip.py
@@ -20,6 +20,7 @@ from app.chat.service import ChatPauseCounter, ChatService
 from app.ollama.chat_client import OllamaChatClient
 from app.ollama.client import OllamaEmbeddingClient
 from app.search.service import SearchService
+from tests.integration.conftest import JELLYFIN_TEST_URL
 from tests.pipeline.conftest import CHAT_MODEL, EMBED_MODEL, OLLAMA_HOST
 
 if TYPE_CHECKING:
@@ -90,7 +91,7 @@ async def test_chat_round_trip_references_fixtures(
         "No fixture titles found — is tests/fixtures/media/ populated?"
     )
 
-    settings = _make_pipeline_settings("http://localhost:8096")
+    settings = _make_pipeline_settings(JELLYFIN_TEST_URL)
 
     async with httpx.AsyncClient(timeout=300.0) as http:
         embed_client = OllamaEmbeddingClient(

--- a/backend/tests/pipeline/test_chat_round_trip.py
+++ b/backend/tests/pipeline/test_chat_round_trip.py
@@ -1,0 +1,158 @@
+"""Chat round-trip verification against real Ollama inference.
+
+Proves the full RAG pipeline — query → embed → search → context → LLM →
+response — produces a coherent response that references fixture media.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from app.chat.conversation_store import ConversationStore
+from app.chat.service import ChatPauseCounter, ChatService
+from app.ollama.chat_client import OllamaChatClient
+from app.ollama.client import OllamaEmbeddingClient
+from app.search.service import SearchService
+from tests.pipeline.conftest import CHAT_MODEL, EMBED_MODEL, OLLAMA_HOST
+
+if TYPE_CHECKING:
+    from app.config import Settings
+    from app.library.store import LibraryStore
+    from app.vectors.repository import SqliteVecRepository
+
+# ---------------------------------------------------------------------------
+# Build fixture title set from NFO files (stays in sync automatically)
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MEDIA_ROOT = _REPO_ROOT / "tests" / "fixtures" / "media"
+
+
+def _extract_titles_from_nfos() -> set[str]:
+    """Parse all movie.nfo and tvshow.nfo files to extract titles."""
+    titles: set[str] = set()
+    for nfo_path in _MEDIA_ROOT.glob("movies/*/movie.nfo"):
+        tree = ET.parse(nfo_path)  # noqa: S314
+        title = tree.getroot().findtext("title")
+        if title:
+            titles.add(title.strip())
+    for nfo_path in _MEDIA_ROOT.glob("shows/*/tvshow.nfo"):
+        tree = ET.parse(nfo_path)  # noqa: S314
+        title = tree.getroot().findtext("title")
+        if title:
+            titles.add(title.strip())
+    return titles
+
+
+FIXTURE_TITLES = _extract_titles_from_nfos()
+
+
+def _make_permit_all_permission_service() -> AsyncMock:
+    """Stub PermissionService that permits all item IDs."""
+    mock = AsyncMock()
+    mock.filter_permitted = AsyncMock(
+        side_effect=lambda user_id, token, candidate_ids: candidate_ids
+    )
+    return mock
+
+
+def _make_pipeline_settings(jellyfin_url: str) -> Settings:
+    """Minimal Settings for ChatService (no real Jellyfin calls needed)."""
+    from pydantic import SecretStr
+
+    from app.config import Settings
+
+    return Settings(
+        jellyfin_url=jellyfin_url,
+        session_secret="a" * 32 + "-test-not-real-secret-12345678",
+        session_secure_cookie=False,
+        jellyfin_api_key=SecretStr("not-used-in-chat"),
+        jellyfin_admin_user_id="not-used-in-chat",
+        ollama_host=OLLAMA_HOST,
+        ollama_chat_model=CHAT_MODEL,
+        log_level="debug",
+    )  # type: ignore[call-arg]
+
+
+@pytest.mark.pipeline
+async def test_chat_round_trip_references_fixtures(
+    embedded_library: SqliteVecRepository,
+    pipeline_library_store: LibraryStore,
+) -> None:
+    """Full RAG pipeline: query → embed → search → LLM → fixture title in response."""
+    assert FIXTURE_TITLES, (
+        "No fixture titles found — is tests/fixtures/media/ populated?"
+    )
+
+    settings = _make_pipeline_settings("http://localhost:8096")
+
+    async with httpx.AsyncClient(timeout=300.0) as http:
+        embed_client = OllamaEmbeddingClient(
+            base_url=OLLAMA_HOST,
+            http_client=http,
+            embed_model=EMBED_MODEL,
+        )
+        chat_client = OllamaChatClient(
+            base_url=OLLAMA_HOST,
+            http_client=http,
+            chat_model=CHAT_MODEL,
+        )
+
+        search_service = SearchService(
+            ollama_client=embed_client,
+            vec_repo=embedded_library,
+            permission_service=_make_permit_all_permission_service(),
+            library_store=pipeline_library_store,
+        )
+
+        chat_service = ChatService(
+            search_service=search_service,
+            chat_client=chat_client,
+            pause_counter=ChatPauseCounter(),
+            settings=settings,
+            conversation_store=ConversationStore(),
+        )
+
+        # Collect all SSE events with a generous timeout for CPU inference
+        text_chunks: list[str] = []
+        error_events: list[dict] = []
+
+        try:
+            async with asyncio.timeout(60):
+                async for event in chat_service.stream(
+                    query="recommend me a sci-fi movie",
+                    user_id="pipeline-test-user",
+                    token="not-used-permit-all",
+                    session_id="pipeline-test-session",
+                ):
+                    if event.get("type") == "text":
+                        text_chunks.append(event.get("content", ""))
+                    elif event.get("type") == "error":
+                        error_events.append(event)
+        except TimeoutError:
+            pytest.fail(
+                "Chat stream timed out after 60s. "
+                "Is Ollama responsive? CPU inference can be slow."
+            )
+
+    full_response = "".join(text_chunks)
+
+    # Assert: non-empty response
+    assert full_response.strip(), "Chat response was empty — no text events received"
+
+    # Assert: no errors
+    assert not error_events, f"Chat stream produced error events: {error_events}"
+
+    # Assert: response references at least one fixture title
+    response_lower = full_response.lower()
+    matched = [t for t in FIXTURE_TITLES if t.lower() in response_lower]
+    assert matched, (
+        f"Response did not reference any fixture title. "
+        f"Response excerpt: {full_response[:500]!r}"
+    )

--- a/backend/tests/pipeline/test_embedding.py
+++ b/backend/tests/pipeline/test_embedding.py
@@ -30,7 +30,7 @@ async def test_ollama_reachable() -> None:
 
 
 @pytest.mark.pipeline
-async def test_models_available() -> None:
+async def test_models_available(_ensure_models: None) -> None:
     """Both required models (nomic-embed-text, llama3.1:8b) are available."""
     async with httpx.AsyncClient(timeout=10.0) as client:
         resp = await client.get(f"{OLLAMA_HOST}/api/tags")

--- a/backend/tests/pipeline/test_embedding.py
+++ b/backend/tests/pipeline/test_embedding.py
@@ -1,0 +1,36 @@
+"""Pipeline pre-flight and embedding verification tests.
+
+These tests validate Ollama reachability, model availability, and that
+all fixture items are successfully embedded with real inference.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tests.pipeline.conftest import OLLAMA_HOST, REQUIRED_MODELS
+
+
+@pytest.mark.pipeline
+async def test_ollama_reachable() -> None:
+    """Ollama health endpoint returns 200."""
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        resp = await client.get(f"{OLLAMA_HOST}/")
+        assert resp.status_code == 200, (
+            f"Ollama not reachable at {OLLAMA_HOST} (status {resp.status_code})"
+        )
+
+
+@pytest.mark.pipeline
+async def test_models_available() -> None:
+    """Both required models (nomic-embed-text, llama3.1:8b) are available."""
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(f"{OLLAMA_HOST}/api/tags")
+        resp.raise_for_status()
+        available = {m["name"] for m in resp.json().get("models", [])}
+
+        for model in REQUIRED_MODELS:
+            assert model in available or f"{model}:latest" in available, (
+                f"Model {model} not available in Ollama. Available: {sorted(available)}"
+            )

--- a/backend/tests/pipeline/test_embedding.py
+++ b/backend/tests/pipeline/test_embedding.py
@@ -6,10 +6,17 @@ all fixture items are successfully embedded with real inference.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import httpx
 import pytest
 
+from tests.integration.conftest import EXPECTED_TOTAL
 from tests.pipeline.conftest import OLLAMA_HOST, REQUIRED_MODELS
+
+if TYPE_CHECKING:
+    from app.library.store import LibraryStore
+    from app.vectors.repository import SqliteVecRepository
 
 
 @pytest.mark.pipeline
@@ -34,3 +41,18 @@ async def test_models_available() -> None:
             assert model in available or f"{model}:latest" in available, (
                 f"Model {model} not available in Ollama. Available: {sorted(available)}"
             )
+
+
+@pytest.mark.pipeline
+async def test_all_items_embedded(
+    embedded_library: SqliteVecRepository,
+    pipeline_library_store: LibraryStore,
+) -> None:
+    """All 35 fixture items produce vectors with 0 pending in queue."""
+    vec_count = await embedded_library.count()
+    assert vec_count >= EXPECTED_TOTAL, (
+        f"Expected >= {EXPECTED_TOTAL} vectors, got {vec_count}"
+    )
+
+    pending = await pipeline_library_store.count_pending_embeddings()
+    assert pending == 0, f"Expected 0 pending embeddings, got {pending}"

--- a/backend/tests/pipeline/test_search_relevance.py
+++ b/backend/tests/pipeline/test_search_relevance.py
@@ -1,0 +1,111 @@
+"""Search relevance assertions against curated query pairings.
+
+These tests validate that vector search returns contextually relevant
+results for known queries using real Ollama embeddings and the 35
+fixture items from Spec 22.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.ollama.client import OllamaEmbeddingClient
+from app.search.models import QUERY_PREFIX
+from tests.pipeline.conftest import EMBED_MODEL, OLLAMA_HOST
+
+if TYPE_CHECKING:
+    from app.library.store import LibraryStore
+    from app.vectors.repository import SqliteVecRepository
+
+
+async def _search(
+    query: str,
+    embed_client: OllamaEmbeddingClient,
+    vec_repo: SqliteVecRepository,
+    library_store: LibraryStore,
+    limit: int = 5,
+) -> list[tuple[str, float]]:
+    """Embed a query and search, returning (title, score) tuples."""
+    result = await embed_client.embed(QUERY_PREFIX + query)
+    search_results = await vec_repo.search(result.vector, limit=limit)
+    items = await library_store.get_many([r.jellyfin_id for r in search_results])
+    id_to_title = {item.jellyfin_id: item.title for item in items}
+    return [
+        (id_to_title.get(r.jellyfin_id, r.jellyfin_id), r.score) for r in search_results
+    ]
+
+
+@pytest.fixture
+async def embed_client() -> OllamaEmbeddingClient:
+    """Embedding client for search queries — function-scoped httpx client."""
+    async with httpx.AsyncClient(timeout=120.0) as http:
+        yield OllamaEmbeddingClient(  # type: ignore[misc]
+            base_url=OLLAMA_HOST,
+            http_client=http,
+            embed_model=EMBED_MODEL,
+        )
+
+
+@pytest.mark.pipeline
+async def test_search_alien_but_funny(
+    embedded_library: SqliteVecRepository,
+    pipeline_library_store: LibraryStore,
+    embed_client: OllamaEmbeddingClient,
+) -> None:
+    """'something like Alien but funny' returns Galaxy Quest in top 5."""
+    results = await _search(
+        "something like Alien but funny",
+        embed_client,
+        embedded_library,
+        pipeline_library_store,
+    )
+    titles = [title for title, _score in results]
+    assert "Galaxy Quest" in titles, (
+        f"Expected 'Galaxy Quest' in top 5, got: "
+        f"{[(t, f'{s:.4f}') for t, s in results]}"
+    )
+
+
+@pytest.mark.pipeline
+async def test_search_space_opera(
+    embedded_library: SqliteVecRepository,
+    pipeline_library_store: LibraryStore,
+    embed_client: OllamaEmbeddingClient,
+) -> None:
+    """'space opera TV show' returns at least one space opera series in top 5."""
+    expected = {"Babylon 5", "Stargate SG-1", "Battlestar Galactica"}
+    results = await _search(
+        "space opera TV show",
+        embed_client,
+        embedded_library,
+        pipeline_library_store,
+    )
+    titles = {title for title, _score in results}
+    assert titles & expected, (
+        f"Expected one of {sorted(expected)} in top 5, got: "
+        f"{[(t, f'{s:.4f}') for t, s in results]}"
+    )
+
+
+@pytest.mark.pipeline
+async def test_search_cozy_mystery(
+    embedded_library: SqliteVecRepository,
+    pipeline_library_store: LibraryStore,
+    embed_client: OllamaEmbeddingClient,
+) -> None:
+    """'cozy murder mystery' returns at least one cozy mystery show in top 5."""
+    expected = {"Midsomer Murders", "Death in Paradise"}
+    results = await _search(
+        "cozy murder mystery",
+        embed_client,
+        embedded_library,
+        pipeline_library_store,
+    )
+    titles = {title for title, _score in results}
+    assert titles & expected, (
+        f"Expected one of {sorted(expected)} in top 5, got: "
+        f"{[(t, f'{s:.4f}') for t, s in results]}"
+    )

--- a/backend/tests/pipeline/test_search_relevance.py
+++ b/backend/tests/pipeline/test_search_relevance.py
@@ -55,16 +55,17 @@ async def test_search_alien_but_funny(
     pipeline_library_store: LibraryStore,
     embed_client: OllamaEmbeddingClient,
 ) -> None:
-    """'something like Alien but funny' returns Galaxy Quest in top 5."""
+    """'something like Alien but funny' returns a sci-fi comedy in top 5."""
+    expected = {"Galaxy Quest", "Mars Attacks!", "Shaun of the Dead"}
     results = await _search(
         "something like Alien but funny",
         embed_client,
         embedded_library,
         pipeline_library_store,
     )
-    titles = [title for title, _score in results]
-    assert "Galaxy Quest" in titles, (
-        f"Expected 'Galaxy Quest' in top 5, got: "
+    titles = {title for title, _score in results}
+    assert titles & expected, (
+        f"Expected one of {sorted(expected)} in top 5, got: "
         f"{[(t, f'{s:.4f}') for t, s in results]}"
     )
 

--- a/backend/tests/pipeline/test_search_relevance.py
+++ b/backend/tests/pipeline/test_search_relevance.py
@@ -11,12 +11,15 @@ from typing import TYPE_CHECKING
 
 import httpx
 import pytest
+import pytest_asyncio
 
 from app.ollama.client import OllamaEmbeddingClient
 from app.search.models import QUERY_PREFIX
 from tests.pipeline.conftest import EMBED_MODEL, OLLAMA_HOST
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
     from app.library.store import LibraryStore
     from app.vectors.repository import SqliteVecRepository
 
@@ -38,11 +41,11 @@ async def _search(
     ]
 
 
-@pytest.fixture
-async def embed_client() -> OllamaEmbeddingClient:
+@pytest_asyncio.fixture
+async def embed_client() -> AsyncGenerator[OllamaEmbeddingClient, None]:
     """Embedding client for search queries — function-scoped httpx client."""
     async with httpx.AsyncClient(timeout=120.0) as http:
-        yield OllamaEmbeddingClient(  # type: ignore[misc]
+        yield OllamaEmbeddingClient(
             base_url=OLLAMA_HOST,
             http_client=http,
             embed_model=EMBED_MODEL,


### PR DESCRIPTION
## Summary

- Add `make validate-pipeline` target and `@pytest.mark.pipeline` marker for end-to-end RAG pipeline validation against real Ollama inference and 35 fixture items from Spec 22
- 7 pipeline tests: Ollama pre-flight (2), embedding verification (1), search relevance (3), chat round-trip (1)
- Add `make pipeline-up` / `make pipeline-down` convenience targets for iterative development
- Document `uv`, Ollama, and pipeline workflow in README

### What it validates

| Test | What it proves |
|------|---------------|
| `test_ollama_reachable` | Ollama health check passes |
| `test_models_available` | `nomic-embed-text` and `llama3.1:8b` pulled |
| `test_all_items_embedded` | 35 fixture items → 35+ vectors, 0 pending |
| `test_search_alien_but_funny` | Sci-fi comedy in top 5 for "Alien but funny" |
| `test_search_space_opera` | Space opera series in top 5 |
| `test_search_cozy_mystery` | Cozy mystery show in top 5 |
| `test_chat_round_trip_references_fixtures` | Full RAG pipeline returns response referencing fixture media |

### Design decisions

- Pipeline tests are **excluded from `make test` and `make test-integration`** — they require Ollama and are local-only (not CI)
- Models are **auto-pulled** by pytest fixtures if missing (avoids fail-fix-rerun cycle)
- Search assertions use **top 5** threshold (council consensus: top 3 is too brittle for approximate embeddings)
- Chat round-trip uses a **stub PermissionService** (permit-all) — this tests the RAG pipe, not auth
- Fixture title set is built **dynamically from NFO files** so it stays in sync with fixture changes

## Test plan

- [x] `make validate-pipeline` — 7 passed, 0 failed (51.72s with warm Ollama)
- [x] `make test` (unit tests) — 690 passed, 0 regressions
- [x] `ruff check` + `ruff format --check` — clean
- [x] Pipeline tests excluded from `make test` and `make test-integration` (verified via `--collect-only`)
- [ ] CI passes (no Ollama in CI — pipeline tests are deselected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)