### PR TITLE
fix(frontend): bypass Next.js rewrite for SSE chat streaming (#189)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,15 @@ TMDB_API_KEY=
 # Default: http://localhost:3000 (matches the dev frontend port)
 # CORS_ORIGIN=http://localhost:3000
 
+# --- Frontend SSE Streaming (set on the frontend service, not the backend) ---
+
+# Direct backend URL for SSE streaming from the browser.
+# Next.js rewrites buffer SSE responses; setting this bypasses the rewrite
+# for chat streaming. The origin must match CORS_ORIGIN on the backend.
+# Not needed for `make dev` (set automatically in docker-compose.localdev.yml).
+# In production, leave unset unless you've configured CORS and exposed the backend port.
+# NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
+
 # Enable /docs and /redoc API documentation endpoints
 # Default: enabled when LOG_LEVEL=debug, disabled otherwise
 # Set explicitly to override the LOG_LEVEL default

--- a/docker-compose.localdev.yml
+++ b/docker-compose.localdev.yml
@@ -108,6 +108,8 @@ services:
 
   # Override frontend to auto-install deps on first run
   # The named node_modules volume starts empty; npm ci populates it
+  # NEXT_PUBLIC_BACKEND_URL tells the client to stream SSE directly from
+  # the backend, bypassing Next.js rewrite buffering.
   frontend:
     command:
       - sh
@@ -115,6 +117,8 @@ services:
       - |
         [ -d node_modules/next ] || npm ci
         exec npm run dev
+    environment:
+      - NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
     depends_on:
       backend:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,10 @@ services:
       start_period: 15s
     restart: unless-stopped
 
+  # NEXT_PUBLIC_BACKEND_URL is intentionally not set here. Without it,
+  # the frontend proxies SSE through the Next.js rewrite (buffered but
+  # functional). Set it in docker-compose.localdev.yml for dev streaming
+  # or in .env for production if the backend is directly reachable.
   frontend:
     build:
       context: ./frontend

--- a/frontend/src/lib/api/chat-stream.ts
+++ b/frontend/src/lib/api/chat-stream.ts
@@ -1,4 +1,4 @@
-import { getCsrfToken, getBaseUrl, parseResponse } from "./shared";
+import { getCsrfToken, getStreamBaseUrl, parseResponse } from "./shared";
 import { networkFetch } from "./client";
 import type { SSEEvent } from "./types";
 
@@ -80,7 +80,7 @@ export async function sendChatMessage(
     headers["X-CSRF-Token"] = csrf;
   }
 
-  const response = await networkFetch(`${getBaseUrl()}/api/chat`, {
+  const response = await networkFetch(`${getStreamBaseUrl()}/api/chat`, {
     method: "POST",
     credentials: "include",
     headers,

--- a/frontend/src/lib/api/shared.ts
+++ b/frontend/src/lib/api/shared.ts
@@ -7,6 +7,23 @@ export function getBaseUrl(): string {
   return "";
 }
 
+/**
+ * Backend URL for client-side streaming (SSE) requests.
+ *
+ * Next.js rewrites buffer the entire response before returning it,
+ * which breaks SSE streaming. For endpoints that stream (e.g. /api/chat),
+ * the client must fetch directly from the backend, bypassing the rewrite.
+ *
+ * Falls back to same-origin rewrite ("") if not configured — streaming
+ * will be buffered but still functional (just not incremental).
+ */
+export function getStreamBaseUrl(): string {
+  if (typeof window === "undefined") {
+    return process.env.BACKEND_URL || "http://localhost:8000";
+  }
+  return process.env.NEXT_PUBLIC_BACKEND_URL || "";
+}
+
 export async function parseResponse<T>(response: Response): Promise<T> {
   let body: unknown;
   try {

--- a/frontend/src/lib/api/shared.ts
+++ b/frontend/src/lib/api/shared.ts
@@ -18,9 +18,12 @@ export function getBaseUrl(): string {
  * will be buffered but still functional (just not incremental).
  */
 export function getStreamBaseUrl(): string {
+  // Server-side: use the internal backend URL (same as getBaseUrl)
   if (typeof window === "undefined") {
-    return process.env.BACKEND_URL || "http://localhost:8000";
+    return getBaseUrl();
   }
+  // Client-side: use the public backend URL for direct SSE streaming,
+  // or fall back to same-origin rewrite ("") if not configured
   return process.env.NEXT_PUBLIC_BACKEND_URL || "";
 }
 

--- a/frontend/tests/lib/api/chat-stream.test.ts
+++ b/frontend/tests/lib/api/chat-stream.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/api/shared", async (importOriginal) => {
     ...actual,
     getCsrfToken: () => "test-csrf-token",
     getBaseUrl: () => "",
+    getStreamBaseUrl: () => "",
   };
 });
 


### PR DESCRIPTION
## Summary

- Next.js rewrites buffer the entire SSE response, causing empty chat bubbles and second-message hangs
- Add `getStreamBaseUrl()` that returns `NEXT_PUBLIC_BACKEND_URL` on the client, allowing direct fetch to the backend for streaming endpoints
- Non-streaming API calls continue using the Next.js rewrite (no change)
- Add `NEXT_PUBLIC_BACKEND_URL=http://localhost:8000` to localdev frontend environment

## Root cause

`sendChatMessage` fetched `/api/chat` through the Next.js rewrite proxy, which buffers the full response before returning. SSE requires chunked streaming. By fetching directly from the backend URL, the browser receives chunks in real time.

## Test plan

- [x] 170 frontend tests pass (vitest)
- [x] eslint + tsc clean
- [x] Manual test: chat streams text incrementally in `make dev` stack
- [x] Multi-turn chat works (second message no longer hangs)
- [ ] CI passes

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)