### PR TITLE
feat(dx): self-contained make dev — zero-config local stack (#186)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,16 @@ _check_port_8096 = @curl -sf http://localhost:8096/health > /dev/null 2>&1 \
 	     echo "  Run: make dev-down  or  make jellyfin-down  first"; exit 1; } \
 	|| true
 
-# Self-contained local dev — Jellyfin + Ollama + provisioning, no .env required
+# Self-contained local dev — Jellyfin + Ollama (CPU) + provisioning, no .env required
 # First run pulls ~4 GB of Ollama models and takes a few minutes.
+# Ollama runs CPU-only; for GPU use make dev-full with docker-compose.ollama.yml
 dev:
 	$(_check_port_8096)
-	docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.ollama.yml -f docker-compose.localdev.yml up
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.localdev.yml up
 
 # Stop the local dev stack
 dev-down:
-	docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.ollama.yml -f docker-compose.localdev.yml down
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.localdev.yml down
 
 # Full stack with hot reload — requires .env with JELLYFIN_URL + SESSION_SECRET
 # Use this if you have your own Jellyfin instance configured

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,25 @@
-.PHONY: dev dev-full dev-ui build test lint ci clean logs health hooks jellyfin-up jellyfin-down test-integration test-integration-full test-injection validate-pipeline pipeline-up pipeline-down
+.PHONY: dev dev-full dev-ui dev-down build test lint ci clean logs health hooks jellyfin-up jellyfin-down test-integration test-integration-full test-injection validate-pipeline pipeline-up pipeline-down
 
-# Default dev target — full stack with Ollama
-dev: dev-full
+# ---------------------------------------------------------------------------
+# Port 8096 guard — localdev Jellyfin and test Jellyfin share this port
+# ---------------------------------------------------------------------------
+_check_port_8096 = @curl -sf http://localhost:8096/health > /dev/null 2>&1 \
+	&& { echo "ERROR: Port 8096 already in use (another Jellyfin stack running?)"; \
+	     echo "  Run: make dev-down  or  make jellyfin-down  first"; exit 1; } \
+	|| true
 
-# Full stack: backend + frontend + Ollama sidecar
+# Self-contained local dev — Jellyfin + Ollama + provisioning, no .env required
+# First run pulls ~4 GB of Ollama models and takes a few minutes.
+dev:
+	$(_check_port_8096)
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.ollama.yml -f docker-compose.localdev.yml up
+
+# Stop the local dev stack
+dev-down:
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.ollama.yml -f docker-compose.localdev.yml down
+
+# Full stack with hot reload — requires .env with JELLYFIN_URL + SESSION_SECRET
+# Use this if you have your own Jellyfin instance configured
 dev-full:
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.ollama.yml up
 
@@ -50,6 +66,7 @@ hooks:
 
 # Start disposable Jellyfin for integration tests
 jellyfin-up:
+	$(_check_port_8096)
 	docker compose -p ai-movie-suggester-test -f docker-compose.test.yml up -d jellyfin
 	@echo "Waiting for Jellyfin to become healthy..."
 	@timeout=120; while [ $$timeout -gt 0 ]; do \

--- a/docker-compose.localdev.yml
+++ b/docker-compose.localdev.yml
@@ -105,7 +105,15 @@ services:
       ollama:
         condition: service_healthy
 
+  # Override frontend to auto-install deps on first run
+  # The named node_modules volume starts empty; npm ci populates it
   frontend:
+    command:
+      - sh
+      - -c
+      - |
+        [ -d node_modules/next ] || npm ci
+        exec npm run dev
     depends_on:
       backend:
         condition: service_healthy

--- a/docker-compose.localdev.yml
+++ b/docker-compose.localdev.yml
@@ -8,7 +8,7 @@
 #   - Disposable Jellyfin with 35 fixture items (movies + shows)
 #   - Ollama model auto-pull (nomic-embed-text + llama3.1:8b)
 #   - Backend dev defaults (no .env required)
-#   - Provisioner that sets up Jellyfin and triggers initial library sync
+#   - Two-phase provisioner: Jellyfin setup → backend sync
 #
 # Dev-only — all credentials are for the disposable local stack.
 # Do not use these values against a real Jellyfin server.
@@ -56,10 +56,39 @@ services:
       start_period: 300s
     restart: unless-stopped
 
+  # Phase 1: Provision Jellyfin BEFORE backend starts.
+  # Completes wizard, creates users, creates API key, writes env to shared volume.
+  jellyfin-init:
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    working_dir: /scripts
+    volumes:
+      - ./scripts:/scripts:ro
+      - localdev-shared:/shared
+    command: uv run --no-project dev-provision.py --phase init
+    environment:
+      - JELLYFIN_URL=http://jellyfin:8096
+      - SHARED_DIR=/shared
+    depends_on:
+      jellyfin:
+        condition: service_healthy
+    restart: on-failure:3
+
   # Override backend with dev defaults — no .env needed
