### PR TITLE
feat(play): real play dispatch + notifications + 401 re-login (Epic 4 T4)

### DIFF
--- a/frontend/src/components/chat/__tests__/card-detail.test.tsx
+++ b/frontend/src/components/chat/__tests__/card-detail.test.tsx
@@ -2,6 +2,33 @@ import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { axe, toHaveNoViolations } from "jest-axe";
+
+// Hoisted module mocks — sonner (card-detail fires toast.success on dispatch)
+// and auth-context (picker uses useAuth internally).
+const mocks = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  clearAuth: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+  Toaster: () => null,
+}));
+
+vi.mock("@/lib/auth/auth-context", () => ({
+  useAuth: () => ({
+    userId: "u1",
+    username: "alice",
+    serverName: "server",
+    isAuthenticated: true,
+    clearAuth: mocks.clearAuth,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 import { CardDetail } from "../card-detail";
 import type { Device, SearchResultItem } from "@/lib/api/types";
 
@@ -192,6 +219,9 @@ describe("CardDetail — Cast to TV entry point", () => {
       writable: true,
       value: "csrf_token=test-csrf-value",
     });
+    mocks.toast.success.mockClear();
+    mocks.toast.error.mockClear();
+    mocks.clearAuth.mockClear();
   });
 
   afterEach(() => {
@@ -263,6 +293,56 @@ describe("CardDetail — Cast to TV entry point", () => {
     // data-return-focus="false" or similar — Radix doesn't expose this, so the
     // grep-in-source check above is the real guard).
     expect(dialogs[0]).toBeInTheDocument();
+  });
+
+  it("fires toast.success('Now playing on {deviceName}') when dispatch succeeds (T4)", async () => {
+    const user = userEvent.setup();
+
+    // Sequence: initial GET /api/devices returns a populated list, then
+    // POST /api/play returns 200 with device_name.
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve([
+              {
+                session_id: "tv",
+                name: "Living Room TV",
+                client: "Jellyfin Android TV",
+                device_type: "Tv",
+              },
+            ] satisfies Device[]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({ status: "ok", device_name: "Living Room TV" }),
+        })
+    );
+
+    render(<CardDetail item={makeItem()} open={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Cast to TV" }));
+
+    // Wait for the device row, then tap it
+    const row = await screen.findByRole("button", {
+      name: /Cast Galaxy Quest to Living Room TV/i,
+    });
+    await user.click(row);
+
+    // Card-detail's onDispatched handler fires toast.success from sonner
+    await waitFor(() => {
+      expect(mocks.toast.success).toHaveBeenCalledWith(
+        "Now playing on Living Room TV"
+      );
+    });
+    expect(mocks.toast.success).toHaveBeenCalledTimes(1);
+    expect(mocks.toast.error).not.toHaveBeenCalled();
   });
 
   it("pressing Escape with both dialogs open dismisses only the top (picker) dialog; card-detail stays open", async () => {

--- a/frontend/src/components/chat/__tests__/device-picker-dialog.test.tsx
+++ b/frontend/src/components/chat/__tests__/device-picker-dialog.test.tsx
@@ -1,6 +1,34 @@
 import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Hoisted mocks — sonner (toast) and auth-context (useAuth).
+// All T2 tests continue to work because the mocks provide defaults;
+// T4 tests add assertions on the mocked call counts.
+const mocks = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  clearAuth: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+  Toaster: () => null,
+}));
+
+vi.mock("@/lib/auth/auth-context", () => ({
+  useAuth: () => ({
+    userId: "u1",
+    username: "alice",
+    serverName: "server",
+    isAuthenticated: true,
+    clearAuth: mocks.clearAuth,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 import { DevicePickerDialog } from "../device-picker-dialog";
 import type { Device, SearchResultItem } from "@/lib/api/types";
 
@@ -411,30 +439,35 @@ describe("DevicePickerDialog — Dispatching state and concurrent-dispatch guard
     document.cookie = "";
   });
 
-  it("shows inline spinner on tapped row and disables other rows during dispatch (T2 stub: never-resolving onDispatched)", async () => {
+  it("shows inline spinner on tapped row and disables other rows during dispatch (postPlay hanging)", async () => {
     const user = userEvent.setup();
-    vi.stubGlobal(
-      "fetch",
-      mockFetchOnce(200, [
-        makeDevice({ session_id: "tv", name: "TV" }),
-        makeDevice({
-          session_id: "phone",
-          name: "Phone",
-          device_type: "Mobile",
-          client: "Jellyfin Mobile",
-        }),
-      ])
-    );
 
-    // Never-resolving onDispatched pins the component in the dispatching state for the assertion
-    const onDispatched = vi.fn(() => new Promise<void>(() => {}));
+    // First call: GET /api/devices. Second call: POST /api/play → hangs forever.
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve([
+            makeDevice({ session_id: "tv", name: "TV" }),
+            makeDevice({
+              session_id: "phone",
+              name: "Phone",
+              device_type: "Mobile",
+              client: "Jellyfin Mobile",
+            }),
+          ]),
+      })
+      .mockImplementationOnce(() => new Promise(() => {}));
+    vi.stubGlobal("fetch", fetchFn);
 
     render(
       <DevicePickerDialog
         item={makeItem({ title: "Galaxy Quest" })}
         open={true}
         onClose={vi.fn()}
-        onDispatched={onDispatched}
+        onDispatched={vi.fn()}
       />
     );
 
@@ -458,47 +491,9 @@ describe("DevicePickerDialog — Dispatching state and concurrent-dispatch guard
     expect(phoneButton).toBeDisabled();
   });
 
-  it("concurrent-dispatch guard: a second tap during an in-flight dispatch is a no-op (postPlay not re-called)", async () => {
-    const user = userEvent.setup();
-    vi.stubGlobal(
-      "fetch",
-      mockFetchOnce(200, [
-        makeDevice({ session_id: "tv", name: "TV" }),
-        makeDevice({
-          session_id: "phone",
-          name: "Phone",
-          device_type: "Mobile",
-          client: "Jellyfin Mobile",
-        }),
-      ])
-    );
-
-    const onDispatched = vi.fn(() => new Promise<void>(() => {}));
-
-    render(
-      <DevicePickerDialog
-        item={makeItem({ title: "Galaxy Quest" })}
-        open={true}
-        onClose={vi.fn()}
-        onDispatched={onDispatched}
-      />
-    );
-
-    const tvButton = await screen.findByRole("button", {
-      name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
-    });
-    const phoneButton = await screen.findByRole("button", {
-      name: "Cast Galaxy Quest to Phone, Jellyfin Mobile",
-    });
-
-    await user.click(tvButton);
-    // Second tap on the other row — must be ignored because first dispatch is in flight
-    await user.click(phoneButton);
-
-    // onDispatched called exactly once, with the first device's name
-    expect(onDispatched).toHaveBeenCalledTimes(1);
-    expect(onDispatched).toHaveBeenCalledWith("TV");
-  });
+  // The concurrent-dispatch guard is tested under real dispatch semantics in
+  // the "DevicePickerDialog — real dispatch (T4)" describe block below
+  // (see "concurrent-dispatch under real dispatch: ... postPlay called exactly once").
 });
 
 describe("DevicePickerDialog — Offline banner rendering (test-only forceOffline)", () => {
@@ -560,5 +555,255 @@ describe("DevicePickerDialog — Offline banner rendering (test-only forceOfflin
     expect(
       screen.queryByText("That device just went offline — pick another")
     ).toBeNull();
+  });
+});
+
+describe("DevicePickerDialog — real dispatch (T4)", () => {
+  const initialDevices = [
+    makeDevice({ session_id: "tv", name: "TV" }),
+    makeDevice({
+      session_id: "phone",
+      name: "Phone",
+      device_type: "Mobile",
+      client: "Jellyfin Mobile",
+    }),
+  ];
+
+  function responseJSON(status: number, body: unknown) {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    };
+  }
+
+  beforeEach(() => {
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "csrf_token=test-csrf-value",
+    });
+    mocks.toast.success.mockClear();
+    mocks.toast.error.mockClear();
+    mocks.clearAuth.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+    document.cookie = "";
+  });
+
+  it("200 success: POST /api/play returns device_name → onDispatched(name) + picker closes", async () => {
+    const user = userEvent.setup();
+    const onDispatched = vi.fn();
+    const onClose = vi.fn();
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(responseJSON(200, initialDevices)) // GET /api/devices
+        .mockResolvedValueOnce(
+          responseJSON(200, { status: "ok", device_name: "TV" })
+        ) // POST /api/play
+    );
+
+    render(
+      <DevicePickerDialog
+        item={makeItem({ title: "Galaxy Quest" })}
+        open={true}
+        onClose={onClose}
+        onDispatched={onDispatched}
+      />
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
+      })
+    );
+
+    await waitFor(() => {
+      expect(onDispatched).toHaveBeenCalledTimes(1);
+    });
+    expect(onDispatched).toHaveBeenCalledWith("TV");
+    expect(onClose).toHaveBeenCalled();
+
+    // No error toast on the happy path; success toast fires from the parent
+    // (card-detail), not the picker, so `mocks.toast.success` should also be 0.
+    expect(mocks.toast.error).not.toHaveBeenCalled();
+    expect(mocks.toast.success).not.toHaveBeenCalled();
+  });
+
+  it("409 device_offline: picker stays open, offline banner appears (aria-live=assertive), device list re-fetched in place", async () => {
+    const user = userEvent.setup();
+    const onDispatched = vi.fn();
+    const onClose = vi.fn();
+
+    const freshDevices = [
+      makeDevice({ session_id: "phone", name: "Phone (fresh)" }),
+    ];
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(responseJSON(200, initialDevices)) // initial GET /api/devices
+        .mockResolvedValueOnce(responseJSON(409, { error: "device_offline" })) // POST /api/play 409
+        .mockResolvedValueOnce(responseJSON(200, freshDevices)) // refetched GET /api/devices
+    );
+
+    render(
+      <DevicePickerDialog
+        item={makeItem({ title: "Galaxy Quest" })}
+        open={true}
+        onClose={onClose}
+        onDispatched={onDispatched}
+      />
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
+      })
+    );
+
+    // Offline banner appears with aria-live=assertive
+    const banner = await screen.findByText(
+      "That device just went offline — pick another"
+    );
+    expect(banner.closest('[aria-live="assertive"]')).not.toBeNull();
+
+    // List refetched — fresh device row appears
+    await screen.findByRole("button", {
+      name: "Cast Galaxy Quest to Phone (fresh), Jellyfin Android TV",
+    });
+
+    // Picker stays open (onClose not called) and onDispatched not called
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onDispatched).not.toHaveBeenCalled();
+    expect(mocks.toast.error).not.toHaveBeenCalled(); // 409 is NOT a toast
+  });
+
+  it("401 auth failure: picker closes, clearAuth() called, toast.error with expired-session copy", async () => {
+    const user = userEvent.setup();
+    const onDispatched = vi.fn();
+    const onClose = vi.fn();
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(responseJSON(200, initialDevices)) // GET /api/devices
+        .mockResolvedValueOnce(
+          responseJSON(401, { error: "jellyfin_auth_failed" })
+        ) // POST /api/play 401
+    );
+
+    render(
+      <DevicePickerDialog
+        item={makeItem({ title: "Galaxy Quest" })}
+        open={true}
+        onClose={onClose}
+        onDispatched={onDispatched}
+      />
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
+      })
+    );
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    expect(mocks.clearAuth).toHaveBeenCalledTimes(1);
+    expect(mocks.toast.error).toHaveBeenCalledWith(
+      "Your session has expired. Please log in again."
+    );
+    expect(onDispatched).not.toHaveBeenCalled();
+  });
+
+  it("500 generic failure: picker closes, toast.error with generic playback copy", async () => {
+    const user = userEvent.setup();
+    const onDispatched = vi.fn();
+    const onClose = vi.fn();
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(responseJSON(200, initialDevices))
+        .mockResolvedValueOnce(responseJSON(500, { error: "playback_failed" }))
+    );
+
+    render(
+      <DevicePickerDialog
+        item={makeItem({ title: "Galaxy Quest" })}
+        open={true}
+        onClose={onClose}
+        onDispatched={onDispatched}
+      />
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
+      })
+    );
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    expect(mocks.toast.error).toHaveBeenCalledWith(
+      "Couldn't start playback. Please try again."
+    );
+    expect(mocks.clearAuth).not.toHaveBeenCalled();
+    expect(onDispatched).not.toHaveBeenCalled();
+  });
+
+  it("concurrent-dispatch under real dispatch: second tap while postPlay is in-flight is a no-op (postPlay called exactly once)", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    // Two fetches: initial devices load succeeds, then /api/play hangs forever.
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(responseJSON(200, initialDevices))
+      .mockImplementationOnce(() => new Promise(() => {})); // /api/play hangs
+
+    vi.stubGlobal("fetch", fetchFn);
+
+    render(
+      <DevicePickerDialog
+        item={makeItem({ title: "Galaxy Quest" })}
+        open={true}
+        onClose={onClose}
+        onDispatched={vi.fn()}
+      />
+    );
+
+    const tvButton = await screen.findByRole("button", {
+      name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
+    });
+    const phoneButton = await screen.findByRole("button", {
+      name: "Cast Galaxy Quest to Phone, Jellyfin Mobile",
+    });
+
+    await user.click(tvButton);
+    // Second tap on a different row while the first is still in-flight
+    await user.click(phoneButton);
+
+    // Only two fetch calls total: the initial devices load + ONE play dispatch.
+    // If the guard were state-only (not ref), React 19's batching could allow
+    // a second postPlay to fire.
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    // The second call is the /api/play dispatch
+    const [, playCall] = fetchFn.mock.calls;
+    expect(playCall[0]).toBe("/api/play");
   });
 });

