### PR TITLE
feat(devices): add GET /api/devices + shared Jellyfin transport

### DIFF
--- a/backend/app/devices/router.py
+++ b/backend/app/devices/router.py
@@ -1,0 +1,74 @@
+"""Devices API route — list Jellyfin sessions that can receive Play commands.
+
+Authenticated read endpoint (CSRF-exempt per the project's Double-Submit
+policy, which only applies to state-changing requests).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from slowapi import Limiter  # noqa: TC002
+
+from app.auth.dependencies import get_current_session
+from app.jellyfin.device_models import Device  # noqa: TC001
+from app.jellyfin.sessions import JellyfinSessionsClient  # noqa: TC001
+
+if TYPE_CHECKING:
+    from app.auth.models import SessionMeta
+
+logger = logging.getLogger(__name__)
+
+# 10 requests/minute per user — consistent with existing read endpoints
+# (search). Rate limit is hard-coded, matching the `CHAT_RATE_LIMIT` /
+# `LOGIN_RATE_LIMIT` pattern for per-endpoint tightening that is not
+# operator-tunable. Non-blocking per Spec 24 Open Question 2.
+_DEVICES_RATE_LIMIT = "10/minute"
+
+
+def get_sessions_client(request: Request) -> JellyfinSessionsClient:
+    """Dependency factory for ``JellyfinSessionsClient``.
+
+    Reads the already-built client off ``request.app.state``. Centralises
+    the lookup so tests can override it via FastAPI ``dependency_overrides``.
+    """
+    return request.app.state.jellyfin_sessions_client  # type: ignore[no-any-return]
+
+
+def create_devices_router(limiter: Limiter | None = None) -> APIRouter:
+    """Build the devices APIRouter.
+
+    Rate limit is hard-coded at 10/min per user (see module docstring).
+    """
+    router = APIRouter(prefix="/api", tags=["devices"])
+    _limit = limiter.limit(_DEVICES_RATE_LIMIT) if limiter else (lambda f: f)
+
+    @router.get(
+        "/devices",
+        response_model=list[Device],
+        responses={
+            401: {"description": "Not authenticated"},
+            429: {"description": "Rate limit exceeded"},
+        },
+    )
+    @_limit
+    async def list_devices(
+        request: Request,
+        session: SessionMeta = Depends(get_current_session),  # noqa: B008
+        sessions_client: JellyfinSessionsClient = Depends(get_sessions_client),  # noqa: B008
+    ) -> list[Device]:
+        """Return this user's controllable Jellyfin sessions.
+
+        Filters on ``SupportsRemoteControl == True``; classifies each
+        session by client string into a coarse ``DeviceType``.
+        """
+        session_store = request.app.state.session_store
+        token = await session_store.get_token(session.session_id)
+        if token is None:
+            raise HTTPException(status_code=401, detail="Not authenticated")
+
+        return await sessions_client.list_controllable(token)
+
+    return router

--- a/backend/app/devices/router.py
+++ b/backend/app/devices/router.py
@@ -14,6 +14,11 @@ from slowapi import Limiter  # noqa: TC002
 
 from app.auth.dependencies import get_current_session
 from app.jellyfin.device_models import Device  # noqa: TC001
+from app.jellyfin.errors import (
+    JellyfinAuthError,
+    JellyfinConnectionError,
+    JellyfinError,
+)
 from app.jellyfin.sessions import JellyfinSessionsClient  # noqa: TC001
 
 if TYPE_CHECKING:
@@ -21,10 +26,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# 10 requests/minute per user — consistent with existing read endpoints
+# 10 requests/minute per client IP — consistent with existing read endpoints
 # (search). Rate limit is hard-coded, matching the `CHAT_RATE_LIMIT` /
 # `LOGIN_RATE_LIMIT` pattern for per-endpoint tightening that is not
 # operator-tunable. Non-blocking per Spec 24 Open Question 2.
+#
+# Rate limit is per client IP (slowapi default). See #204 to migrate
+# auth-gated endpoints to per-user keying.
 _DEVICES_RATE_LIMIT = "10/minute"
 
 
@@ -40,7 +48,7 @@ def get_sessions_client(request: Request) -> JellyfinSessionsClient:
 def create_devices_router(limiter: Limiter | None = None) -> APIRouter:
     """Build the devices APIRouter.
 
-    Rate limit is hard-coded at 10/min per user (see module docstring).
+    Rate limit is hard-coded at 10/min per client IP (see module docstring).
     """
     router = APIRouter(prefix="/api", tags=["devices"])
     _limit = limiter.limit(_DEVICES_RATE_LIMIT) if limiter else (lambda f: f)
@@ -51,6 +59,8 @@ def create_devices_router(limiter: Limiter | None = None) -> APIRouter:
         responses={
             401: {"description": "Not authenticated"},
             429: {"description": "Rate limit exceeded"},
+            502: {"description": "Jellyfin upstream error"},
+            503: {"description": "Jellyfin unreachable"},
         },
     )
     @_limit
@@ -63,12 +73,26 @@ def create_devices_router(limiter: Limiter | None = None) -> APIRouter:
 
         Filters on ``SupportsRemoteControl == True``; classifies each
         session by client string into a coarse ``DeviceType``.
+
+        Rate limit is per client IP (slowapi default). See #204 to migrate
+        auth-gated endpoints to per-user keying.
         """
         session_store = request.app.state.session_store
         token = await session_store.get_token(session.session_id)
         if token is None:
             raise HTTPException(status_code=401, detail="Not authenticated")
 
-        return await sessions_client.list_controllable(token)
+        try:
+            return await sessions_client.list_controllable(token)
+        except JellyfinAuthError as exc:
+            # Revoked/expired Jellyfin token — surface as 401 so the
+            # frontend can trigger re-login. Mirrors the auth-failure
+            # split pattern used in auth/login and play routers.
+            raise HTTPException(status_code=401, detail="jellyfin_auth_failed") from exc
+        except JellyfinConnectionError as exc:
+            raise HTTPException(status_code=503, detail="jellyfin_unreachable") from exc
+        except JellyfinError as exc:
+            # Catch-all for upstream protocol/parse failures.
+            raise HTTPException(status_code=502, detail="jellyfin_error") from exc
 
     return router

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -11,26 +11,22 @@ import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypeVar
 
-import httpx
+from app.jellyfin.errors import (
+    JellyfinAuthError,
+    JellyfinError,
+)
+from app.jellyfin.models import AuthResult, PaginatedItems, UserInfo, WatchHistoryEntry
+from app.jellyfin.transport import _DEFAULT_DEVICE_ID, _JellyfinTransport
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable
 
-from app.jellyfin.errors import (
-    JellyfinAuthError,
-    JellyfinConnectionError,
-    JellyfinError,
-)
-from app.jellyfin.models import AuthResult, PaginatedItems, UserInfo, WatchHistoryEntry
+    import httpx
 
 logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
 
-_APP_NAME = "ai-movie-suggester"
-_APP_VERSION = "0.1.0"
-_DEVICE = "Server"
-_DEFAULT_DEVICE_ID = "ai-movie-suggester-server"
 # Fields to request from Jellyfin — matches our LibraryItem model
 _ITEM_FIELDS = (
     "Overview,Genres,ProductionYear,Tags,Studios,CommunityRating,RunTimeTicks,People"
@@ -46,24 +42,29 @@ class JellyfinClient:
         http_client: httpx.AsyncClient,
         device_id: str = _DEFAULT_DEVICE_ID,
     ) -> None:
-        self._base_url = base_url.rstrip("/")
-        self._client = http_client
-        self._server_name: str | None = None
-        self._auth_value = (
-            f'MediaBrowser Client="{_APP_NAME}", '
-            f'Device="{_DEVICE}", '
-            f'DeviceId="{device_id}", '
-            f'Version="{_APP_VERSION}"'
+        self._transport = _JellyfinTransport(
+            base_url=base_url,
+            client=http_client,
+            device_id=device_id,
         )
+        self._server_name: str | None = None
+
+    @property
+    def _base_url(self) -> str:
+        """Expose the base URL for callers that introspect the client."""
+        return self._transport.base_url
+
+    @property
+    def _client(self) -> httpx.AsyncClient:
+        """Expose the shared http client for callers that introspect it."""
+        return self._transport.client
 
     def _headers(self, token: str | None = None) -> dict[str, str]:
-        """Build Jellyfin Authorization header, optionally with token."""
-        value = (
-            self._auth_value
-            if token is None
-            else f"{self._auth_value}, Token={token.strip()}"
-        )
-        return {"Authorization": value}
+        """Build Jellyfin Authorization header, optionally with token.
+
+        Delegates to the shared transport helper.
+        """
+        return self._transport.headers(token)
 
     async def _request(
         self,
@@ -76,33 +77,15 @@ class JellyfinClient:
     ) -> httpx.Response:
         """Send a request to Jellyfin with standard error handling.
 
-        Raises JellyfinAuthError on 401.
-        Raises JellyfinConnectionError on transport failure.
-        Raises JellyfinError on other non-2xx responses.
+        Delegates to the shared transport helper.
         """
-        try:
-            resp = await self._client.request(
-                method,
-                f"{self._base_url}{path}",
-                headers=self._headers(token),
-                **kwargs,
-            )
-        except httpx.TransportError as exc:
-            raise JellyfinConnectionError(
-                f"Cannot reach Jellyfin at {self._base_url}"
-            ) from exc
-
-        if resp.status_code == 401:
-            raise JellyfinAuthError(auth_error_message)
-
-        try:
-            resp.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            raise JellyfinError(
-                f"Unexpected response from Jellyfin: {resp.status_code}"
-            ) from exc
-
-        return resp
+        return await self._transport.request(
+            method,
+            path,
+            token=token,
+            auth_error_message=auth_error_message,
+            **kwargs,
+        )
 
     @staticmethod
     def _parse_response(resp: httpx.Response, parser: Callable[..., _T]) -> _T:

--- a/backend/app/jellyfin/device_models.py
+++ b/backend/app/jellyfin/device_models.py
@@ -1,0 +1,25 @@
+"""Jellyfin-domain device models for the `/api/devices` endpoint.
+
+Keeping the `Device` Pydantic model and `DeviceType` literal here
+(rather than under a top-level `schemas/` directory) follows the
+project's module-local convention and matches placement of other
+Jellyfin-domain types in `app.jellyfin.models`.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+DeviceType = Literal["Tv", "Mobile", "Tablet", "Other"]
+"""Coarse-grained device classification used by the frontend picker."""
+
+
+class Device(BaseModel):
+    """A Jellyfin session that can receive playback commands."""
+
+    session_id: str
+    name: str
+    client: str
+    device_type: DeviceType

--- a/backend/app/jellyfin/errors.py
+++ b/backend/app/jellyfin/errors.py
@@ -13,3 +13,7 @@ class JellyfinAuthError(JellyfinError):
 
 class JellyfinConnectionError(JellyfinError):
     """Cannot reach the Jellyfin server."""
+
+
+class DeviceOfflineError(JellyfinError):
+    """Target Jellyfin session is no longer available (404/400 on session ID)."""

--- a/backend/app/jellyfin/sessions.py
+++ b/backend/app/jellyfin/sessions.py
@@ -1,0 +1,110 @@
+"""Jellyfin sessions capability client.
+
+Wraps GET /Sessions to produce a filtered list of controllable
+``Device`` records (sessions where ``SupportsRemoteControl == True``)
+for the `/api/devices` endpoint.
+
+User tokens are **request-scoped** — they are passed as a parameter
+to ``list_controllable`` and never cached on the instance. The
+instance holds only a ``_JellyfinTransport`` (which itself holds no
+token state) and a ``__repr__`` that returns a fixed string.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from app.jellyfin.device_models import Device, DeviceType
+
+if TYPE_CHECKING:
+    from app.jellyfin.transport import _JellyfinTransport
+
+logger = logging.getLogger(__name__)
+
+
+# Table of (substring, result). Evaluated in order, case-sensitive.
+# First match wins. Must include a fallback entry.
+_CLASSIFICATION_TABLE: tuple[tuple[str, DeviceType], ...] = (
+    # TVs — check "TV" substring before bare-Kodi or mobile checks
+    ("TV", "Tv"),
+    # Tablets — iPad and generic "Tablet" substring
+    ("iPad", "Tablet"),
+    ("Tablet", "Tablet"),
+    # Mobile — iOS / Android phone clients
+    ("iOS", "Mobile"),
+    ("Android", "Mobile"),
+)
+
+
+def _classify_device(client: str, device_id: str) -> DeviceType:
+    """Classify a Jellyfin session's device by its reported Client string.
+
+    Returns one of ``"Tv" | "Mobile" | "Tablet" | "Other"``. Falls
+    through to ``"Other"`` when no substring matches — including the
+    bare ``"Kodi"`` case, which is not remote-controllable via
+    ``/Sessions/{id}/Playing`` per Jellyfin's own behavior.
+
+    ``device_id`` is accepted for future signal extension (currently
+    unused; kept in signature so call sites don't need to change).
+    """
+    _ = device_id  # reserved for future classification signal
+    for substring, result in _CLASSIFICATION_TABLE:
+        if substring in client:
+            return result
+    return "Other"
+
+
+class JellyfinSessionsClient:
+    """Capability client for Jellyfin's /Sessions endpoint.
+
+    Holds no authentication state. The caller supplies the user token
+    per-call; it is never persisted on the instance.
+    """
+
+    __slots__ = ("_transport",)
+
+    def __init__(self, transport: _JellyfinTransport) -> None:
+        self._transport = transport
+
+    def __repr__(self) -> str:
+        """Fixed repr — no dynamic fields, no token leakage surface."""
+        return "JellyfinSessionsClient()"
+
+    async def list_controllable(self, user_token: str) -> list[Device]:
+        """Return the caller's controllable Jellyfin sessions.
+
+        Calls ``GET /Sessions`` with the user's token and filters to
+        sessions with ``SupportsRemoteControl == True``. Returns an
+        empty list if no sessions match (valid case).
+
+        Raises ``JellyfinAuthError`` on 401.
+        Raises ``JellyfinConnectionError`` on transport failure.
+        """
+        resp = await self._transport.request(
+            "GET",
+            "/Sessions",
+            token=user_token,
+        )
+
+        raw: Any = resp.json()
+        if not isinstance(raw, list):
+            # Jellyfin always returns a JSON array; if not, treat as empty
+            # rather than crashing.
+            return []
+
+        devices: list[Device] = []
+        for session in raw:
+            if session.get("SupportsRemoteControl") is not True:
+                continue
+            client_str: str = session.get("Client", "") or ""
+            device_id: str = session.get("DeviceId", "") or ""
+            devices.append(
+                Device(
+                    session_id=session["Id"],
+                    name=session.get("DeviceName", "") or "",
+                    client=client_str,
+                    device_type=_classify_device(client_str, device_id),
+                )
+            )
+        return devices

--- a/backend/app/jellyfin/sessions.py
+++ b/backend/app/jellyfin/sessions.py
@@ -12,9 +12,11 @@ token state) and a ``__repr__`` that returns a fixed string.
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 
 from app.jellyfin.device_models import Device, DeviceType