+  # Sources runtime env from jellyfin-init (API key + admin user ID)
   # user: root so named volume at /app/data is writable (dev-only)
   backend:
     user: "0"
+    command:
+      - sh
+      - -c
+      - |
+        if [ -f /shared/.localdev-env ]; then
+          export $$(cat /shared/.localdev-env | xargs)
+          echo "[localdev] Loaded runtime env from jellyfin-init"
+        fi
+        exec uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+    volumes:
+      - localdev-shared:/shared:ro
     environment:
       - JELLYFIN_URL=http://jellyfin:8096
       - SESSION_SECRET=localdev-32char-not-for-production
@@ -71,6 +100,8 @@ services:
     depends_on:
       jellyfin:
         condition: service_healthy
+      jellyfin-init:
+        condition: service_completed_successfully
       ollama:
         condition: service_healthy
 
@@ -79,13 +110,13 @@ services:
       backend:
         condition: service_healthy
 
-  # One-shot provisioner: Jellyfin wizard + users + library + backend sync
+  # Phase 2: Trigger backend sync + wait for completion
   provisioner:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
     working_dir: /scripts
     volumes:
       - ./scripts:/scripts:ro
-    command: uv run --no-project dev-provision.py
+    command: uv run --no-project dev-provision.py --phase sync
     environment:
       - JELLYFIN_URL=http://jellyfin:8096
       - BACKEND_URL=http://backend:8000
@@ -94,9 +125,10 @@ services:
         condition: service_healthy
       backend:
         condition: service_healthy
-    restart: on-failure:5
+    restart: on-failure:3
 
 volumes:
   jellyfin-localdev-config:
   jellyfin-localdev-cache:
   ollama-localdev-data:
+  localdev-shared:

--- a/docker-compose.localdev.yml
+++ b/docker-compose.localdev.yml
@@ -46,10 +46,10 @@ services:
         ollama serve &
         sleep 3
         ollama pull nomic-embed-text
-        ollama pull llama3.2:3b
+        ollama pull tinyllama:1.1b
         wait
     healthcheck:
-      test: ["CMD-SHELL", "ollama list | grep -q nomic-embed-text && ollama list | grep -q llama3.2"]
+      test: ["CMD-SHELL", "ollama list | grep -q nomic-embed-text && ollama list | grep -q tinyllama"]
       interval: 30s
       timeout: 10s
       retries: 20
@@ -94,7 +94,7 @@ services:
       - SESSION_SECRET=localdev-32char-not-for-production
       - SESSION_SECURE_COOKIE=false
       - OLLAMA_HOST=http://ollama:11434
-      - OLLAMA_CHAT_MODEL=llama3.2:3b
+      - OLLAMA_CHAT_MODEL=tinyllama:1.1b
       - LOG_LEVEL=debug
       - SYNC_INTERVAL_HOURS=0
       - CORS_ORIGIN=http://localhost:3000

--- a/docker-compose.localdev.yml
+++ b/docker-compose.localdev.yml
@@ -1,0 +1,91 @@
+# =============================================================================
+# Local development stack — self-contained, zero-config
+# =============================================================================
+# Usage:
+#   make dev
+#
+# This overlay adds:
+#   - Disposable Jellyfin with 35 fixture items (movies + shows)
+#   - Ollama model auto-pull (nomic-embed-text + llama3.1:8b)
+#   - Backend dev defaults (no .env required)
+#   - Provisioner that sets up Jellyfin and triggers initial library sync
+#
+# Dev-only — all credentials are for the disposable local stack.
+# Do not use these values against a real Jellyfin server.
+# =============================================================================
+
+services:
+  jellyfin:
+    image: jellyfin/jellyfin:10.11.6
+    ports:
+      - "127.0.0.1:8096:8096"
+    volumes:
+      - jellyfin-localdev-config:/config
+      - jellyfin-localdev-cache:/cache
+      - ./tests/fixtures/media:/media:ro
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8096/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  # Override Ollama to auto-pull required models on first start
+  ollama:
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        ollama serve &
+        sleep 3
+        ollama pull nomic-embed-text
+        ollama pull llama3.1:8b
+        wait
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list | grep -q nomic-embed-text && ollama list | grep -q llama3.1"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+      start_period: 300s
+
+  # Override backend with dev defaults — no .env needed
+  backend:
+    environment:
+      - JELLYFIN_URL=http://jellyfin:8096
+      - SESSION_SECRET=localdev-32char-not-for-production
+      - SESSION_SECURE_COOKIE=false
+      - OLLAMA_HOST=http://ollama:11434
+      - LOG_LEVEL=debug
+      - SYNC_INTERVAL_HOURS=0
+      - CORS_ORIGIN=http://localhost:3000
+    depends_on:
+      jellyfin:
+        condition: service_healthy
+      ollama:
+        condition: service_healthy
+
+  frontend:
+    depends_on:
+      backend:
+        condition: service_healthy
+
+  # One-shot provisioner: Jellyfin wizard + users + library + backend sync
+  provisioner:
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    working_dir: /scripts
+    volumes:
+      - ./scripts:/scripts:ro
+    command: uv run --no-project dev-provision.py
+    environment:
+      - JELLYFIN_URL=http://jellyfin:8096
+      - BACKEND_URL=http://backend:8000
+    depends_on:
+      jellyfin:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
+    restart: on-failure:5
+
+volumes:
+  jellyfin-localdev-config:
+  jellyfin-localdev-cache:

--- a/docker-compose.localdev.yml
+++ b/docker-compose.localdev.yml
@@ -57,7 +57,9 @@ services:
     restart: unless-stopped
 
   # Override backend with dev defaults — no .env needed
+  # user: root so named volume at /app/data is writable (dev-only)
   backend:
+    user: "0"
     environment:
       - JELLYFIN_URL=http://jellyfin:8096
       - SESSION_SECRET=localdev-32char-not-for-production

--- a/docker-compose.localdev.yml
+++ b/docker-compose.localdev.yml
@@ -30,8 +30,15 @@ services:
       retries: 10
       start_period: 30s
 
-  # Override Ollama to auto-pull required models on first start
+  # Ollama — CPU-only, auto-pulls required models on first start
+  # No nvidia GPU reservation (works on macOS + Linux without GPU)
+  # For GPU acceleration, use docker-compose.ollama.yml with make dev-full instead
   ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama-localdev-data:/root/.ollama
     entrypoint:
       - /bin/sh
       - -c
@@ -47,6 +54,7 @@ services:
       timeout: 10s
       retries: 20
       start_period: 300s
+    restart: unless-stopped
 
   # Override backend with dev defaults — no .env needed
   backend:
@@ -89,3 +97,4 @@ services:
 volumes:
   jellyfin-localdev-config:
   jellyfin-localdev-cache:
+  ollama-localdev-data:

--- a/docker-compose.localdev.yml
+++ b/docker-compose.localdev.yml
@@ -46,10 +46,10 @@ services:
         ollama serve &
         sleep 3
         ollama pull nomic-embed-text
-        ollama pull llama3.1:8b
+        ollama pull llama3.2:3b
         wait
     healthcheck:
-      test: ["CMD-SHELL", "ollama list | grep -q nomic-embed-text && ollama list | grep -q llama3.1"]
+      test: ["CMD-SHELL", "ollama list | grep -q nomic-embed-text && ollama list | grep -q llama3.2"]
       interval: 30s
       timeout: 10s
       retries: 20
@@ -94,6 +94,7 @@ services:
       - SESSION_SECRET=localdev-32char-not-for-production
       - SESSION_SECURE_COOKIE=false
       - OLLAMA_HOST=http://ollama:11434
+      - OLLAMA_CHAT_MODEL=llama3.2:3b
       - LOG_LEVEL=debug
       - SYNC_INTERVAL_HOURS=0
       - CORS_ORIGIN=http://localhost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-    env_file: .env
+    env_file:
+      - path: .env
+        required: false
     ports:
       - "127.0.0.1:8000:8000"
     volumes:

--- a/scripts/dev-provision.py
+++ b/scripts/dev-provision.py
@@ -2,13 +2,16 @@
 # requires-python = ">=3.12"
 # dependencies = ["httpx"]
 # ///
-"""Provision the local dev stack: Jellyfin wizard, test users, library, backend sync.
+"""Provision the local dev stack in two phases.
+
+Phase 1 (--phase init): Jellyfin wizard, test users, API key, library scan.
+  Writes JELLYFIN_API_KEY and JELLYFIN_ADMIN_USER_ID to /shared/.localdev-env
+  so the backend can source them at startup.
+
+Phase 2 (--phase sync): Log in to backend, trigger library sync, wait.
 
 Dev-only — all credentials are for the disposable local stack.
 Do not use these values against a real Jellyfin server.