--- a/frontend/src/components/chat/card-detail.tsx
+++ b/frontend/src/components/chat/card-detail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useId, useState } from "react";
+import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
@@ -128,9 +129,8 @@ export function CardDetail({ item, open, onClose }: CardDetailProps) {
         item={item}
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
-        onDispatched={() => {
-          // T2 stub — T4 will replace with toast.success(`Now playing on ${deviceName}`)
-          setPickerOpen(false);
+        onDispatched={(deviceName) => {
+          toast.success(`Now playing on ${deviceName}`);
         }}
       />
     </>

--- a/frontend/src/components/chat/device-picker-dialog.tsx
+++ b/frontend/src/components/chat/device-picker-dialog.tsx
@@ -8,6 +8,7 @@ import {
   MonitorSmartphone,
   Loader2,
 } from "lucide-react";
+import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
@@ -15,9 +16,10 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
-import { fetchDevices } from "@/lib/api/devices";
-import { ApiAuthError } from "@/lib/api/types";
+import { fetchDevices, postPlay } from "@/lib/api/devices";
+import { ApiAuthError, DeviceOfflineError } from "@/lib/api/types";
 import type { Device, DeviceType, SearchResultItem } from "@/lib/api/types";
+import { useAuth } from "@/lib/auth/auth-context";
 
 interface DevicePickerDialogProps {
   item: SearchResultItem;
@@ -51,12 +53,15 @@ export function DevicePickerDialog({
   const titleId = useId();
   const descId = useId();
 
+  const { clearAuth } = useAuth();
+
   const [loading, setLoading] = useState(false);
   const [devices, setDevices] = useState<Device[]>([]);
   const [fetchError, setFetchError] = useState(false);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
     null
   );
+  const [showOfflineBanner, setShowOfflineBanner] = useState(false);
 
   // Ref guards — see spec Technical Considerations.
   const mountedRef = useRef(true);
@@ -99,8 +104,9 @@ export function DevicePickerDialog({
   // Fresh fetch on every open false→true transition.
   useEffect(() => {
     if (open) {
-      // Reset non-fetch transient state whenever the dialog opens
+      // Reset transient state whenever the dialog opens
       setSelectedSessionId(null);
+      setShowOfflineBanner(false);
       dispatchInFlightRef.current = false;
       runFetch();
     }
@@ -112,17 +118,41 @@ export function DevicePickerDialog({
       dispatchInFlightRef.current = true;
       setSelectedSessionId(sessionId);
 
-      const device = devices.find((d) => d.session_id === sessionId);
       try {
-        if (device) {
-          await onDispatched(device.name);
+        const result = await postPlay({
+          item_id: item.jellyfin_id,
+          session_id: sessionId,
+        });
+        if (!mountedRef.current) return;
+        // Success — clear any prior offline state, notify parent, close picker
+        setShowOfflineBanner(false);
+        onDispatched(result.device_name);
+        onClose();
+      } catch (err) {
+        if (!mountedRef.current) return;
+        if (err instanceof ApiAuthError) {
+          // Revoked session — match use-chat.ts:314 pattern: clear auth context
+          // and surface a toast. Middleware handles redirect on next navigation.
+          clearAuth();
+          toast.error("Your session has expired. Please log in again.");
+          onClose();
+        } else if (err instanceof DeviceOfflineError) {
+          // 409 — stay open, show banner, refetch device list in place.
+          setShowOfflineBanner(true);
+          runFetch();
+        } else {
+          // PlaybackFailedError, NetworkError, or anything else — generic
+          // error toast with fixed copy (no err.message interpolation per
+          // Angua's ruling on information-disclosure via toast strings).
+          toast.error("Couldn't start playback. Please try again.");
+          onClose();
         }
       } finally {
         if (mountedRef.current) setSelectedSessionId(null);
         dispatchInFlightRef.current = false;
       }
     },
-    [devices, onDispatched]
+    [clearAuth, item.jellyfin_id, onClose, onDispatched, runFetch]
   );
 
   return (
@@ -139,7 +169,7 @@ export function DevicePickerDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {forceOffline && (
+        {(forceOffline || showOfflineBanner) && (
           <div
             role="alert"
             aria-live="assertive"

--- a/frontend/src/lib/api/__tests__/devices.test.ts
+++ b/frontend/src/lib/api/__tests__/devices.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ApiAuthError } from "../types";
-import type { Device } from "../types";
+import {
+  ApiAuthError,
+  DeviceOfflineError,
+  PlaybackFailedError,
+} from "../types";
+import type { Device, PlayRequest } from "../types";
+import * as client from "../client";
 
 function mockFetch(status: number, body: unknown): void {
   vi.stubGlobal(
@@ -80,5 +85,78 @@ describe("fetchDevices", () => {
 
     await expect(fetchDevices()).rejects.toThrow(ApiAuthError);
     await expect(fetchDevices()).rejects.toHaveProperty("status", 401);
+  });
+});
+
+describe("postPlay", () => {
+  const validRequest: PlayRequest = {
+    item_id: "f4e3d2c1",
+    session_id: "a1b2c3d4",
+  };
+
+  beforeEach(() => {
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "csrf_token=test-csrf-value",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.cookie = "";
+  });
+
+  it("resolves to PlayResponse {status, device_name} on 200 and routes through apiPost (not raw fetch)", async () => {
+    mockFetch(200, { status: "ok", device_name: "Living Room TV" });
+    const apiPostSpy = vi.spyOn(client, "apiPost");
+
+    const { postPlay } = await import("../devices");
+    const result = await postPlay(validRequest);
+
+    expect(result).toEqual({ status: "ok", device_name: "Living Room TV" });
+
+    // Angua C1 — guard against a regression that bypasses apiPost (and therefore CSRF).
+    expect(apiPostSpy).toHaveBeenCalledTimes(1);
+    expect(apiPostSpy).toHaveBeenCalledWith("/api/play", validRequest);
+
+    // CSRF header present in the outgoing fetch call (apiPost's responsibility, re-asserted here).
+    const call = vi.mocked(fetch).mock.calls[0];
+    const headers = call[1]?.headers as Record<string, string>;
+    expect(headers["X-CSRF-Token"]).toBe("test-csrf-value");
+
+    // Body shape matches PlayRequest
+    expect(JSON.parse(call[1]?.body as string)).toEqual(validRequest);
+  });
+
+  it("rejects with ApiAuthError on 401 (passes through — T4 picker will handle re-login)", async () => {
+    mockFetch(401, { error: "jellyfin_auth_failed" });
+    const { postPlay } = await import("../devices");
+
+    await expect(postPlay(validRequest)).rejects.toThrow(ApiAuthError);
+    await expect(postPlay(validRequest)).rejects.toHaveProperty("status", 401);
+  });
+
+  it("rejects with DeviceOfflineError on 409", async () => {
+    mockFetch(409, { error: "device_offline" });
+    const { postPlay } = await import("../devices");
+
+    await expect(postPlay(validRequest)).rejects.toThrow(DeviceOfflineError);
+    await expect(postPlay(validRequest)).rejects.toHaveProperty("status", 409);
+  });
+
+  it("rejects with PlaybackFailedError on 500", async () => {
+    mockFetch(500, { error: "playback_failed" });
+    const { postPlay } = await import("../devices");
+
+    await expect(postPlay(validRequest)).rejects.toThrow(PlaybackFailedError);
+    await expect(postPlay(validRequest)).rejects.toHaveProperty("status", 500);
+  });
+
+  it("rejects with PlaybackFailedError on any other non-ok non-auth status (e.g., 502)", async () => {
+    mockFetch(502, { detail: "Bad gateway" });
+    const { postPlay } = await import("../devices");
+
+    await expect(postPlay(validRequest)).rejects.toThrow(PlaybackFailedError);
+    await expect(postPlay(validRequest)).rejects.toHaveProperty("status", 502);
   });
 });

--- a/frontend/src/lib/api/devices.ts
+++ b/frontend/src/lib/api/devices.ts
@@ -1,6 +1,45 @@
-import { apiGet } from "./client";
-import type { Device } from "./types";
+import { apiGet, apiPost } from "./client";
+import {
+  ApiAuthError,
+  ApiError,
+  DeviceOfflineError,
+  PlaybackFailedError,
+} from "./types";
+import type { Device, PlayRequest, PlayResponse } from "./types";
 
 export async function fetchDevices(): Promise<Device[]> {
   return apiGet<Device[]>("/api/devices");
+}
+
+/**
+ * Dispatch a play command to a Jellyfin session.
+ *
+ * Error mapping (per backend/app/play/router.py contract):
+ *   200 → PlayResponse
+ *   401 → ApiAuthError (pass through; picker will call clearAuth + toast.error)
+ *   409 → DeviceOfflineError (picker stays open, in-place refetch)
+ *   500 / other → PlaybackFailedError (picker closes + toast.error)
+ *
+ * Goes through `apiPost` (not raw `fetch`) so the CSRF header + session
+ * cookie are always attached. Do not bypass this — the backend enforces
+ * CSRF on `/api/play` and a raw-fetch bypass would silently drop it.
+ */
+export async function postPlay(req: PlayRequest): Promise<PlayResponse> {
+  try {
+    return await apiPost<PlayResponse>("/api/play", req);
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      // Preserve auth errors as-is — T4 picker distinguishes this from
+      // other failures to trigger the re-login flow.
+      throw err;
+    }
+    if (err instanceof ApiError) {
+      if (err.status === 409) {
+        throw new DeviceOfflineError(err.body);
+      }
+      throw new PlaybackFailedError(err.status, err.body);
+    }
+    // NetworkError or anything else — classify as playback failure.
+    throw err;
+  }
 }

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -41,6 +41,25 @@ export class ApiAuthError extends ApiError {
   }
 }
 
+/** Raised when the chosen Jellyfin device is no longer reachable (HTTP 409). */
+export class DeviceOfflineError extends ApiError {
+  constructor(body: unknown) {
+    super(409, body);
+    this.name = "DeviceOfflineError";
+  }
+}
+
+/**
+ * Raised when the play dispatch failed for a reason other than auth or device
+ * offline (HTTP 500, transport error, unexpected backend state).
+ */
+export class PlaybackFailedError extends ApiError {
+  constructor(status: number, body: unknown) {
+    super(status, body);
+    this.name = "PlaybackFailedError";
+  }
+}
+
 // --- Device / Play types (Epic 4 Remote Control — mirroring backend models) ---
 
 /** Mirrors backend DeviceType literal from backend/app/jellyfin/device_models.py */
@@ -52,6 +71,18 @@ export interface Device {
   name: string;
   client: string;
   device_type: DeviceType;
+}
+
+/** Mirrors backend PlayRequest Pydantic model from backend/app/play/models.py */
+export interface PlayRequest {
+  item_id: string;
+  session_id: string;
+}
+
+/** Mirrors backend PlayResponse Pydantic model from backend/app/play/models.py */
+export interface PlayResponse {
+  status: string;
+  device_name: string;
 }
 
 // --- Chat / Search types (mirroring backend models) ---


### PR DESCRIPTION
## Summary

Second of two PRs closing **Epic 4 (Remote Control / Cast to TV)**. Replaces T2's stubbed dispatch with real `postPlay` calls and full error-contract routing — 200 → success toast, 409 → in-place offline recovery, 401 → `clearAuth()` + re-login toast, 500/other → generic error toast. **Merging this PR closes Epic 4.**

- Closes #198 (Epic 4 T4)
- Closes Epic 4 (Remote Control)
- **Stacked on top of PR #208** (T2). Base branch: `feat/cast-to-tv-picker`. GitHub will auto-retarget to `main` once #208 merges.
- Depends on backend endpoint from #203 (`POST /api/play` — merged)

## Commits

| SHA | Scope | Notes |
|---|---|---|
| `ff21237` | `feat(play)` | `postPlay()` client + `PlayRequest`/`PlayResponse` types + `DeviceOfflineError`/`PlaybackFailedError` classes |
| `f7ad04d` | `feat(play)` | Wire real dispatch into the picker: 200/409/401/500 routing + sonner error toasts + `clearAuth` on 401 + success toast in card-detail |

## Error-contract routing (matches backend PR #203)

| Status | Frontend path |
|---|---|
| 200 | `onDispatched(device_name)` → parent fires `toast.success('Now playing on {device_name}')` → picker closes |
| 401 | Close picker + `clearAuth()` + `toast.error('Your session has expired. Please log in again.')` |
| 409 | Stay open + `aria-live="assertive"` banner + refetch device list in place |
| 500 / other | Close picker + `toast.error('Couldn't start playback. Please try again.')` |

## Security posture (Angua C1/C3 honored)

- `postPlay` routes through `apiPost` — CSRF header always attached. Verified by `vi.spyOn(apiPost)` test that catches any future regression that bypasses it.
- Toast strings are all static literals — no `err.message` interpolation into user-facing messages, so a future catch-rethrow can't leak backend JSON to toasts.
- 401 handling matches the `use-chat.ts:314` pattern (clearAuth + toast, no forced programmatic redirect; middleware handles the next navigation).

## Test plan

- [x] `npm run test` — 203/203 green
- [x] `npm run type-check` — clean
- [x] `npm run lint` — 0 errors (2 pre-existing warnings unrelated)
- [x] 5 new picker dispatch tests (200/409/401/500/concurrent-under-real) + 1 card-detail success-toast test
- [x] Concurrent-dispatch `useRef` guard verified under real `postPlay` semantics (React 19 Strict Mode safe)
- [ ] Live-Jellyfin E2E walkthrough — deferred to #195 per original design-doc scoping

## What ships

- `frontend/src/lib/api/types.ts` — `PlayRequest`, `PlayResponse`, `DeviceOfflineError`, `PlaybackFailedError`
- `frontend/src/lib/api/devices.ts` — `postPlay()` with error-class mapping
- `frontend/src/components/chat/device-picker-dialog.tsx` — real dispatch handler, internal `showOfflineBanner` state, 401 auth-context integration
- `frontend/src/components/chat/card-detail.tsx` — `toast.success('Now playing on ${deviceName}')` wired to `onDispatched`

## Related

- Design doc: `docs/superpowers/specs/2026-04-22-epic-4-remote-control-design.md` (#196)
- Deferred integration coverage: #195 (fake playback client)
- Follow-ups filed during implementation: #205 (shared auth-expiry hook), #206 (`make deps-sync`), #207 (Playwright focus-return E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)