### PR TITLE
chore: tech debt batch 4 — shared fixtures, DRY helpers, pre-commit fix

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 # Pre-commit hook for ai-movie-suggester monorepo
 # Install with: make hooks
 # Runs ruff on staged Python files, eslint+prettier on staged TS/TSX files

--- a/backend/app/sync/engine.py
+++ b/backend/app/sync/engine.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
-def _to_row(item: LibraryItem, content_hash: str) -> LibraryItemRow:
+def to_library_row(item: LibraryItem, content_hash: str) -> LibraryItemRow:
     """Convert a Jellyfin LibraryItem to a LibraryItemRow for storage.
 
     Extracts actor names from the people list (filtering by Type == "Actor").
@@ -194,13 +194,13 @@ class SyncEngine:
                             if old_hash is None:
                                 # New item
                                 state.items_created += 1
-                                row = _to_row(item, content_hash)
+                                row = to_library_row(item, content_hash)
                                 rows_to_upsert.append(row)
                                 ids_to_enqueue.append(item.id)
                             elif old_hash != content_hash:
                                 # Changed item
                                 state.items_updated += 1
-                                row = _to_row(item, content_hash)
+                                row = to_library_row(item, content_hash)
                                 rows_to_upsert.append(row)
                                 ids_to_enqueue.append(item.id)
                             else:

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -4,15 +4,26 @@ Wizard completion and auth follow the pattern from Jellyfin's own
 integration tests (tests/Jellyfin.Server.Integration.Tests/AuthHelper.cs).
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
 import warnings
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import httpx
 import pytest
 import pytest_asyncio
+
+from app.jellyfin.client import JellyfinClient
+from app.library.store import LibraryStore
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import AsyncGenerator
+
+    from app.jellyfin.models import AuthResult
 
 _logger = logging.getLogger(__name__)
 
@@ -350,3 +361,38 @@ async def populated_library(
             f"within {_SCAN_POLL_TIMEOUT}s (got {total_count})"
         )
         raise TimeoutError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures — used across integration test modules
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def jf_client(
+    jellyfin: JellyfinInstance,
+) -> AsyncGenerator[JellyfinClient, None]:
+    """JellyfinClient pointed at the test instance."""
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        yield JellyfinClient(base_url=jellyfin.url, http_client=http)
+
+
+@pytest_asyncio.fixture
+async def library_store(
+    tmp_path: pathlib.Path,
+) -> AsyncGenerator[LibraryStore, None]:
+    """Temporary LibraryStore for integration tests."""
+    db_path = tmp_path / "test_library.db"
+    store = LibraryStore(str(db_path))
+    await store.init()
+    yield store
+    await store.close()
+
+
+@pytest_asyncio.fixture
+async def alice_auth(
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],  # noqa: ARG001 — ensures users exist
+) -> AuthResult:
+    """Authenticate as test-alice. Returns AuthResult."""
+    return await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)

--- a/backend/tests/integration/test_jellyfin_client.py
+++ b/backend/tests/integration/test_jellyfin_client.py
@@ -8,31 +8,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import httpx
 import pytest
-import pytest_asyncio
 
-from app.jellyfin.client import JellyfinClient
 from app.jellyfin.errors import JellyfinAuthError
 from app.jellyfin.models import AuthResult, PaginatedItems, UserInfo, WatchHistoryEntry
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
-
-    from tests.integration.conftest import JellyfinInstance
-
-# Re-use credentials from conftest
 from tests.integration.conftest import TEST_USER_ALICE, TEST_USER_ALICE_PASS
 
-
-@pytest_asyncio.fixture
-async def jf_client(
-    jellyfin: JellyfinInstance,
-) -> AsyncGenerator[JellyfinClient, None]:
-    """JellyfinClient pointed at the test instance."""
-    # TODO(#29): Read timeout from Settings.jellyfin_timeout when wired
-    async with httpx.AsyncClient(timeout=10.0) as http:
-        yield JellyfinClient(base_url=jellyfin.url, http_client=http)
+if TYPE_CHECKING:
+    from app.jellyfin.client import JellyfinClient
 
 
 @pytest.mark.integration
@@ -61,14 +44,13 @@ async def test_authenticate_invalid_credentials(
 @pytest.mark.integration
 async def test_get_user_with_valid_token(
     jf_client: JellyfinClient,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
 ) -> None:
     """get_user() returns correct info for an authenticated user."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