-
-Runs as a one-shot container in docker-compose.localdev.yml.
-Idempotent — safe to re-run against an already-provisioned instance.
 """
 
 from __future__ import annotations
@@ -17,6 +20,7 @@ import asyncio
 import logging
 import os
 import sys
+from pathlib import Path
 
 import httpx
 
@@ -32,6 +36,7 @@ log = logging.getLogger("provision")
 # ---------------------------------------------------------------------------
 JELLYFIN_URL = os.environ.get("JELLYFIN_URL", "http://jellyfin:8096")
 BACKEND_URL = os.environ.get("BACKEND_URL", "http://backend:8000")
+SHARED_DIR = os.environ.get("SHARED_DIR", "/shared")
 
 ADMIN_USER = "root"
 ADMIN_PASS = "test-admin-password"
@@ -43,7 +48,6 @@ TEST_USERS = [
 
 EXPECTED_TOTAL = 35  # 25 movies + 10 shows
 
-# Jellyfin auth header format (same as integration conftest)
 _AUTH_HEADER = (
     'MediaBrowser Client="ai-movie-suggester-dev", '
     'DeviceId="dev-provision", Device="provision-script", Version="0.0.0"'
@@ -59,9 +63,29 @@ def _auth_headers(token: str | None = None) -> dict[str, str]:
 
 
 # ---------------------------------------------------------------------------
-# Phase 1: Jellyfin wizard
+# Phase 1: Init — Jellyfin provisioning
 # ---------------------------------------------------------------------------
-async def complete_wizard(client: httpx.AsyncClient) -> str:
+async def phase_init() -> None:
+    """Provision Jellyfin and write runtime env for the backend."""
+    log.info("=== Phase 1: Jellyfin init ===")
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        admin_user = await _complete_wizard(client)
+        token, user_id = await _authenticate_admin(client, admin_user)
+        await _create_test_users(client, token)
+        api_key = await _create_api_key(client, token)
+        await _setup_libraries(client, token)
+
+    # Write runtime env for the backend to source
+    env_path = Path(SHARED_DIR) / ".localdev-env"
+    env_path.write_text(
+        f"JELLYFIN_API_KEY={api_key}\nJELLYFIN_ADMIN_USER_ID={user_id}\n"
+    )
+    log.info("Wrote runtime env to %s", env_path)
+    log.info("=== Phase 1 complete ===")
+
+
+async def _complete_wizard(client: httpx.AsyncClient) -> str:
     """Complete Jellyfin first-run wizard. Returns admin username."""
     admin_user = ADMIN_USER
 
@@ -70,7 +94,6 @@ async def complete_wizard(client: httpx.AsyncClient) -> str:
         log.info("Wizard already completed")
         return admin_user
 
-    # Discover admin username
     resp = await client.get(f"{JELLYFIN_URL}/Startup/User")
     if resp.is_success:
         admin_user = resp.json().get("Name", ADMIN_USER)
@@ -85,31 +108,27 @@ async def complete_wizard(client: httpx.AsyncClient) -> str:
             "PreferredMetadataLanguage": "en",
         },
     )
-
     await client.post(
         f"{JELLYFIN_URL}/Startup/User",
         json={"Name": admin_user, "Password": ADMIN_PASS},
     )
-
     await client.post(
         f"{JELLYFIN_URL}/Startup/RemoteAccess",
         json={"EnableRemoteAccess": True, "EnableAutomaticPortMapping": False},
     )
-
     resp = await client.post(f"{JELLYFIN_URL}/Startup/Complete")
     resp.raise_for_status()
     log.info("Wizard complete")
     return admin_user
 
 
-# ---------------------------------------------------------------------------
-# Phase 2: Authenticate as admin
-# ---------------------------------------------------------------------------
-async def authenticate_admin(client: httpx.AsyncClient, admin_user: str) -> str:
-    """Authenticate as admin, setting password if needed. Returns token."""
+async def _authenticate_admin(
+    client: httpx.AsyncClient, admin_user: str
+) -> tuple[str, str]:
+    """Authenticate as admin. Returns (token, user_id)."""
     credentials = [
         (admin_user, ADMIN_PASS),
-        (admin_user, ""),  # fresh instance may have empty password
+        (admin_user, ""),
     ]
 
     for attempt in range(10):
@@ -124,7 +143,6 @@ async def authenticate_admin(client: httpx.AsyncClient, admin_user: str) -> str:
                 token: str = data["AccessToken"]
                 user_id: str = data["User"]["Id"]
 
-                # Set password if it was empty
                 if password != ADMIN_PASS:
                     await client.post(
                         f"{JELLYFIN_URL}/Users/{user_id}/Password",
@@ -133,8 +151,8 @@ async def authenticate_admin(client: httpx.AsyncClient, admin_user: str) -> str:
                     )
                     log.info("Admin password set")
 
-                log.info("Authenticated as '%s'", username)
-                return token
+                log.info("Authenticated as '%s' (id=%s)", username, user_id)
+                return token, user_id
 
         if attempt < 9:
             await asyncio.sleep(3)
@@ -143,10 +161,7 @@ async def authenticate_admin(client: httpx.AsyncClient, admin_user: str) -> str:
     sys.exit(1)
 
 
-# ---------------------------------------------------------------------------
-# Phase 3: Create test users
-# ---------------------------------------------------------------------------
-async def create_test_users(client: httpx.AsyncClient, token: str) -> None:
+async def _create_test_users(client: httpx.AsyncClient, token: str) -> None:
     """Create test users if they don't exist."""
     headers = _auth_headers(token)
     resp = await client.get(f"{JELLYFIN_URL}/Users", headers=headers)
@@ -166,11 +181,40 @@ async def create_test_users(client: httpx.AsyncClient, token: str) -> None:
         log.info("Created user '%s'", username)
 
 