+from app.jellyfin.errors import JellyfinError
 
 if TYPE_CHECKING:
     from app.jellyfin.transport import _JellyfinTransport
@@ -73,6 +75,8 @@ class JellyfinSessionsClient:
 
         Raises ``JellyfinAuthError`` on 401.
         Raises ``JellyfinConnectionError`` on transport failure.
+        Raises ``JellyfinError`` if Jellyfin returns a non-JSON response
+        (e.g. a reverse-proxy HTML error page).
         """
         resp = await self._transport.request(
             "GET",
@@ -80,7 +84,12 @@ class JellyfinSessionsClient:
             token=user_token,
         )
 
-        raw: Any = resp.json()
+        try:
+            raw: Any = resp.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            # A reverse proxy in front of Jellyfin may return HTML on an
+            # upstream error; treat as an upstream protocol failure.
+            raise JellyfinError("Jellyfin returned non-JSON response") from exc
         if not isinstance(raw, list):
             # Jellyfin always returns a JSON array; if not, treat as empty
             # rather than crashing.

--- a/backend/app/jellyfin/sessions.py
+++ b/backend/app/jellyfin/sessions.py
@@ -12,7 +12,6 @@ token state) and a ``__repr__`` that returns a fixed string.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
 from app.jellyfin.device_models import Device, DeviceType
@@ -20,11 +19,9 @@ from app.jellyfin.device_models import Device, DeviceType
 if TYPE_CHECKING:
     from app.jellyfin.transport import _JellyfinTransport
 
-logger = logging.getLogger(__name__)
-
 
 # Table of (substring, result). Evaluated in order, case-sensitive.
-# First match wins. Must include a fallback entry.
+# First match wins; unmatched clients fall through to ``"Other"``.
 _CLASSIFICATION_TABLE: tuple[tuple[str, DeviceType], ...] = (
     # TVs — check "TV" substring before bare-Kodi or mobile checks
     ("TV", "Tv"),
@@ -37,18 +34,14 @@ _CLASSIFICATION_TABLE: tuple[tuple[str, DeviceType], ...] = (
 )
 
 
-def _classify_device(client: str, device_id: str) -> DeviceType:
+def _classify_device(client: str) -> DeviceType:
     """Classify a Jellyfin session's device by its reported Client string.
 
     Returns one of ``"Tv" | "Mobile" | "Tablet" | "Other"``. Falls
     through to ``"Other"`` when no substring matches — including the
     bare ``"Kodi"`` case, which is not remote-controllable via
     ``/Sessions/{id}/Playing`` per Jellyfin's own behavior.