-    user = await jf_client.get_user(auth.access_token)
+    user = await jf_client.get_user(alice_auth.access_token)
     assert isinstance(user, UserInfo)
     assert user.name == TEST_USER_ALICE
-    assert user.id == test_users[TEST_USER_ALICE]
+    assert user.id == alice_auth.user_id
 
 
 @pytest.mark.integration
@@ -84,13 +66,12 @@ async def test_get_user_with_invalid_token(
 @pytest.mark.integration
 async def test_get_items_returns_paginated_result(
     jf_client: JellyfinClient,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
 ) -> None:
     """get_items() returns a PaginatedItems even if library is empty."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
     result = await jf_client.get_items(
-        auth.access_token,
-        auth.user_id,
+        alice_auth.access_token,
+        alice_auth.user_id,
         item_types=["Movie"],
     )
     assert isinstance(result, PaginatedItems)
@@ -102,13 +83,12 @@ async def test_get_items_returns_paginated_result(
 @pytest.mark.integration
 async def test_get_items_pagination_params(
     jf_client: JellyfinClient,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
 ) -> None:
     """Pagination parameters are respected (no crash, correct start_index)."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
     result = await jf_client.get_items(
-        auth.access_token,
-        auth.user_id,
+        alice_auth.access_token,
+        alice_auth.user_id,
         start_index=0,
         limit=5,
     )
@@ -119,11 +99,12 @@ async def test_get_items_pagination_params(
 @pytest.mark.integration
 async def test_get_watched_items_returns_list(
     jf_client: JellyfinClient,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
 ) -> None:
     """get_watched_items returns list[WatchHistoryEntry] (empty for test instance)."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
-    result = await jf_client.get_watched_items(auth.access_token, auth.user_id)
+    result = await jf_client.get_watched_items(
+        alice_auth.access_token, alice_auth.user_id
+    )
     assert isinstance(result, list)
     for entry in result:
         assert isinstance(entry, WatchHistoryEntry)
@@ -132,11 +113,12 @@ async def test_get_watched_items_returns_list(
 @pytest.mark.integration
 async def test_get_favorite_items_returns_list(
     jf_client: JellyfinClient,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
 ) -> None:
     """get_favorite_items returns list[WatchHistoryEntry] (empty for test instance)."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
-    result = await jf_client.get_favorite_items(auth.access_token, auth.user_id)
+    result = await jf_client.get_favorite_items(
+        alice_auth.access_token, alice_auth.user_id
+    )
     assert isinstance(result, list)
     for entry in result:
         assert isinstance(entry, WatchHistoryEntry)

--- a/backend/tests/integration/test_jellyfin_library.py
+++ b/backend/tests/integration/test_jellyfin_library.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from app.library.hashing import compute_content_hash
-from app.sync.engine import _to_row
+from app.sync.engine import to_library_row
 
 if TYPE_CHECKING:
     from app.jellyfin.client import JellyfinClient
@@ -30,7 +30,7 @@ def _to_library_row(item: LibraryItem) -> LibraryItemRow:
     """Convert a LibraryItem to a LibraryItemRow using the sync engine's converter."""
     # Build a temporary row to compute the content hash, then create
     # the real row with the correct hash — same as SyncEngine.run_sync().
-    temp = _to_row(item, "placeholder")
+    temp = to_library_row(item, "placeholder")
     return dataclasses.replace(temp, content_hash=compute_content_hash(temp))
 
 
@@ -40,11 +40,11 @@ async def test_get_all_items_returns_pages(
     alice_auth: AuthResult,
 ) -> None:
     """get_all_items returns pages — may be 0 items on fresh Jellyfin."""
-    auth = alice_auth
+
     pages: list[PaginatedItems] = []
     async for page in jf_client.get_all_items(
-        auth.access_token,
-        auth.user_id,
+        alice_auth.access_token,
+        alice_auth.user_id,
         item_types=["Movie"],
     ):
         pages.append(page)
@@ -61,13 +61,13 @@ async def test_fetch_and_store_cycle(
     library_store: LibraryStore,
 ) -> None:
     """Fetch items via get_all_items, store in LibraryStore, verify count."""
-    auth = alice_auth
+
     total_items = 0
     all_rows: list[LibraryItemRow] = []
 
     async for page in jf_client.get_all_items(
-        auth.access_token,
-        auth.user_id,
+        alice_auth.access_token,
+        alice_auth.user_id,
         item_types=["Movie"],
     ):
         total_items = page.total_count
@@ -89,10 +89,10 @@ async def test_extended_fields_no_validation_errors(
     alice_auth: AuthResult,
 ) -> None:
     """Extended fields parse without Pydantic validation errors."""
-    auth = alice_auth
+
     async for page in jf_client.get_all_items(
-        auth.access_token,
-        auth.user_id,
+        alice_auth.access_token,
+        alice_auth.user_id,
         item_types=["Movie"],
     ):
         for item in page.items:
@@ -118,10 +118,10 @@ async def test_populated_library_has_movies(
     alice_auth: AuthResult,
 ) -> None:
     """Populated Jellyfin has at least the expected number of movies."""
-    auth = alice_auth
+
     total = 0
     async for page in jf_client.get_all_items(
-        auth.access_token, auth.user_id, item_types=["Movie"]
+        alice_auth.access_token, alice_auth.user_id, item_types=["Movie"]
     ):
         total = page.total_count
     assert total >= EXPECTED_MOVIES
@@ -134,10 +134,10 @@ async def test_populated_library_has_shows(
     alice_auth: AuthResult,
 ) -> None:
     """Populated Jellyfin has at least the expected number of shows."""
-    auth = alice_auth
+
     total = 0
     async for page in jf_client.get_all_items(
-        auth.access_token, auth.user_id, item_types=["Series"]
+        alice_auth.access_token, alice_auth.user_id, item_types=["Series"]
     ):
         total = page.total_count
     assert total >= EXPECTED_SHOWS
@@ -150,9 +150,9 @@ async def test_movie_metadata_from_nfo(
     alice_auth: AuthResult,
 ) -> None:
     """At least one movie has overview, genres, and year from NFO."""
-    auth = alice_auth
+
     async for page in jf_client.get_all_items(
-        auth.access_token, auth.user_id, item_types=["Movie"]
+        alice_auth.access_token, alice_auth.user_id, item_types=["Movie"]
     ):
         for item in page.items:
             if item.overview and item.genres and item.production_year:
@@ -167,9 +167,9 @@ async def test_show_metadata_from_nfo(
     alice_auth: AuthResult,
 ) -> None:
     """At least one show has overview and genres from NFO."""
-    auth = alice_auth
+
     async for page in jf_client.get_all_items(
-        auth.access_token, auth.user_id, item_types=["Series"]
+        alice_auth.access_token, alice_auth.user_id, item_types=["Series"]
     ):
         for item in page.items:
             if item.overview and item.genres:

--- a/backend/tests/integration/test_jellyfin_library.py
+++ b/backend/tests/integration/test_jellyfin_library.py
@@ -28,8 +28,9 @@ from tests.integration.conftest import (
 
 def _to_library_row(item: LibraryItem) -> LibraryItemRow:
     """Convert a LibraryItem to a LibraryItemRow using the sync engine's converter."""
-    # Build a temporary row to compute the content hash, then create
-    # the real row with the correct hash — same as SyncEngine.run_sync().
+    # Build a temporary row to compute a content hash, then replace the
+    # placeholder. Note: SyncEngine uses build_composite_text + SHA-256;
+    # this uses compute_content_hash which is sufficient for test assertions.
     temp = to_library_row(item, "placeholder")
     return dataclasses.replace(temp, content_hash=compute_content_hash(temp))
 

--- a/backend/tests/integration/test_jellyfin_library.py
+++ b/backend/tests/integration/test_jellyfin_library.py
@@ -7,17 +7,17 @@ Uses the existing fixture chain: jellyfin -> admin_auth_token -> test_users.
 from __future__ import annotations
 
 import dataclasses
-import time
 from typing import TYPE_CHECKING
 
 import pytest
 
 from app.library.hashing import compute_content_hash
-from app.library.models import LibraryItemRow
+from app.sync.engine import _to_row
 
 if TYPE_CHECKING:
     from app.jellyfin.client import JellyfinClient
     from app.jellyfin.models import AuthResult, LibraryItem, PaginatedItems
+    from app.library.models import LibraryItemRow
     from app.library.store import LibraryStore
 
 from tests.integration.conftest import (
@@ -27,23 +27,11 @@ from tests.integration.conftest import (
 
 
 def _to_library_row(item: LibraryItem) -> LibraryItemRow:
-    """Convert a LibraryItem to a LibraryItemRow for storage."""
-    actor_names = [p["Name"] for p in item.people if p.get("Type") == "Actor"]
-    row = LibraryItemRow(
-        jellyfin_id=item.id,
-        title=item.name,
-        overview=item.overview,
-        production_year=item.production_year,
-        genres=item.genres,
-        tags=item.tags,
-        studios=item.studios,
-        community_rating=item.community_rating,
-        people=actor_names,
-        content_hash="placeholder",
-        synced_at=int(time.time()),
-    )
-    # Compute real hash and replace placeholder
-    return dataclasses.replace(row, content_hash=compute_content_hash(row))
+    """Convert a LibraryItem to a LibraryItemRow using the sync engine's converter."""
+    # Build a temporary row to compute the content hash, then create
+    # the real row with the correct hash — same as SyncEngine.run_sync().
+    temp = _to_row(item, "placeholder")
+    return dataclasses.replace(temp, content_hash=compute_content_hash(temp))
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/test_jellyfin_library.py
+++ b/backend/tests/integration/test_jellyfin_library.py
@@ -10,47 +10,20 @@ import dataclasses
 import time
 from typing import TYPE_CHECKING
 
-import httpx
 import pytest
-import pytest_asyncio
 
-from app.jellyfin.client import JellyfinClient
 from app.library.hashing import compute_content_hash
 from app.library.models import LibraryItemRow
-from app.library.store import LibraryStore
 
 if TYPE_CHECKING:
-    import pathlib
-    from collections.abc import AsyncGenerator
-
-    from app.jellyfin.models import LibraryItem, PaginatedItems
-    from tests.integration.conftest import JellyfinInstance
+    from app.jellyfin.client import JellyfinClient
+    from app.jellyfin.models import AuthResult, LibraryItem, PaginatedItems
+    from app.library.store import LibraryStore
 
 from tests.integration.conftest import (
     EXPECTED_MOVIES,
     EXPECTED_SHOWS,
-    TEST_USER_ALICE,
-    TEST_USER_ALICE_PASS,
 )
-
-
-@pytest_asyncio.fixture
-async def jf_client(
-    jellyfin: JellyfinInstance,
-) -> AsyncGenerator[JellyfinClient, None]:
-    """JellyfinClient pointed at the test instance."""
-    async with httpx.AsyncClient(timeout=10.0) as http:
-        yield JellyfinClient(base_url=jellyfin.url, http_client=http)
-
-
-@pytest_asyncio.fixture
-async def library_store(tmp_path: pathlib.Path) -> AsyncGenerator[LibraryStore, None]:
-    """Temporary LibraryStore for integration tests."""
-    db_path = tmp_path / "test_library.db"
-    store = LibraryStore(str(db_path))
-    await store.init()
-    yield store
-    await store.close()
 
 
 def _to_library_row(item: LibraryItem) -> LibraryItemRow:
@@ -76,10 +49,10 @@ def _to_library_row(item: LibraryItem) -> LibraryItemRow:
 @pytest.mark.integration
 async def test_get_all_items_returns_pages(
     jf_client: JellyfinClient,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
 ) -> None:
     """get_all_items returns pages — may be 0 items on fresh Jellyfin."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    auth = alice_auth
     pages: list[PaginatedItems] = []
     async for page in jf_client.get_all_items(
         auth.access_token,
@@ -96,11 +69,11 @@ async def test_get_all_items_returns_pages(
 @pytest.mark.integration
 async def test_fetch_and_store_cycle(
     jf_client: JellyfinClient,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
     library_store: LibraryStore,
 ) -> None:
     """Fetch items via get_all_items, store in LibraryStore, verify count."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    auth = alice_auth
     total_items = 0
     all_rows: list[LibraryItemRow] = []
 
@@ -125,10 +98,10 @@ async def test_fetch_and_store_cycle(
 @pytest.mark.integration
 async def test_extended_fields_no_validation_errors(
     jf_client: JellyfinClient,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
 ) -> None:
     """Extended fields parse without Pydantic validation errors."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    auth = alice_auth
     async for page in jf_client.get_all_items(
         auth.access_token,
         auth.user_id,
@@ -154,10 +127,10 @@ async def test_extended_fields_no_validation_errors(
 async def test_populated_library_has_movies(
     jf_client: JellyfinClient,
     populated_library: int,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
 ) -> None:
     """Populated Jellyfin has at least the expected number of movies."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    auth = alice_auth
     total = 0
     async for page in jf_client.get_all_items(
         auth.access_token, auth.user_id, item_types=["Movie"]
@@ -170,10 +143,10 @@ async def test_populated_library_has_movies(
 async def test_populated_library_has_shows(
     jf_client: JellyfinClient,
     populated_library: int,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
 ) -> None:
     """Populated Jellyfin has at least the expected number of shows."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    auth = alice_auth
     total = 0
     async for page in jf_client.get_all_items(
         auth.access_token, auth.user_id, item_types=["Series"]
@@ -186,10 +159,10 @@ async def test_populated_library_has_shows(
 async def test_movie_metadata_from_nfo(
     jf_client: JellyfinClient,
     populated_library: int,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
 ) -> None:
     """At least one movie has overview, genres, and year from NFO."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    auth = alice_auth
     async for page in jf_client.get_all_items(
         auth.access_token, auth.user_id, item_types=["Movie"]
     ):
@@ -203,10 +176,10 @@ async def test_movie_metadata_from_nfo(
 async def test_show_metadata_from_nfo(
     jf_client: JellyfinClient,
     populated_library: int,
-    test_users: dict[str, str],
+    alice_auth: AuthResult,
 ) -> None:
     """At least one show has overview and genres from NFO."""
-    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    auth = alice_auth
     async for page in jf_client.get_all_items(
         auth.access_token, auth.user_id, item_types=["Series"]
     ):

--- a/backend/tests/integration/test_nfo_validation.py
+++ b/backend/tests/integration/test_nfo_validation.py
@@ -65,6 +65,25 @@ def _assert_required_fields(root: ET.Element, fields: list[str], filename: str) 
         assert elem.text and elem.text.strip(), f"Empty <{field}> in {filename}"
 
 
+def _assert_actors(root: ET.Element, min_count: int, filename: str) -> None:
+    """Assert at least min_count actors with <name> elements."""
+    actors = root.findall("actor")
+    assert len(actors) >= min_count, (
+        f"Need >= {min_count} <actor> entries in {filename}, got {len(actors)}"
+    )
+    for actor in actors:
+        name = actor.find("name")
+        assert name is not None and name.text, f"Actor missing <name> in {filename}"
+
+
+def _assert_min_plot_length(root: ET.Element, filename: str) -> None:
+    """Assert plot text meets minimum length."""
+    plot = root.findtext("plot", default="")
+    assert len(plot) >= _MIN_PLOT_LENGTH, (
+        f"Plot too short ({len(plot)} chars, need {_MIN_PLOT_LENGTH}): {filename}"
+    )
+
+
 @pytest.mark.integration
 def test_fixture_counts_match_expected() -> None:
     """Guard: fixture directory has the expected number of NFO files.
@@ -91,19 +110,8 @@ def test_movie_nfo_has_required_fields(nfo_path: Path) -> None:
     assert root.tag == "movie", f"Expected <movie> root, got <{root.tag}>"
 
     _assert_required_fields(root, _MOVIE_REQUIRED, nfo_path.name)
-
-    # Actors need nested <name> elements
-    actors = root.findall("actor")
-    assert len(actors) >= 2, f"Need >= 2 <actor> entries, got {len(actors)}"
-    for actor in actors:
-        name = actor.find("name")
-        assert name is not None and name.text, "Actor missing <name>"
-
-    # Plot richness check
-    plot = root.findtext("plot", default="")
-    assert len(plot) >= _MIN_PLOT_LENGTH, (
-        f"Plot too short ({len(plot)} chars, need {_MIN_PLOT_LENGTH}): {nfo_path.name}"
-    )
+    _assert_actors(root, 2, nfo_path.name)
+    _assert_min_plot_length(root, nfo_path.name)
 
 
 @pytest.mark.integration
@@ -115,17 +123,8 @@ def test_show_nfo_has_required_fields(nfo_path: Path) -> None:
     assert root.tag == "tvshow", f"Expected <tvshow> root, got <{root.tag}>"
 
     _assert_required_fields(root, _SHOW_REQUIRED, nfo_path.name)
-
-    actors = root.findall("actor")
-    assert len(actors) >= 2, f"Need >= 2 <actor> entries, got {len(actors)}"
-    for actor in actors:
-        name = actor.find("name")
-        assert name is not None and name.text, "Actor missing <name>"
-
-    plot = root.findtext("plot", default="")
-    assert len(plot) >= _MIN_PLOT_LENGTH, (
-        f"Plot too short ({len(plot)} chars, need {_MIN_PLOT_LENGTH}): {nfo_path.name}"
-    )
+    _assert_actors(root, 2, nfo_path.name)
+    _assert_min_plot_length(root, nfo_path.name)
 
 
 @pytest.mark.integration
@@ -139,8 +138,4 @@ def test_episode_nfo_has_required_fields(nfo_path: Path) -> None:
     )
 
     _assert_required_fields(root, _EPISODE_REQUIRED, nfo_path.name)
-
-    plot = root.findtext("plot", default="")
-    assert len(plot) >= _MIN_PLOT_LENGTH, (
-        f"Plot too short ({len(plot)} chars, need {_MIN_PLOT_LENGTH}): {nfo_path.name}"
-    )
+    _assert_min_plot_length(root, nfo_path.name)

--- a/backend/tests/integration/test_nfo_validation.py
+++ b/backend/tests/integration/test_nfo_validation.py
@@ -57,6 +57,14 @@ def _nfo_id(path: Path) -> str:
     return str(path.relative_to(_MEDIA_ROOT))
 
 
+def _assert_required_fields(root: ET.Element, fields: list[str], filename: str) -> None:
+    """Assert all required fields exist and have non-empty text."""
+    for field in fields:
+        elem = root.find(field)
+        assert elem is not None, f"Missing <{field}> in {filename}"
+        assert elem.text and elem.text.strip(), f"Empty <{field}> in {filename}"
+
+
 @pytest.mark.integration
 def test_fixture_counts_match_expected() -> None:
     """Guard: fixture directory has the expected number of NFO files.
@@ -82,10 +90,7 @@ def test_movie_nfo_has_required_fields(nfo_path: Path) -> None:
     root = tree.getroot()
     assert root.tag == "movie", f"Expected <movie> root, got <{root.tag}>"
 
-    for field in _MOVIE_REQUIRED:
-        elem = root.find(field)
-        assert elem is not None, f"Missing <{field}> in {nfo_path.name}"
-        assert elem.text and elem.text.strip(), f"Empty <{field}> in {nfo_path.name}"
+    _assert_required_fields(root, _MOVIE_REQUIRED, nfo_path.name)
 
     # Actors need nested <name> elements
     actors = root.findall("actor")
@@ -109,10 +114,7 @@ def test_show_nfo_has_required_fields(nfo_path: Path) -> None:
     root = tree.getroot()
     assert root.tag == "tvshow", f"Expected <tvshow> root, got <{root.tag}>"
 
-    for field in _SHOW_REQUIRED:
-        elem = root.find(field)
-        assert elem is not None, f"Missing <{field}> in {nfo_path.name}"
-        assert elem.text and elem.text.strip(), f"Empty <{field}> in {nfo_path.name}"
+    _assert_required_fields(root, _SHOW_REQUIRED, nfo_path.name)
 
     actors = root.findall("actor")
     assert len(actors) >= 2, f"Need >= 2 <actor> entries, got {len(actors)}"
@@ -136,10 +138,7 @@ def test_episode_nfo_has_required_fields(nfo_path: Path) -> None:
         f"Expected <episodedetails> root, got <{root.tag}>"
     )
 
-    for field in _EPISODE_REQUIRED:
-        elem = root.find(field)
-        assert elem is not None, f"Missing <{field}> in {nfo_path.name}"
-        assert elem.text and elem.text.strip(), f"Empty <{field}> in {nfo_path.name}"
+    _assert_required_fields(root, _EPISODE_REQUIRED, nfo_path.name)
 
     plot = root.findtext("plot", default="")
     assert len(plot) >= _MIN_PLOT_LENGTH, (

--- a/backend/tests/integration/test_sync_engine.py
+++ b/backend/tests/integration/test_sync_engine.py
@@ -15,40 +15,16 @@ from pydantic import SecretStr
 
 from app.config import Settings
 from app.jellyfin.client import JellyfinClient
-from app.library.store import LibraryStore
 from app.sync.engine import SyncEngine
 
 if TYPE_CHECKING:
-    import pathlib
-    from collections.abc import AsyncGenerator
-
+    from app.library.store import LibraryStore
     from tests.integration.conftest import JellyfinInstance
 
 from tests.integration.conftest import (
     EXPECTED_TOTAL,
     TEST_ADMIN_PASS,
 )
-
-
-@pytest_asyncio.fixture
-async def jf_client(
-    jellyfin: JellyfinInstance,
-) -> AsyncGenerator[JellyfinClient, None]:
-    """JellyfinClient pointed at the test instance."""
-    async with httpx.AsyncClient(timeout=30.0) as http:
-        yield JellyfinClient(base_url=jellyfin.url, http_client=http)
-
-
-@pytest_asyncio.fixture
-async def library_store(
-    tmp_path: pathlib.Path,
-) -> AsyncGenerator[LibraryStore, None]:
-    """Temporary LibraryStore for sync tests."""
-    db_path = tmp_path / "sync_test_library.db"
-    store = LibraryStore(str(db_path))
-    await store.init()
-    yield store
-    await store.close()
 
 
 def _make_sync_settings(


### PR DESCRIPTION
## Summary

Clean house before Epic 4. Six tech debt issues resolved in two commits:

| Issue | Fix |
|-------|-----|
| #170 | Add `set -e` to pre-commit hook (abort on lint/format failure) |
| #180 | Extract shared `jf_client` fixture to integration conftest |
| #181 | Extract shared `library_store` fixture to integration conftest |
| #184 | Add `alice_auth` fixture, replace 13 duplicate authenticate calls |
| #182 | Extract `_assert_required_fields` helper in NFO validation tests |
| #183 | Reuse sync engine's `_to_row` in test instead of duplicating converter |

Also closed #188 (DialogTitle a11y) — already fixed in existing code.

**Net result:** -138 lines removed, +103 added. Less duplication, same coverage.

## Test plan

- [x] 690 unit tests pass (0 regressions)
- [x] Ruff lint + format clean
- [ ] CI passes
- [ ] Integration tests pass (fixture changes — verify with `make test-integration-full`)

Closes #170, #180, #181, #182, #183, #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)