-# ---------------------------------------------------------------------------
-# Phase 4: Add libraries and scan
-# ---------------------------------------------------------------------------
-async def setup_libraries(client: httpx.AsyncClient, token: str) -> None:
-    """Add Movies and Shows libraries, trigger scan, poll for completion."""
+async def _create_api_key(client: httpx.AsyncClient, token: str) -> str:
+    """Create a Jellyfin API key for the backend sync engine."""
+    headers = _auth_headers(token)
+
+    # Check if key already exists
+    resp = await client.get(f"{JELLYFIN_URL}/Auth/Keys", headers=headers)
+    resp.raise_for_status()
+    for key in resp.json().get("Items", []):
+        if key.get("AppName") == "localdev-sync":
+            log.info("API key 'localdev-sync' already exists")
+            return key["AccessToken"]
+
+    # Create new key
+    resp = await client.post(
+        f"{JELLYFIN_URL}/Auth/Keys",
+        params={"App": "localdev-sync"},
+        headers=headers,
+    )
+    resp.raise_for_status()
+
+    # Fetch back to get the generated key
+    resp = await client.get(f"{JELLYFIN_URL}/Auth/Keys", headers=headers)
+    resp.raise_for_status()
+    for key in resp.json().get("Items", []):
+        if key.get("AppName") == "localdev-sync":
+            log.info("Created API key 'localdev-sync'")
+            return key["AccessToken"]
+
+    log.error("Failed to retrieve created API key")
+    sys.exit(1)
+
+
+async def _setup_libraries(client: httpx.AsyncClient, token: str) -> None:
+    """Add libraries, trigger scan, poll for completion."""
     headers = _auth_headers(token)
 
     resp = await client.get(f"{JELLYFIN_URL}/Library/VirtualFolders", headers=headers)
@@ -203,7 +247,6 @@ async def setup_libraries(client: httpx.AsyncClient, token: str) -> None:
         )
         log.info("Added Shows library (status %d)", resp.status_code)
 
-    # Trigger library scan
     resp = await client.post(f"{JELLYFIN_URL}/Library/Refresh", headers=headers)
     resp.raise_for_status()
     log.info("Library scan triggered, polling for %d items...", EXPECTED_TOTAL)
@@ -213,7 +256,6 @@ async def setup_libraries(client: httpx.AsyncClient, token: str) -> None:
     while elapsed < POLL_TIMEOUT:
         await asyncio.sleep(POLL_INTERVAL)
         elapsed += POLL_INTERVAL