-
-    ``device_id`` is accepted for future signal extension (currently
-    unused; kept in signature so call sites don't need to change).
     """
-    _ = device_id  # reserved for future classification signal
     for substring, result in _CLASSIFICATION_TABLE:
         if substring in client:
             return result
@@ -98,13 +91,12 @@ class JellyfinSessionsClient:
             if session.get("SupportsRemoteControl") is not True:
                 continue
             client_str: str = session.get("Client", "") or ""
-            device_id: str = session.get("DeviceId", "") or ""
             devices.append(
                 Device(
                     session_id=session["Id"],
                     name=session.get("DeviceName", "") or "",
                     client=client_str,
-                    device_type=_classify_device(client_str, device_id),
+                    device_type=_classify_device(client_str),
                 )
             )
         return devices

--- a/backend/app/jellyfin/transport.py
+++ b/backend/app/jellyfin/transport.py
@@ -1,0 +1,113 @@
+"""Shared Jellyfin HTTP transport helper.
+
+Extracted from JellyfinClient so that capability clients
+(JellyfinSessionsClient, JellyfinPlaybackClient, and future ones) can
+consume the same MediaBrowser-auth-header + error-mapping logic without
+duplicating it or inheriting from JellyfinClient.
+
+Used via composition: each capability client holds a ``_JellyfinTransport``
+and calls ``transport.request(...)`` internally.
+
+Module-level helper functions were rejected: they would either re-derive
+instance state (base URL, device id) per call or smuggle it through
+closures, bloating call sites. A small class gives us a clean injection
+seam at each capability client's constructor.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.jellyfin.errors import (
+    JellyfinAuthError,
+    JellyfinConnectionError,
+    JellyfinError,
+)
+
+_APP_NAME = "ai-movie-suggester"
+_APP_VERSION = "0.1.0"
+_DEVICE = "Server"
+_DEFAULT_DEVICE_ID = "ai-movie-suggester-server"
+
+
+class _JellyfinTransport:
+    """Shared HTTP transport for Jellyfin capability clients.
+
+    Holds the base URL, a shared ``httpx.AsyncClient``, and the
+    MediaBrowser auth-value template. Exposes:
+
+    * ``headers(token=None)`` — build the Authorization header,
+      optionally including a per-request user token.
+    * ``request(method, path, ...)`` — perform a request and map
+      401 → ``JellyfinAuthError``, transport errors →
+      ``JellyfinConnectionError``, and other non-2xx →
+      ``JellyfinError``.
+    """
+
+    __slots__ = ("_auth_value", "base_url", "client", "device_id")
+
+    def __init__(
+        self,
+        base_url: str,
+        client: httpx.AsyncClient,
+        device_id: str = _DEFAULT_DEVICE_ID,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.client = client
+        self.device_id = device_id
+        self._auth_value = (
+            f'MediaBrowser Client="{_APP_NAME}", '
+            f'Device="{_DEVICE}", '
+            f'DeviceId="{device_id}", '
+            f'Version="{_APP_VERSION}"'
+        )
+
+    def headers(self, token: str | None = None) -> dict[str, str]:
+        """Build Jellyfin Authorization header, optionally with token."""
+        value = (
+            self._auth_value
+            if token is None
+            else f"{self._auth_value}, Token={token.strip()}"
+        )
+        return {"Authorization": value}
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        token: str | None = None,
+        auth_error_message: str = "Token is invalid or expired",
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Send a request to Jellyfin with standard error handling.
+
+        Raises ``JellyfinAuthError`` on 401.
+        Raises ``JellyfinConnectionError`` on transport failure.
+        Raises ``JellyfinError`` on other non-2xx responses.
+        """
+        try:
+            resp = await self.client.request(
+                method,
+                f"{self.base_url}{path}",
+                headers=self.headers(token),
+                **kwargs,
+            )
+        except httpx.TransportError as exc:
+            raise JellyfinConnectionError(
+                f"Cannot reach Jellyfin at {self.base_url}"
+            ) from exc
+
+        if resp.status_code == 401:
+            raise JellyfinAuthError(auth_error_message)
+
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise JellyfinError(
+                f"Unexpected response from Jellyfin: {resp.status_code}"
+            ) from exc
+
+        return resp

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,9 +21,12 @@ from app.auth.service import AuthService, cleanup_expired_sessions
 from app.auth.session_store import SessionStore
 from app.chat.conversation_store import ConversationStore
 from app.config import Settings
+from app.devices.router import create_devices_router
 from app.embedding.router import router as embedding_router
 from app.embedding.worker import EmbeddingWorker
 from app.jellyfin.client import JellyfinClient
+from app.jellyfin.sessions import JellyfinSessionsClient
+from app.jellyfin.transport import _JellyfinTransport
 from app.library.store import LibraryStore
 from app.logging_config import configure_logging
 from app.middleware import SecurityHeadersMiddleware
@@ -133,6 +136,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             http_client=http_client,
         )
         app.state.jellyfin_client = jf_client
+
+        # Capability clients (composed against the shared transport — see
+        # app.jellyfin.transport._JellyfinTransport). Request-scoped user
+        # tokens only; no auth state on the instance.
+        jf_sessions_transport = _JellyfinTransport(
+            base_url=settings.jellyfin_url,
+            client=http_client,
+        )
+        app.state.jellyfin_sessions_client = JellyfinSessionsClient(
+            transport=jf_sessions_transport,
+        )
 
         # Permission service (stateless in-memory cache, no init()/close())
         from app.permissions.service import PermissionService
@@ -289,6 +303,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             limiter=limiter,
         )
         app.include_router(chat_router)
+
+        # Devices router — GET /api/devices (Epic 4 remote control)
+        devices_router = create_devices_router(limiter=limiter)
+        app.include_router(devices_router)
 
         # Store settings on app.state for routers that need them
         app.state.settings = settings

--- a/backend/tests/integration/test_devices_endpoint.py
+++ b/backend/tests/integration/test_devices_endpoint.py
@@ -1,0 +1,155 @@
+"""Integration tests for GET /api/devices against a real Jellyfin instance.
+
+Two tests:
+
+1. Authenticate as a test user, call the endpoint via FastAPI's in-process
+   TestClient, and assert 200 with an empty JSON array. Disposable Jellyfin
+   has no active controllable sessions by default.
+
+2. Verify the Jellyfin ``/Sessions`` JSON shape we depend on —
+   ``Id``, ``UserId``, ``DeviceId``, ``DeviceName``, ``Client``,
+   ``SupportsRemoteControl`` — so we get a loud CI failure if Jellyfin
+   ever renames these fields.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+
+from app.auth.crypto import derive_keys
+from app.auth.dependencies import get_current_session
+from app.auth.models import SessionMeta
+from app.devices.router import create_devices_router
+from app.jellyfin.sessions import JellyfinSessionsClient
+from app.jellyfin.transport import _JellyfinTransport
+from tests.integration.conftest import TEST_USER_ALICE, TEST_USER_ALICE_PASS
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from app.jellyfin.client import JellyfinClient
+    from tests.integration.conftest import JellyfinInstance
+
+_TEST_SECRET = "kG7xP2mN9qR4wL8jT3vF6yA5dH0sE1cB"  # fixed, matches unit test suite
+_COOKIE_KEY, _ = derive_keys(_TEST_SECRET)
+
+
+@pytest.mark.integration
+async def test_devices_endpoint_returns_empty_list_against_real_jellyfin(
+    jellyfin: JellyfinInstance,
+    jf_client: JellyfinClient,
+    test_users: dict[str, str],
+) -> None:
+    """GET /api/devices returns 200 [] when no controllable sessions exist."""
+    auth = await jf_client.authenticate(TEST_USER_ALICE, TEST_USER_ALICE_PASS)
+    # `test_users` is forced here so user provisioning has run before auth.
+    assert auth.user_id == test_users[TEST_USER_ALICE]
+
+    # Use the FastAPI app's lifespan to own the httpx.AsyncClient so it is
+    # closed on the TestClient's portal event loop. Mixing a manually-managed
+    # `async with httpx.AsyncClient()` outside TestClient's portal triggers
+    # "Event loop is closed" on __aexit__ when the portal tears down first.
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        async with httpx.AsyncClient(timeout=15.0) as http:
+            transport = _JellyfinTransport(base_url=jellyfin.url, client=http)
+            app.state.jellyfin_sessions_client = JellyfinSessionsClient(
+                transport=transport,
+            )
+            yield
+
+    app = FastAPI(lifespan=lifespan)
+    app.state.cookie_key = _COOKIE_KEY
+    app.state.limiter = None
+    app.add_exception_handler(
+        RateLimitExceeded,
+        _rate_limit_exceeded_handler,  # type: ignore[arg-type]
+    )
+
+    # Mock session_store.get_token to return the real Jellyfin token
+    class _TokenStore:
+        async def get_token(self, _session_id: str) -> str:
+            return auth.access_token
+
+    app.state.session_store = _TokenStore()
+
+    meta = SessionMeta(
+        session_id="integration-sess",
+        user_id=auth.user_id,
+        username=auth.user_name,
+        server_name="TestJellyfin",
+        expires_at=int(time.time()) + 3600,
+    )
+
+    async def _session() -> SessionMeta:
+        return meta
+
+    app.dependency_overrides[get_current_session] = _session
+    app.include_router(create_devices_router(limiter=None))
+
+    with TestClient(app) as client:
+        resp = client.get("/api/devices")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    # Disposable Jellyfin has no cast targets. An empty list is the
+    # correct answer; future tests can relax this if we stand up a
+    # simulated controllable session.
+    assert body == []
+
+
+@pytest.mark.integration
+async def test_devices_endpoint_field_mapping_matches_jellyfin_shape(
+    jellyfin: JellyfinInstance,
+    admin_auth_token: str,
+) -> None:
+    """Guard the Jellyfin /Sessions field-name contract.
+
+    We hit ``/Sessions`` directly with the admin token so at least one
+    session (the admin's) is present, then assert the response shape
+    exposes the six fields we depend on. If Jellyfin ever renames any
+    of them, this test turns red loudly instead of the production client
+    returning an empty list by silent fall-through.
+    """
+    async with httpx.AsyncClient(timeout=15.0) as http:
+        resp = await http.get(
+            f"{jellyfin.url}/Sessions",
+            headers={
+                "Authorization": (
+                    'MediaBrowser Client="ai-movie-suggester-tests", '
+                    f'DeviceId="integration-test", Device="pytest", '
+                    f'Version="0.0.0", Token={admin_auth_token}'
+                )
+            },
+        )
+    assert resp.status_code == 200
+    sessions = resp.json()
+    assert isinstance(sessions, list)
+    assert len(sessions) >= 1, (
+        "expected at least one Jellyfin session (admin) for shape check"
+    )
+
+    required_fields = {
+        "Id",
+        "UserId",
+        "DeviceId",
+        "DeviceName",
+        "Client",
+        "SupportsRemoteControl",
+    }
+    for session in sessions:
+        missing = required_fields - session.keys()
+        assert not missing, (
+            f"Jellyfin /Sessions session missing field(s) {missing}: "
+            f"{list(session.keys())!r}"
+        )

--- a/backend/tests/test_device_models.py
+++ b/backend/tests/test_device_models.py
@@ -1,0 +1,63 @@
+"""Unit tests for Device / DeviceType Pydantic models.
+
+The Literal typing on `device_type` must reject any value outside the
+four-member set `{"Tv", "Mobile", "Tablet", "Other"}`. Happy-construction
+tests cover each of the four literal values.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.jellyfin.device_models import Device
+
+
+class TestDeviceType:
+    def test_device_type_literal_rejects_unknown(self) -> None:
+        """Constructing Device with an out-of-set device_type raises."""
+        with pytest.raises(ValidationError):
+            Device(
+                session_id="sess-1",
+                name="Living Room",
+                client="Jellyfin Android",
+                device_type="Phone",  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.parametrize(
+        "device_type",
+        ["Tv", "Mobile", "Tablet", "Other"],
+    )
+    def test_device_type_literal_accepts_each_allowed_value(
+        self, device_type: str
+    ) -> None:
+        """All four literal values construct a valid Device."""
+        device = Device(
+            session_id="sess-1",
+            name="Some Device",
+            client="Jellyfin Client",
+            device_type=device_type,  # type: ignore[arg-type]
+        )
+        assert device.device_type == device_type
+
+    def test_device_shape_fields(self) -> None:
+        """Device exposes session_id, name, client, device_type."""
+        device = Device(
+            session_id="sess-42",
+            name="Living Room TV",
+            client="Jellyfin Android TV",
+            device_type="Tv",
+        )
+        assert device.session_id == "sess-42"
+        assert device.name == "Living Room TV"
+        assert device.client == "Jellyfin Android TV"
+        assert device.device_type == "Tv"
+
+    def test_device_requires_all_fields(self) -> None:
+        """Missing any field raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Device(  # type: ignore[call-arg]
+                session_id="sess-1",
+                name="dev",
+                client="client",
+            )

--- a/backend/tests/test_devices_router.py
+++ b/backend/tests/test_devices_router.py
@@ -30,6 +30,11 @@ from app.auth.dependencies import get_current_session
 from app.auth.models import SessionMeta
 from app.devices.router import create_devices_router, get_sessions_client
 from app.jellyfin.device_models import Device
+from app.jellyfin.errors import (
+    JellyfinAuthError,
+    JellyfinConnectionError,
+    JellyfinError,
+)
 from app.jellyfin.sessions import JellyfinSessionsClient
 from app.middleware.rate_limit import create_limiter
 from tests.conftest import TEST_SECRET, make_test_settings
@@ -179,3 +184,34 @@ class TestDevicesRouterOpenAPI:
         assert "/api/devices" in openapi["paths"]
         op = openapi["paths"]["/api/devices"]["get"]
         assert "devices" in op.get("tags", [])
+
+
+class TestDevicesRouterErrorMapping:
+    """Jellyfin-layer exceptions map to structured HTTP errors (not 500)."""
+
+    def test_jellyfin_auth_error_returns_401(self) -> None:
+        """Revoked/expired Jellyfin token -> 401 so frontend can re-login."""
+        mock = AsyncMock(spec=JellyfinSessionsClient)
+        mock.list_controllable.side_effect = JellyfinAuthError("token revoked")
+        _, client = _make_devices_app(sessions_client=mock)
+        resp = client.get("/api/devices")
+        assert resp.status_code == 401
+        assert resp.json() == {"detail": "jellyfin_auth_failed"}
+
+    def test_jellyfin_connection_error_returns_503(self) -> None:
+        """Upstream unreachable -> 503."""
+        mock = AsyncMock(spec=JellyfinSessionsClient)
+        mock.list_controllable.side_effect = JellyfinConnectionError("conn refused")
+        _, client = _make_devices_app(sessions_client=mock)
+        resp = client.get("/api/devices")
+        assert resp.status_code == 503
+        assert resp.json() == {"detail": "jellyfin_unreachable"}
+
+    def test_generic_jellyfin_error_returns_502(self) -> None:
+        """Upstream protocol/parse failure -> 502."""
+        mock = AsyncMock(spec=JellyfinSessionsClient)
+        mock.list_controllable.side_effect = JellyfinError("bad upstream")
+        _, client = _make_devices_app(sessions_client=mock)
+        resp = client.get("/api/devices")
+        assert resp.status_code == 502
+        assert resp.json() == {"detail": "jellyfin_error"}

--- a/backend/tests/test_devices_router.py
+++ b/backend/tests/test_devices_router.py
@@ -1,0 +1,181 @@
+"""Unit tests for the GET /api/devices router.
+
+Covers:
+
+* unauthenticated -> 401
+* authenticated happy path -> 200 with device list
+* empty list -> 200 []
+* 11th request within 60s -> 429
+
+Mocks ``JellyfinSessionsClient`` via FastAPI dependency override;
+the ``get_current_session`` dep is also overridden in authenticated
+cases. The rate-limit test follows the pattern from
+``test_rate_limit.py`` and per-endpoint exemplars in
+``test_chat_router.py`` / ``test_search_router.py``.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+
+from app.auth.crypto import derive_keys
+from app.auth.dependencies import get_current_session
+from app.auth.models import SessionMeta
+from app.devices.router import create_devices_router, get_sessions_client
+from app.jellyfin.device_models import Device
+from app.jellyfin.sessions import JellyfinSessionsClient
+from app.middleware.rate_limit import create_limiter
+from tests.conftest import TEST_SECRET, make_test_settings
+
+_COOKIE_KEY, _ = derive_keys(TEST_SECRET)
+_SESSION_ID = "test-session-devices"
+_USER_ID = "uid-devices-1"
+_NOW = int(time.time())
+
+
+def _session_meta() -> SessionMeta:
+    return SessionMeta(
+        session_id=_SESSION_ID,
+        user_id=_USER_ID,
+        username="alice",
+        server_name="TestJellyfin",
+        expires_at=_NOW + 3600,
+    )
+
+
+def _make_devices_app(
+    *,
+    sessions_client: Any = None,
+    limiter: Any = None,
+    authenticated: bool = True,
+    session_token: str | None = "jf-token-abc",
+) -> tuple[FastAPI, TestClient]:
+    """Build a FastAPI app with the devices router wired up and mocked deps."""
+    settings = make_test_settings()
+    app = FastAPI()
+    app.state.cookie_key = _COOKIE_KEY
+    app.state.settings = settings
+    app.state.limiter = limiter
+
+    if limiter is not None:
+        app.add_exception_handler(
+            RateLimitExceeded,
+            _rate_limit_exceeded_handler,  # type: ignore[arg-type]
+        )
+
+    session_store = AsyncMock()
+    session_store.get_token = AsyncMock(return_value=session_token)
+    app.state.session_store = session_store
+
+    router = create_devices_router(limiter=limiter)
+    app.include_router(router)
+
+    if authenticated:
+
+        async def _mock_session() -> SessionMeta:
+            return _session_meta()
+
+        app.dependency_overrides[get_current_session] = _mock_session
+
+    if sessions_client is not None:
+
+        def _provide_sessions_client() -> JellyfinSessionsClient:
+            return sessions_client
+
+        app.dependency_overrides[get_sessions_client] = _provide_sessions_client
+
+    return app, TestClient(app)
+
+
+class TestDevicesRouterAuth:
+    def test_unauthenticated_returns_401(self) -> None:
+        _, client = _make_devices_app(authenticated=False)
+        resp = client.get("/api/devices")
+        assert resp.status_code == 401
+
+
+class TestDevicesRouterHappyPath:
+    def test_returns_device_list(self) -> None:
+        mock = AsyncMock(spec=JellyfinSessionsClient)
+        mock.list_controllable.return_value = [
+            Device(
+                session_id="sess-1",
+                name="Living Room TV",
+                client="Jellyfin Android TV",
+                device_type="Tv",
+            ),
+            Device(
+                session_id="sess-2",
+                name="Phone",
+                client="Jellyfin iOS",
+                device_type="Mobile",
+            ),
+        ]
+        _, client = _make_devices_app(sessions_client=mock)
+        resp = client.get("/api/devices")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert isinstance(body, list)
+        assert len(body) == 2
+        assert body[0]["session_id"] == "sess-1"
+        assert body[0]["name"] == "Living Room TV"
+        assert body[0]["client"] == "Jellyfin Android TV"
+        assert body[0]["device_type"] == "Tv"
+        assert body[1]["device_type"] == "Mobile"
+
+        # Confirm the caller's token was forwarded
+        mock.list_controllable.assert_awaited_once_with("jf-token-abc")
+
+    def test_empty_list_returns_200(self) -> None:
+        mock = AsyncMock(spec=JellyfinSessionsClient)
+        mock.list_controllable.return_value = []
+        _, client = _make_devices_app(sessions_client=mock)
+        resp = client.get("/api/devices")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestDevicesRouterTokenMissing:
+    def test_token_missing_returns_401(self) -> None:
+        """If the session has no token, return 401 (matches chat/search)."""
+        mock = AsyncMock(spec=JellyfinSessionsClient)
+        _, client = _make_devices_app(sessions_client=mock, session_token=None)
+        resp = client.get("/api/devices")
+        assert resp.status_code == 401
+
+
+class TestDevicesRouterRateLimit:
+    def test_eleventh_request_within_window_returns_429(self) -> None:
+        """10/min cap: 10 rapid requests OK, 11th returns 429."""
+        limiter = create_limiter()
+        # Reset limiter storage — ensure clean state between tests
+        limiter.reset()
+
+        mock = AsyncMock(spec=JellyfinSessionsClient)
+        mock.list_controllable.return_value = []
+
+        _, client = _make_devices_app(sessions_client=mock, limiter=limiter)
+
+        statuses = [client.get("/api/devices").status_code for _ in range(11)]
+        # First 10 are 200; the 11th is 429
+        assert statuses[:10] == [200] * 10, f"first 10 must be 200, got {statuses[:10]}"
+        assert statuses[10] == 429
+
+
+class TestDevicesRouterOpenAPI:
+    def test_openapi_documents_get_devices(self) -> None:
+        """The OpenAPI spec exposes GET /api/devices with the tag 'devices'."""
+        app, _ = _make_devices_app(
+            sessions_client=AsyncMock(spec=JellyfinSessionsClient)
+        )
+        openapi = app.openapi()
+        assert "/api/devices" in openapi["paths"]
+        op = openapi["paths"]["/api/devices"]["get"]
+        assert "devices" in op.get("tags", [])

--- a/backend/tests/test_jellyfin_sessions.py
+++ b/backend/tests/test_jellyfin_sessions.py
@@ -42,30 +42,28 @@ def sessions_client(mock_http: AsyncMock) -> JellyfinSessionsClient:
 
 class TestClassifyDevice:
     @pytest.mark.parametrize(
-        ("client", "device_id", "expected"),
+        ("client", "expected"),
         [
             # TV clients — substring "TV" wins
-            ("Jellyfin Android TV", "dev-1", "Tv"),
-            ("Jellyfin Kodi TV", "dev-2", "Tv"),
-            ("Samsung Smart TV", "dev-3", "Tv"),
+            ("Jellyfin Android TV", "Tv"),
+            ("Jellyfin Kodi TV", "Tv"),
+            ("Samsung Smart TV", "Tv"),
             # Bare Kodi — NOT a TV, not remote-controllable via /Sessions/Playing
             # per Jellyfin's own behavior. Explicit fallback row makes
             # this deliberate, not accidental.
-            ("Kodi", "dev-4", "Other"),
+            ("Kodi", "Other"),
             # Mobile clients — iOS/Android without "TV" suffix
-            ("Jellyfin iOS", "dev-5", "Mobile"),
-            ("Jellyfin Android", "dev-6", "Mobile"),
+            ("Jellyfin iOS", "Mobile"),
+            ("Jellyfin Android", "Mobile"),
             # Tablet clients
-            ("Jellyfin iPad", "dev-7", "Tablet"),
-            ("SomeTablet", "dev-8", "Tablet"),
+            ("Jellyfin iPad", "Tablet"),
+            ("SomeTablet", "Tablet"),
             # Unknown fall-through
-            ("Unknown Client", "dev-9", "Other"),
+            ("Unknown Client", "Other"),
         ],
     )
-    def test_classify_device_fixture_table(
-        self, client: str, device_id: str, expected: str
-    ) -> None:
-        assert _classify_device(client, device_id) == expected
+    def test_classify_device_fixture_table(self, client: str, expected: str) -> None:
+        assert _classify_device(client) == expected
 
 
 class TestSessionsClientHappyPath:
@@ -245,7 +243,6 @@ class TestSessionsClientTokenHandling:
         """repr(client) / str(client) expose no auth/token state."""
         text = repr(sessions_client) + str(sessions_client)
         assert "Token=" not in text
-        assert "token" not in text.lower() or "token" in text.lower()  # sanity
         # Stronger: no attribute surface should ever contain a token value,
         # because the client holds no token. These asserts guard future regressions.
         assert "MediaBrowser" not in text

--- a/backend/tests/test_jellyfin_sessions.py
+++ b/backend/tests/test_jellyfin_sessions.py
@@ -19,7 +19,7 @@ import httpx
 import pytest
 
 from app.jellyfin.device_models import Device
-from app.jellyfin.errors import JellyfinAuthError
+from app.jellyfin.errors import JellyfinAuthError, JellyfinError
 from app.jellyfin.sessions import JellyfinSessionsClient, _classify_device
 from app.jellyfin.transport import _JellyfinTransport
 
@@ -196,6 +196,27 @@ class TestSessionsClientAuthFailure:
         mock_http.request.return_value = httpx.Response(401, request=_FAKE_REQUEST)
         with pytest.raises(JellyfinAuthError):
             await sessions_client.list_controllable("bad-tok")
+
+
+class TestSessionsClientNonJsonResponse:
+    async def test_non_json_body_raises_jellyfin_error(
+        self,
+        sessions_client: JellyfinSessionsClient,
+        mock_http: AsyncMock,
+    ) -> None:
+        """A 200 with HTML body (e.g. reverse-proxy error) -> JellyfinError."""
+        # Construct a 200 response whose body is not valid JSON. Calling
+        # ``.json()`` on this will raise ``json.JSONDecodeError``.
+        mock_http.request.return_value = httpx.Response(
+            200,
+            content=b"<html><body>502 Bad Gateway</body></html>",
+            headers={"content-type": "text/html"},
+            request=_FAKE_REQUEST,
+        )
+        with pytest.raises(JellyfinError) as excinfo:
+            await sessions_client.list_controllable("tok")
+        # The original JSONDecodeError is preserved as __cause__
+        assert excinfo.value.__cause__ is not None
 
 
 class TestSessionsClientTokenHandling:

--- a/backend/tests/test_jellyfin_sessions.py
+++ b/backend/tests/test_jellyfin_sessions.py
@@ -1,0 +1,240 @@
+"""Unit tests for JellyfinSessionsClient and the `_classify_device` table.
+
+Covers:
+
+* ``_classify_device`` fixture-table classification
+* Happy path: three sessions, two controllable -> two Device items
+* ``SupportsRemoteControl`` filter keeps only controllable sessions
+* 401 -> JellyfinAuthError
+* Empty list round-trip
+* ``user_token`` is request-scoped (never cached on the client)
+* ``repr()`` / ``str()`` do not leak any token fragment
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from app.jellyfin.device_models import Device
+from app.jellyfin.errors import JellyfinAuthError
+from app.jellyfin.sessions import JellyfinSessionsClient, _classify_device
+from app.jellyfin.transport import _JellyfinTransport
+
+_FAKE_REQUEST = httpx.Request("GET", "http://fake")
+
+
+@pytest.fixture
+def mock_http() -> AsyncMock:
+    return AsyncMock(spec=httpx.AsyncClient)
+
+
+@pytest.fixture
+def sessions_client(mock_http: AsyncMock) -> JellyfinSessionsClient:
+    transport = _JellyfinTransport(
+        base_url="http://jellyfin:8096",
+        client=mock_http,
+    )
+    return JellyfinSessionsClient(transport=transport)
+
+
+class TestClassifyDevice:
+    @pytest.mark.parametrize(
+        ("client", "device_id", "expected"),
+        [
+            # TV clients — substring "TV" wins
+            ("Jellyfin Android TV", "dev-1", "Tv"),
+            ("Jellyfin Kodi TV", "dev-2", "Tv"),
+            ("Samsung Smart TV", "dev-3", "Tv"),
+            # Bare Kodi — NOT a TV, not remote-controllable via /Sessions/Playing
+            # per Jellyfin's own behavior. Explicit fallback row makes
+            # this deliberate, not accidental.
+            ("Kodi", "dev-4", "Other"),
+            # Mobile clients — iOS/Android without "TV" suffix
+            ("Jellyfin iOS", "dev-5", "Mobile"),
+            ("Jellyfin Android", "dev-6", "Mobile"),
+            # Tablet clients
+            ("Jellyfin iPad", "dev-7", "Tablet"),
+            ("SomeTablet", "dev-8", "Tablet"),
+            # Unknown fall-through
+            ("Unknown Client", "dev-9", "Other"),
+        ],
+    )
+    def test_classify_device_fixture_table(
+        self, client: str, device_id: str, expected: str
+    ) -> None:
+        assert _classify_device(client, device_id) == expected
+
+
+class TestSessionsClientHappyPath:
+    async def test_happy_path_returns_only_controllable(
+        self,
+        sessions_client: JellyfinSessionsClient,
+        mock_http: AsyncMock,
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json=[
+                {
+                    "Id": "sess-1",
+                    "UserId": "u-1",
+                    "DeviceId": "dev-1",
+                    "DeviceName": "Living Room TV",
+                    "Client": "Jellyfin Android TV",
+                    "SupportsRemoteControl": True,
+                },
+                {
+                    "Id": "sess-2",
+                    "UserId": "u-1",
+                    "DeviceId": "dev-2",
+                    "DeviceName": "Phone",
+                    "Client": "Jellyfin iOS",
+                    "SupportsRemoteControl": True,
+                },
+                {
+                    "Id": "sess-3",
+                    "UserId": "u-1",
+                    "DeviceId": "dev-3",
+                    "DeviceName": "Laptop Web",
+                    "Client": "Jellyfin Web",
+                    "SupportsRemoteControl": False,
+                },
+            ],
+            request=_FAKE_REQUEST,
+        )
+
+        devices = await sessions_client.list_controllable("tok-abc")
+
+        assert len(devices) == 2
+        assert all(isinstance(d, Device) for d in devices)
+        tv = next(d for d in devices if d.session_id == "sess-1")
+        assert tv.name == "Living Room TV"
+        assert tv.client == "Jellyfin Android TV"
+        assert tv.device_type == "Tv"
+        phone = next(d for d in devices if d.session_id == "sess-2")
+        assert phone.device_type == "Mobile"
+
+    async def test_filter_drops_all_non_controllable(
+        self,
+        sessions_client: JellyfinSessionsClient,
+        mock_http: AsyncMock,
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json=[
+                {
+                    "Id": "s1",
+                    "UserId": "u",
+                    "DeviceId": "d1",
+                    "DeviceName": "web-1",
+                    "Client": "Jellyfin Web",
+                    "SupportsRemoteControl": False,
+                },
+                {
+                    "Id": "s2",
+                    "UserId": "u",
+                    "DeviceId": "d2",
+                    "DeviceName": "web-2",
+                    "Client": "Jellyfin Web",
+                    "SupportsRemoteControl": False,
+                },
+            ],
+            request=_FAKE_REQUEST,
+        )
+        assert await sessions_client.list_controllable("tok") == []
+
+    async def test_empty_list_from_jellyfin(
+        self,
+        sessions_client: JellyfinSessionsClient,
+        mock_http: AsyncMock,
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200, json=[], request=_FAKE_REQUEST
+        )
+        assert await sessions_client.list_controllable("tok") == []
+
+    async def test_missing_supports_remote_control_treated_as_false(
+        self,
+        sessions_client: JellyfinSessionsClient,
+        mock_http: AsyncMock,
+    ) -> None:
+        """If Jellyfin omits SupportsRemoteControl, treat as False."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json=[
+                {
+                    "Id": "s1",
+                    "UserId": "u",
+                    "DeviceId": "d1",
+                    "DeviceName": "TV",
+                    "Client": "Jellyfin Android TV",
+                    # no SupportsRemoteControl key
+                },
+            ],
+            request=_FAKE_REQUEST,
+        )
+        assert await sessions_client.list_controllable("tok") == []
+
+
+class TestSessionsClientAuthFailure:
+    async def test_401_raises_jellyfin_auth_error(
+        self,
+        sessions_client: JellyfinSessionsClient,
+        mock_http: AsyncMock,
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinAuthError):
+            await sessions_client.list_controllable("bad-tok")
+
+
+class TestSessionsClientTokenHandling:
+    async def test_token_passed_in_auth_header(
+        self,
+        sessions_client: JellyfinSessionsClient,
+        mock_http: AsyncMock,
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200, json=[], request=_FAKE_REQUEST
+        )
+        await sessions_client.list_controllable("tok-xyz-42")
+        call = mock_http.request.call_args
+        assert "Token=tok-xyz-42" in call.kwargs["headers"]["Authorization"]
+
+    async def test_user_token_not_cached_on_instance(
+        self,
+        sessions_client: JellyfinSessionsClient,
+        mock_http: AsyncMock,
+    ) -> None:
+        """After a call, no attribute on the client contains the token."""
+        mock_http.request.return_value = httpx.Response(
+            200, json=[], request=_FAKE_REQUEST
+        )
+        token = "super-secret-tok-do-not-persist"
+        await sessions_client.list_controllable(token)
+
+        # Probe every attribute reachable on the client instance
+        for attr_name in dir(sessions_client):
+            if attr_name.startswith("__"):
+                continue
+            value = getattr(sessions_client, attr_name, None)
+            try:
+                text = repr(value)
+            except Exception:
+                continue
+            assert token not in text, (
+                f"token leaked via attribute {attr_name!r}: {text!r}"
+            )
+
+    def test_repr_contains_no_token_fragment(
+        self,
+        sessions_client: JellyfinSessionsClient,
+    ) -> None:
+        """repr(client) / str(client) expose no auth/token state."""
+        text = repr(sessions_client) + str(sessions_client)
+        assert "Token=" not in text
+        assert "token" not in text.lower() or "token" in text.lower()  # sanity
+        # Stronger: no attribute surface should ever contain a token value,
+        # because the client holds no token. These asserts guard future regressions.
+        assert "MediaBrowser" not in text

--- a/backend/tests/test_jellyfin_sessions.py
+++ b/backend/tests/test_jellyfin_sessions.py
@@ -155,6 +155,17 @@ class TestSessionsClientHappyPath:
         )
         assert await sessions_client.list_controllable("tok") == []
 
+    async def test_non_list_body_returns_empty(
+        self,
+        sessions_client: JellyfinSessionsClient,
+        mock_http: AsyncMock,
+    ) -> None:
+        """If Jellyfin somehow returns a non-list, return [] (no crash)."""
+        mock_http.request.return_value = httpx.Response(
+            200, json={"unexpected": "dict"}, request=_FAKE_REQUEST
+        )
+        assert await sessions_client.list_controllable("tok") == []
+
     async def test_missing_supports_remote_control_treated_as_false(
         self,
         sessions_client: JellyfinSessionsClient,

--- a/backend/tests/test_jellyfin_transport.py
+++ b/backend/tests/test_jellyfin_transport.py
@@ -1,0 +1,180 @@
+"""Unit tests for the shared Jellyfin transport helper.
+
+The transport helper is extracted from JellyfinClient and consumed by
+future capability clients (JellyfinSessionsClient, JellyfinPlaybackClient)
+via composition. This module asserts:
+
+* MediaBrowser Authorization header format (with and without token)
+* 401 → JellyfinAuthError mapping
+* Transport failure → JellyfinConnectionError mapping
+* Non-2xx non-401 → JellyfinError wrapping
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from app.jellyfin.errors import (
+    JellyfinAuthError,
+    JellyfinConnectionError,
+    JellyfinError,
+)
+from app.jellyfin.transport import _JellyfinTransport
+
+_FAKE_REQUEST = httpx.Request("GET", "http://fake")
+
+
+@pytest.fixture
+def mock_http() -> AsyncMock:
+    """Mock httpx.AsyncClient for unit tests."""
+    return AsyncMock(spec=httpx.AsyncClient)
+
+
+@pytest.fixture
+def transport(mock_http: AsyncMock) -> _JellyfinTransport:
+    return _JellyfinTransport(
+        base_url="http://jellyfin:8096",
+        client=mock_http,
+    )
+
+
+class TestHeadersBuilder:
+    """MediaBrowser Authorization header construction."""
+
+    def test_headers_without_token(self, transport: _JellyfinTransport) -> None:
+        headers = transport.headers()
+        auth = headers["Authorization"]
+        assert auth.startswith("MediaBrowser ")
+        assert 'Client="ai-movie-suggester"' in auth
+        assert 'Device="Server"' in auth
+        assert "DeviceId=" in auth
+        assert 'Version="0.1.0"' in auth
+        assert "Token=" not in auth
+
+    def test_headers_with_token(self, transport: _JellyfinTransport) -> None:
+        headers = transport.headers(token="my-token")
+        auth = headers["Authorization"]
+        assert auth.endswith(", Token=my-token")
+        assert 'Client="ai-movie-suggester"' in auth
+
+    def test_custom_device_id(self, mock_http: AsyncMock) -> None:
+        t = _JellyfinTransport(
+            base_url="http://jellyfin:8096",
+            client=mock_http,
+            device_id="custom-id",
+        )
+        headers = t.headers()
+        assert 'DeviceId="custom-id"' in headers["Authorization"]
+
+    def test_base_url_trailing_slash_stripped(self, mock_http: AsyncMock) -> None:
+        t = _JellyfinTransport(
+            base_url="http://jellyfin:8096/",
+            client=mock_http,
+        )
+        assert t.base_url == "http://jellyfin:8096"
+
+    def test_token_whitespace_stripped(self, transport: _JellyfinTransport) -> None:
+        headers = transport.headers(token="  tok-123  ")
+        auth = headers["Authorization"]
+        assert auth.endswith(", Token=tok-123")
+        # No extra quotes sneaked in
+        assert 'Token="' not in auth
+
+
+class TestRequest:
+    """_JellyfinTransport.request() error mapping."""
+
+    async def test_401_raises_jellyfin_auth_error(
+        self, transport: _JellyfinTransport, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinAuthError):
+            await transport.request("GET", "/Sessions", token="tok-123")
+
+    async def test_401_default_message(
+        self, transport: _JellyfinTransport, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinAuthError) as info:
+            await transport.request("GET", "/Sessions", token="tok-123")
+        assert "Token is invalid or expired" in str(info.value)
+
+    async def test_401_custom_auth_error_message(
+        self, transport: _JellyfinTransport, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(401, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinAuthError) as info:
+            await transport.request(
+                "POST",
+                "/Users/AuthenticateByName",
+                auth_error_message="Invalid username or password",
+            )
+        assert "Invalid username or password" in str(info.value)
+
+    async def test_transport_error_raises_connection_error(
+        self, transport: _JellyfinTransport, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.side_effect = httpx.ConnectError("refused")
+        with pytest.raises(JellyfinConnectionError) as info:
+            await transport.request("GET", "/Sessions")
+        assert "http://jellyfin:8096" in str(info.value)
+
+    async def test_unexpected_status_raises_jellyfin_error(
+        self, transport: _JellyfinTransport, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(500, request=_FAKE_REQUEST)
+        with pytest.raises(JellyfinError) as info:
+            await transport.request("GET", "/Sessions")
+        # The wrapped error is *not* JellyfinAuthError or JellyfinConnectionError
+        assert not isinstance(info.value, JellyfinAuthError)
+        assert not isinstance(info.value, JellyfinConnectionError)
+        assert "500" in str(info.value)
+
+    async def test_success_returns_response(
+        self, transport: _JellyfinTransport, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200, json={"ok": True}, request=_FAKE_REQUEST
+        )
+        resp = await transport.request("GET", "/Sessions")
+        assert resp.status_code == 200
+
+    async def test_request_sends_auth_header_with_token(
+        self, transport: _JellyfinTransport, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200, json=[], request=_FAKE_REQUEST
+        )
+        await transport.request("GET", "/Sessions", token="tok-xyz")
+        call = mock_http.request.call_args
+        assert "Token=tok-xyz" in call.kwargs["headers"]["Authorization"]
+
+    async def test_request_passes_through_kwargs(
+        self, transport: _JellyfinTransport, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200, json={}, request=_FAKE_REQUEST
+        )
+        await transport.request(
+            "POST",
+            "/Sessions/abc/Playing",
+            params={"itemIds": "item-1"},
+            json={"foo": "bar"},
+        )
+        call = mock_http.request.call_args
+        assert call.kwargs["params"] == {"itemIds": "item-1"}
+        assert call.kwargs["json"] == {"foo": "bar"}
+
+    async def test_request_uses_base_url(
+        self, transport: _JellyfinTransport, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200, json={}, request=_FAKE_REQUEST
+        )
+        await transport.request("GET", "/Sessions")
+        call = mock_http.request.call_args
+        assert call.args[0] == "GET"
+        assert call.args[1] == "http://jellyfin:8096/Sessions"


### PR DESCRIPTION
## Summary

Implements Epic 4 T1 backend. Closes #12.

This PR lands the shared Jellyfin transport helper (extracted from `JellyfinClient` via composition) and the new `GET /api/devices` endpoint backed by a `JellyfinSessionsClient` capability client.

## Parent tasks completed (per Spec 24)

- **1.0** Shared Jellyfin transport helper — `backend/app/jellyfin/transport.py` (new), `JellyfinClient` refactored to compose against it; no behavioral drift confirmed against unit + integration test suites.
- **2.0** Sessions capability client + device models — `JellyfinSessionsClient.list_controllable`, `_classify_device` fixture table (including bare `Kodi` → `Other` per Carrot), `Device`/`DeviceType` models, `DeviceOfflineError` exception.
- **3.0** `GET /api/devices` router — module-local `backend/app/devices/router.py`, 10/min slowapi limit, two disposable-Jellyfin integration tests (empty shape + field-name mapping).

## Watch Council conditions applied

Per the SDD-2 Run-3 audit:
- **B1**: `_JellyfinTransport` class shape prescribed (not module functions)
- **A7**: bare `Kodi` classifier fixture row explicit
- **A6**: repr/str of `JellyfinSessionsClient` asserted free of token leakage (plus an attribute-surface sweep covering all public attrs after a call)
- **C1**: section-2 sub-tasks TDD-ordered (literal-rejection test before `device_models.py`)
- **F1**: integration regression check (1.6b) executed post-refactor — all 69 existing integration tests pass verbatim

## Test + lint results

- `uv run ruff check .` — clean
- `uv run ruff format --check .` — 133 files already formatted
- `uv run pyright .` — 0 errors, 0 warnings
- Unit: `uv run pytest -m "not integration and not ollama_integration" --cov=app --cov-fail-under=70` — **735 passed, 7 skipped, total coverage 94.36%**
- Integration: `make test-integration` — **71 passed** (includes the two new `test_devices_endpoint_*` tests; all 69 pre-existing integration tests pass unchanged post-refactor)
- Per-module coverage for new files: `sessions.py` 100%, `transport.py` 100%, `device_models.py` 100%, `devices/router.py` 96% (only the real-app dependency-provider lookup is unreached in unit tests; exercised by integration)

## OpenAPI

`GET /api/devices` renders under the `devices` tag with a `list[Device]` 200 response schema. Verified by dumping `app.openapi()['paths']['/api/devices']` while the app lifespan was running.

## Related

- Paired PR for #13 (T3) is in flight on a parallel branch.
- If this PR merges first, the T3 PR rebases onto `main` and picks up the shared transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>