-
         resp = await client.get(
             f"{JELLYFIN_URL}/Items",
             params={"Recursive": "true", "IncludeItemTypes": "Movie,Series"},
@@ -235,86 +277,91 @@ async def setup_libraries(client: httpx.AsyncClient, token: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Phase 5: Trigger backend sync via authenticated session
+# Phase 2: Sync — trigger backend library sync
 # ---------------------------------------------------------------------------
-async def trigger_backend_sync(client: httpx.AsyncClient) -> None:
-    """Log in to the backend as admin and trigger library sync."""
-    # Log in to the backend (which authenticates against Jellyfin)
-    log.info("Logging in to backend as '%s'...", ADMIN_USER)
-    resp = await client.post(
-        f"{BACKEND_URL}/api/auth/login",
-        json={"username": ADMIN_USER, "password": ADMIN_PASS},
-    )
-    if not resp.is_success:
-        log.error(
-            "Backend login failed (status %d): %s",
-            resp.status_code,
-            resp.text[:200],
+async def phase_sync() -> None:
+    """Log in to the backend and trigger library sync."""
+    log.info("=== Phase 2: Backend sync ===")
+
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        # Log in as admin
+        log.info("Logging in to backend as '%s'...", ADMIN_USER)
+        resp = await client.post(
+            f"{BACKEND_URL}/api/auth/login",
+            json={"username": ADMIN_USER, "password": ADMIN_PASS},
         )
-        sys.exit(1)
+        if not resp.is_success:
+            log.error(
+                "Backend login failed (status %d): %s",
+                resp.status_code,
+                resp.text[:200],
+            )
+            sys.exit(1)
 
-    # Extract session cookie for subsequent requests
-    cookies = resp.cookies
-    log.info("Backend login successful, triggering sync...")
+        cookies = resp.cookies
+        csrf_token = cookies.get("csrf_token", "")
+        csrf_headers = {"X-CSRF-Token": csrf_token} if csrf_token else {}
+        log.info("Backend login successful, triggering sync...")
 
-    resp = await client.post(
-        f"{BACKEND_URL}/api/admin/sync",
-        cookies=cookies,
-    )
-    if resp.status_code == 202:
-        log.info("Sync triggered (202 Accepted)")
-    elif resp.status_code == 409:
-        log.info("Sync already running (409 Conflict) — OK")
-    else:
-        log.warning(
-            "Sync trigger returned %d: %s",
-            resp.status_code,
-            resp.text[:200],
-        )
-
-    # Poll sync status until complete
-    log.info("Waiting for sync to complete...")
-    for _ in range(60):
-        await asyncio.sleep(5)
-        resp = await client.get(
-            f"{BACKEND_URL}/api/admin/sync/status",
+        # Trigger sync
+        resp = await client.post(
+            f"{BACKEND_URL}/api/admin/sync",
             cookies=cookies,
+            headers=csrf_headers,
         )
-        if resp.is_success:
-            data = resp.json()
-            status = data.get("status", "unknown")
-            if status == "idle":
-                item_count = data.get("items_synced", 0)
-                log.info("Sync complete: %d items synced", item_count)
-                return
-            log.info("Sync status: %s", status)
+        if resp.status_code == 202:
+            log.info("Sync triggered (202 Accepted)")
+        elif resp.status_code == 409:
+            log.info("Sync already running (409 Conflict) — OK")
+        else:
+            log.warning(
+                "Sync trigger returned %d: %s",
+                resp.status_code,
+                resp.text[:200],
+            )
+            # Non-fatal — sync may not be configured yet on first run
+            # The backend will sync when it has the right env vars
 
-    log.warning("Sync did not complete within timeout — continuing anyway")
+        # Poll sync status
+        log.info("Waiting for sync to complete...")
+        for _ in range(60):
+            await asyncio.sleep(5)
+            resp = await client.get(
+                f"{BACKEND_URL}/api/admin/sync/status",
+                cookies=cookies,
+                headers=csrf_headers,
+            )
+            if resp.is_success:
+                data = resp.json()
+                status = data.get("status", "unknown")
+                if status == "idle":
+                    item_count = data.get("items_synced", 0)
+                    log.info("Sync complete: %d items synced", item_count)
+                    break
+                log.info("Sync status: %s", status)
+        else:
+            log.warning("Sync did not complete within timeout — continuing")
+
+    log.info("=== Phase 2 complete ===")
+    log.info("Open http://localhost:3000 and log in as:")
+    log.info("  Username: test-alice")
+    log.info("  Password: test-alice-password")
 
 
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 async def main() -> None:
-    log.info("=== Dev provisioner starting ===")
-    log.info("Jellyfin: %s", JELLYFIN_URL)
-    log.info("Backend:  %s", BACKEND_URL)
+    phase = "all"
+    if "--phase" in sys.argv:
+        idx = sys.argv.index("--phase")
+        if idx + 1 < len(sys.argv):
+            phase = sys.argv[idx + 1]
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        # Phase 1-4: Jellyfin provisioning
-        admin_user = await complete_wizard(client)
-        token = await authenticate_admin(client, admin_user)
-        await create_test_users(client, token)
-        await setup_libraries(client, token)
-
-    # Phase 5: Backend sync (separate client for cookie handling)
-    async with httpx.AsyncClient(timeout=60.0) as client:
-        await trigger_backend_sync(client)
-
-    log.info("=== Dev provisioner complete ===")
-    log.info("Open http://localhost:3000 and log in as:")
-    log.info("  Username: test-alice")
-    log.info("  Password: test-alice-password")
+    if phase in ("all", "init"):
+        await phase_init()
+    if phase in ("all", "sync"):
+        await phase_sync()
 
 
 if __name__ == "__main__":

--- a/scripts/dev-provision.py
+++ b/scripts/dev-provision.py
@@ -1,0 +1,321 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["httpx"]
+# ///
+"""Provision the local dev stack: Jellyfin wizard, test users, library, backend sync.
+
+Dev-only — all credentials are for the disposable local stack.
+Do not use these values against a real Jellyfin server.
+
+Runs as a one-shot container in docker-compose.localdev.yml.
+Idempotent — safe to re-run against an already-provisioned instance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+import httpx
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [provision] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("provision")
+
+# ---------------------------------------------------------------------------
+# Config — matches docker-compose.localdev.yml and integration conftest
+# ---------------------------------------------------------------------------
+JELLYFIN_URL = os.environ.get("JELLYFIN_URL", "http://jellyfin:8096")
+BACKEND_URL = os.environ.get("BACKEND_URL", "http://backend:8000")
+
+ADMIN_USER = "root"
+ADMIN_PASS = "test-admin-password"
+
+TEST_USERS = [
+    ("test-alice", "test-alice-password"),
+    ("test-bob", "test-bob-password"),
+]
+
+EXPECTED_TOTAL = 35  # 25 movies + 10 shows
+
+# Jellyfin auth header format (same as integration conftest)
+_AUTH_HEADER = (
+    'MediaBrowser Client="ai-movie-suggester-dev", '
+    'DeviceId="dev-provision", Device="provision-script", Version="0.0.0"'
+)
+
+POLL_INTERVAL = 2
+POLL_TIMEOUT = 120
+
+
+def _auth_headers(token: str | None = None) -> dict[str, str]:
+    value = _AUTH_HEADER if token is None else f"{_AUTH_HEADER}, Token={token}"
+    return {"Authorization": value}
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Jellyfin wizard
+# ---------------------------------------------------------------------------
+async def complete_wizard(client: httpx.AsyncClient) -> str:
+    """Complete Jellyfin first-run wizard. Returns admin username."""
+    admin_user = ADMIN_USER
+
+    resp = await client.get(f"{JELLYFIN_URL}/Startup/Configuration")
+    if resp.status_code != 200:
+        log.info("Wizard already completed")
+        return admin_user
+
+    # Discover admin username
+    resp = await client.get(f"{JELLYFIN_URL}/Startup/User")
+    if resp.is_success:
+        admin_user = resp.json().get("Name", ADMIN_USER)
+
+    log.info("Completing wizard for user '%s'...", admin_user)
+
+    await client.post(
+        f"{JELLYFIN_URL}/Startup/Configuration",
+        json={
+            "UICulture": "en-US",
+            "MetadataCountryCode": "US",
+            "PreferredMetadataLanguage": "en",
+        },
+    )
+
+    await client.post(
+        f"{JELLYFIN_URL}/Startup/User",
+        json={"Name": admin_user, "Password": ADMIN_PASS},
+    )
+
+    await client.post(
+        f"{JELLYFIN_URL}/Startup/RemoteAccess",
+        json={"EnableRemoteAccess": True, "EnableAutomaticPortMapping": False},
+    )
+
+    resp = await client.post(f"{JELLYFIN_URL}/Startup/Complete")
+    resp.raise_for_status()
+    log.info("Wizard complete")
+    return admin_user
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Authenticate as admin
+# ---------------------------------------------------------------------------
+async def authenticate_admin(client: httpx.AsyncClient, admin_user: str) -> str:
+    """Authenticate as admin, setting password if needed. Returns token."""
+    credentials = [
+        (admin_user, ADMIN_PASS),
+        (admin_user, ""),  # fresh instance may have empty password
+    ]
+
+    for attempt in range(10):
+        for username, password in credentials:
+            resp = await client.post(
+                f"{JELLYFIN_URL}/Users/AuthenticateByName",
+                json={"Username": username, "Pw": password},
+                headers=_auth_headers(),
+            )
+            if resp.is_success:
+                data = resp.json()
+                token: str = data["AccessToken"]
+                user_id: str = data["User"]["Id"]
+
+                # Set password if it was empty
+                if password != ADMIN_PASS:
+                    await client.post(
+                        f"{JELLYFIN_URL}/Users/{user_id}/Password",
+                        json={"CurrentPw": password, "NewPw": ADMIN_PASS},
+                        headers=_auth_headers(token),
+                    )
+                    log.info("Admin password set")
+
+                log.info("Authenticated as '%s'", username)
+                return token
+
+        if attempt < 9:
+            await asyncio.sleep(3)
+
+    log.error("Failed to authenticate as admin after 10 attempts")
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Create test users
+# ---------------------------------------------------------------------------
+async def create_test_users(client: httpx.AsyncClient, token: str) -> None:
+    """Create test users if they don't exist."""
+    headers = _auth_headers(token)
+    resp = await client.get(f"{JELLYFIN_URL}/Users", headers=headers)
+    resp.raise_for_status()
+    existing = {u["Name"] for u in resp.json()}
+
+    for username, password in TEST_USERS:
+        if username in existing:
+            log.info("User '%s' already exists", username)
+            continue
+        resp = await client.post(
+            f"{JELLYFIN_URL}/Users/New",
+            json={"Name": username, "Password": password},
+            headers=headers,
+        )
+        resp.raise_for_status()
+        log.info("Created user '%s'", username)
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Add libraries and scan
+# ---------------------------------------------------------------------------
+async def setup_libraries(client: httpx.AsyncClient, token: str) -> None:
+    """Add Movies and Shows libraries, trigger scan, poll for completion."""
+    headers = _auth_headers(token)
+
+    resp = await client.get(f"{JELLYFIN_URL}/Library/VirtualFolders", headers=headers)
+    resp.raise_for_status()
+    existing = {lib["Name"] for lib in resp.json()}
+
+    if "Movies" not in existing:
+        resp = await client.post(
+            f"{JELLYFIN_URL}/Library/VirtualFolders",
+            params={
+                "name": "Movies",
+                "collectionType": "movies",
+                "refreshLibrary": "false",
+                "paths": "/media/movies",
+            },
+            headers=headers,
+        )
+        log.info("Added Movies library (status %d)", resp.status_code)
+
+    if "Shows" not in existing:
+        resp = await client.post(
+            f"{JELLYFIN_URL}/Library/VirtualFolders",
+            params={
+                "name": "Shows",
+                "collectionType": "tvshows",
+                "refreshLibrary": "false",
+                "paths": "/media/shows",
+            },
+            headers=headers,
+        )
+        log.info("Added Shows library (status %d)", resp.status_code)
+
+    # Trigger library scan
+    resp = await client.post(f"{JELLYFIN_URL}/Library/Refresh", headers=headers)
+    resp.raise_for_status()
+    log.info("Library scan triggered, polling for %d items...", EXPECTED_TOTAL)
+
+    elapsed = 0.0
+    total_count = 0
+    while elapsed < POLL_TIMEOUT:
+        await asyncio.sleep(POLL_INTERVAL)
+        elapsed += POLL_INTERVAL
+
+        resp = await client.get(
+            f"{JELLYFIN_URL}/Items",
+            params={"Recursive": "true", "IncludeItemTypes": "Movie,Series"},
+            headers=headers,
+        )
+        if resp.is_success:
+            total_count = resp.json().get("TotalRecordCount", 0)
+            if total_count >= EXPECTED_TOTAL:
+                log.info("Library scan complete: %d items", total_count)
+                return
+
+    log.error(
+        "Library scan did not reach %d items within %ds (got %d)",
+        EXPECTED_TOTAL,
+        POLL_TIMEOUT,
+        total_count,
+    )
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Trigger backend sync via authenticated session
+# ---------------------------------------------------------------------------
+async def trigger_backend_sync(client: httpx.AsyncClient) -> None:
+    """Log in to the backend as admin and trigger library sync."""
+    # Log in to the backend (which authenticates against Jellyfin)
+    log.info("Logging in to backend as '%s'...", ADMIN_USER)
+    resp = await client.post(
+        f"{BACKEND_URL}/api/auth/login",
+        json={"username": ADMIN_USER, "password": ADMIN_PASS},
+    )
+    if not resp.is_success:
+        log.error(
+            "Backend login failed (status %d): %s",
+            resp.status_code,
+            resp.text[:200],
+        )
+        sys.exit(1)
+
+    # Extract session cookie for subsequent requests
+    cookies = resp.cookies
+    log.info("Backend login successful, triggering sync...")
+
+    resp = await client.post(
+        f"{BACKEND_URL}/api/admin/sync",
+        cookies=cookies,
+    )
+    if resp.status_code == 202:
+        log.info("Sync triggered (202 Accepted)")
+    elif resp.status_code == 409:
+        log.info("Sync already running (409 Conflict) — OK")
+    else:
+        log.warning(
+            "Sync trigger returned %d: %s",
+            resp.status_code,
+            resp.text[:200],
+        )
+
+    # Poll sync status until complete
+    log.info("Waiting for sync to complete...")
+    for _ in range(60):
+        await asyncio.sleep(5)
+        resp = await client.get(
+            f"{BACKEND_URL}/api/admin/sync/status",
+            cookies=cookies,
+        )
+        if resp.is_success:
+            data = resp.json()
+            status = data.get("status", "unknown")
+            if status == "idle":
+                item_count = data.get("items_synced", 0)
+                log.info("Sync complete: %d items synced", item_count)
+                return
+            log.info("Sync status: %s", status)
+
+    log.warning("Sync did not complete within timeout — continuing anyway")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+async def main() -> None:
+    log.info("=== Dev provisioner starting ===")
+    log.info("Jellyfin: %s", JELLYFIN_URL)
+    log.info("Backend:  %s", BACKEND_URL)
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        # Phase 1-4: Jellyfin provisioning
+        admin_user = await complete_wizard(client)
+        token = await authenticate_admin(client, admin_user)
+        await create_test_users(client, token)
+        await setup_libraries(client, token)
+
+    # Phase 5: Backend sync (separate client for cookie handling)
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        await trigger_backend_sync(client)
+
+    log.info("=== Dev provisioner complete ===")
+    log.info("Open http://localhost:3000 and log in as:")
+    log.info("  Username: test-alice")
+    log.info("  Password: test-alice-password")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- `make dev` now spins up a complete working stack with zero configuration — Jellyfin with 35 fixture items, Ollama (CPU, tinyllama:1.1b), backend, frontend
- Two-phase provisioner: Phase 1 (jellyfin-init) provisions Jellyfin and writes API key to shared volume, Phase 2 (provisioner) triggers backend sync
- `.env` file no longer required — `env_file: required: false` in base compose, dev defaults inline in localdev overlay
- `make dev-full` preserved as fallback for BYO-Jellyfin users
- Port 8096 mutual-exclusion guard prevents collision between localdev and test Jellyfin stacks

### New files

| File | Purpose |
|------|---------|
| `docker-compose.localdev.yml` | Overlay: Jellyfin, Ollama (CPU), provisioner, backend dev defaults |
| `scripts/dev-provision.py` | Two-phase provisioner (PEP 723 inline deps) |

### Developer workflow

```bash
git clone <repo> && cd ai-movie-suggester
make dev
# → Everything starts. Open localhost:3000, log in as test-alice / test-alice-password
```

### Issues found during smoke testing

- #188 — a11y: CardDetail dialog missing DialogTitle
- #189 — Frontend SSE rendering: empty bubble + hang on second message
- #190 — No integration test for restricted Jellyfin user (parental controls)

## Test plan

- [x] `make dev` starts all services (Jellyfin, Ollama, backend, frontend, provisioner)
- [x] Provisioner completes Jellyfin wizard, creates users, scans 35 items
- [x] Backend syncs and embeds all 35 items (verified via `/health`)
- [x] Login as test-alice works
- [x] Chat API returns search results + streaming text (verified via curl)
- [x] Movie cards render in UI
- [x] Port guard prevents collision with `make jellyfin-up`
- [x] `make dev-down` tears down cleanly
- [ ] Existing unit tests pass (`make test`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)