### PR TITLE
feat(play): real play dispatch + notifications + 401 re-login (Epic 4 T4)

### DIFF
--- a/frontend/src/components/chat/__tests__/card-detail.test.tsx
+++ b/frontend/src/components/chat/__tests__/card-detail.test.tsx
@@ -2,6 +2,33 @@ import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { axe, toHaveNoViolations } from "jest-axe";
+
+// Hoisted module mocks — sonner (card-detail fires toast.success on dispatch)
+// and auth-context (picker uses useAuth internally).
+const mocks = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  clearAuth: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+  Toaster: () => null,
+}));
+
+vi.mock("@/lib/auth/auth-context", () => ({
+  useAuth: () => ({
+    userId: "u1",
+    username: "alice",
+    serverName: "server",
+    isAuthenticated: true,
+    clearAuth: mocks.clearAuth,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 import { CardDetail } from "../card-detail";
 import type { Device, SearchResultItem } from "@/lib/api/types";
 
@@ -192,6 +219,9 @@ describe("CardDetail — Cast to TV entry point", () => {
       writable: true,
       value: "csrf_token=test-csrf-value",
     });
+    mocks.toast.success.mockClear();
+    mocks.toast.error.mockClear();
+    mocks.clearAuth.mockClear();
   });
 
   afterEach(() => {
@@ -264,6 +294,56 @@ describe("CardDetail — Cast to TV entry point", () => {
     // data-return-focus="false" or similar — Radix doesn't expose this, so the
     // grep-in-source check above is the real guard).
     expect(dialogs[0]).toBeInTheDocument();
+  });
+
+  it("fires toast.success('Now playing on {deviceName}') when dispatch succeeds (T4)", async () => {
+    const user = userEvent.setup();
+
+    // Sequence: initial GET /api/devices returns a populated list, then
+    // POST /api/play returns 200 with device_name.
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve([
+              {
+                session_id: "tv",
+                name: "Living Room TV",
+                client: "Jellyfin Android TV",
+                device_type: "Tv",
+              },
+            ] satisfies Device[]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({ status: "ok", device_name: "Living Room TV" }),
+        })
+    );
+
+    render(<CardDetail item={makeItem()} open={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Cast to TV" }));
+
+    // Wait for the device row, then tap it
+    const row = await screen.findByRole("button", {
+      name: /Cast Galaxy Quest to Living Room TV/i,
+    });
+    await user.click(row);
+
+    // Card-detail's onDispatched handler fires toast.success from sonner
+    await waitFor(() => {
+      expect(mocks.toast.success).toHaveBeenCalledWith(
+        "Now playing on Living Room TV"
+      );
+    });
+    expect(mocks.toast.success).toHaveBeenCalledTimes(1);
+    expect(mocks.toast.error).not.toHaveBeenCalled();
   });
 
   it("pressing Escape with both dialogs open dismisses only the top (picker) dialog; card-detail stays open", async () => {

--- a/frontend/src/components/chat/__tests__/card-detail.test.tsx
+++ b/frontend/src/components/chat/__tests__/card-detail.test.tsx
@@ -344,6 +344,17 @@ describe("CardDetail — Cast to TV entry point", () => {
     });
     expect(mocks.toast.success).toHaveBeenCalledTimes(1);
     expect(mocks.toast.error).not.toHaveBeenCalled();
+
+    // Picker should close after successful dispatch (handleTap calls onClose,
+    // which flips pickerOpen back to false in the parent). Assert the tapped
+    // device row is gone — picker DialogContent unmounts via Radix portal.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", {
+          name: /Cast Galaxy Quest to Living Room TV/i,
+        })
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("pressing Escape with both dialogs open dismisses only the top (picker) dialog; card-detail stays open", async () => {

--- a/frontend/src/components/chat/__tests__/device-picker-dialog.test.tsx
+++ b/frontend/src/components/chat/__tests__/device-picker-dialog.test.tsx
@@ -1,6 +1,34 @@
 import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Hoisted mocks — sonner (toast) and auth-context (useAuth).
+// All T2 tests continue to work because the mocks provide defaults;
+// T4 tests add assertions on the mocked call counts.
+const mocks = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  clearAuth: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+  Toaster: () => null,
+}));
+
+vi.mock("@/lib/auth/auth-context", () => ({
+  useAuth: () => ({
+    userId: "u1",
+    username: "alice",
+    serverName: "server",
+    isAuthenticated: true,
+    clearAuth: mocks.clearAuth,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 import { DevicePickerDialog } from "../device-picker-dialog";
 import type { Device, SearchResultItem } from "@/lib/api/types";
 
@@ -417,30 +445,35 @@ describe("DevicePickerDialog — Dispatching state and concurrent-dispatch guard
     document.cookie = "";
   });
 
-  it("shows inline spinner on tapped row and disables other rows during dispatch (T2 stub: never-resolving onDispatched)", async () => {
+  it("shows inline spinner on tapped row and disables other rows during dispatch (postPlay hanging)", async () => {
     const user = userEvent.setup();
-    vi.stubGlobal(
-      "fetch",
-      mockFetchOnce(200, [
-        makeDevice({ session_id: "tv", name: "TV" }),
-        makeDevice({
-          session_id: "phone",
-          name: "Phone",
-          device_type: "Mobile",
-          client: "Jellyfin Mobile",
-        }),
-      ])
-    );
 
-    // Never-resolving onDispatched pins the component in the dispatching state for the assertion
-    const onDispatched = vi.fn(() => new Promise<void>(() => {}));
+    // First call: GET /api/devices. Second call: POST /api/play → hangs forever.
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve([
+            makeDevice({ session_id: "tv", name: "TV" }),
+            makeDevice({
+              session_id: "phone",
+              name: "Phone",
+              device_type: "Mobile",
+              client: "Jellyfin Mobile",
+            }),
+          ]),
+      })
+      .mockImplementationOnce(() => new Promise(() => {}));
+    vi.stubGlobal("fetch", fetchFn);
 
     render(
       <DevicePickerDialog
         item={makeItem({ title: "Galaxy Quest" })}
         open={true}
         onClose={vi.fn()}
-        onDispatched={onDispatched}
+        onDispatched={vi.fn()}
       />
     );
 
@@ -464,47 +497,9 @@ describe("DevicePickerDialog — Dispatching state and concurrent-dispatch guard
     expect(phoneButton).toBeDisabled();
   });
 
-  it("concurrent-dispatch guard: a second tap during an in-flight dispatch is a no-op (postPlay not re-called)", async () => {
-    const user = userEvent.setup();
-    vi.stubGlobal(
-      "fetch",
-      mockFetchOnce(200, [
-        makeDevice({ session_id: "tv", name: "TV" }),
-        makeDevice({
-          session_id: "phone",
-          name: "Phone",
-          device_type: "Mobile",
-          client: "Jellyfin Mobile",
-        }),
-      ])
-    );
-
-    const onDispatched = vi.fn(() => new Promise<void>(() => {}));
-
-    render(
-      <DevicePickerDialog
-        item={makeItem({ title: "Galaxy Quest" })}
-        open={true}
-        onClose={vi.fn()}
-        onDispatched={onDispatched}
-      />
-    );
-
-    const tvButton = await screen.findByRole("button", {
-      name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
-    });
-    const phoneButton = await screen.findByRole("button", {
-      name: "Cast Galaxy Quest to Phone, Jellyfin Mobile",
-    });
-
-    await user.click(tvButton);
-    // Second tap on the other row — must be ignored because first dispatch is in flight
-    await user.click(phoneButton);
-
-    // onDispatched called exactly once, with the first device's name
-    expect(onDispatched).toHaveBeenCalledTimes(1);
-    expect(onDispatched).toHaveBeenCalledWith("TV");
-  });
+  // The concurrent-dispatch guard is tested under real dispatch semantics in
+  // the "DevicePickerDialog — real dispatch (T4)" describe block below
+  // (see "concurrent-dispatch under real dispatch: ... postPlay called exactly once").
 });
 
 describe("DevicePickerDialog — Offline banner rendering (test-only forceOffline)", () => {
@@ -566,5 +561,255 @@ describe("DevicePickerDialog — Offline banner rendering (test-only forceOfflin
     expect(
       screen.queryByText("That device just went offline — pick another")
     ).toBeNull();
+  });
+});
+
+describe("DevicePickerDialog — real dispatch (T4)", () => {
+  const initialDevices = [
+    makeDevice({ session_id: "tv", name: "TV" }),
+    makeDevice({
+      session_id: "phone",
+      name: "Phone",
+      device_type: "Mobile",
+      client: "Jellyfin Mobile",
+    }),
+  ];
+
+  function responseJSON(status: number, body: unknown) {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    };
+  }
+
+  beforeEach(() => {
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "csrf_token=test-csrf-value",
+    });
+    mocks.toast.success.mockClear();
+    mocks.toast.error.mockClear();
+    mocks.clearAuth.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+    document.cookie = "";
+  });
+
+  it("200 success: POST /api/play returns device_name → onDispatched(name) + picker closes", async () => {
+    const user = userEvent.setup();
+    const onDispatched = vi.fn();
+    const onClose = vi.fn();
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(responseJSON(200, initialDevices)) // GET /api/devices
+        .mockResolvedValueOnce(
+          responseJSON(200, { status: "ok", device_name: "TV" })
+        ) // POST /api/play
+    );
+
+    render(
+      <DevicePickerDialog
+        item={makeItem({ title: "Galaxy Quest" })}
+        open={true}
+        onClose={onClose}
+        onDispatched={onDispatched}
+      />
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
+      })
+    );
+
+    await waitFor(() => {
+      expect(onDispatched).toHaveBeenCalledTimes(1);
+    });
+    expect(onDispatched).toHaveBeenCalledWith("TV");
+    expect(onClose).toHaveBeenCalled();
+
+    // No error toast on the happy path; success toast fires from the parent
+    // (card-detail), not the picker, so `mocks.toast.success` should also be 0.
+    expect(mocks.toast.error).not.toHaveBeenCalled();
+    expect(mocks.toast.success).not.toHaveBeenCalled();
+  });
+
+  it("409 device_offline: picker stays open, offline banner appears (aria-live=assertive), device list re-fetched in place", async () => {
+    const user = userEvent.setup();
+    const onDispatched = vi.fn();
+    const onClose = vi.fn();
+
+    const freshDevices = [
+      makeDevice({ session_id: "phone", name: "Phone (fresh)" }),
+    ];
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(responseJSON(200, initialDevices)) // initial GET /api/devices
+        .mockResolvedValueOnce(responseJSON(409, { error: "device_offline" })) // POST /api/play 409
+        .mockResolvedValueOnce(responseJSON(200, freshDevices)) // refetched GET /api/devices
+    );
+
+    render(
+      <DevicePickerDialog
+        item={makeItem({ title: "Galaxy Quest" })}
+        open={true}
+        onClose={onClose}
+        onDispatched={onDispatched}
+      />
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
+      })
+    );
+
+    // Offline banner appears with aria-live=assertive
+    const banner = await screen.findByText(
+      "That device just went offline — pick another"
+    );
+    expect(banner.closest('[aria-live="assertive"]')).not.toBeNull();
+
+    // List refetched — fresh device row appears
+    await screen.findByRole("button", {
+      name: "Cast Galaxy Quest to Phone (fresh), Jellyfin Android TV",
+    });
+
+    // Picker stays open (onClose not called) and onDispatched not called
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onDispatched).not.toHaveBeenCalled();
+    expect(mocks.toast.error).not.toHaveBeenCalled(); // 409 is NOT a toast
+  });
+
+  it("401 auth failure: picker closes, clearAuth() called, toast.error with expired-session copy", async () => {
+    const user = userEvent.setup();
+    const onDispatched = vi.fn();
+    const onClose = vi.fn();
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(responseJSON(200, initialDevices)) // GET /api/devices
+        .mockResolvedValueOnce(
+          responseJSON(401, { error: "jellyfin_auth_failed" })
+        ) // POST /api/play 401
+    );
+
+    render(
+      <DevicePickerDialog
+        item={makeItem({ title: "Galaxy Quest" })}
+        open={true}
+        onClose={onClose}
+        onDispatched={onDispatched}
+      />
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
+      })
+    );
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    expect(mocks.clearAuth).toHaveBeenCalledTimes(1);
+    expect(mocks.toast.error).toHaveBeenCalledWith(
+      "Your session has expired. Please log in again."
+    );
+    expect(onDispatched).not.toHaveBeenCalled();
+  });
+
+  it("500 generic failure: picker closes, toast.error with generic playback copy", async () => {
+    const user = userEvent.setup();
+    const onDispatched = vi.fn();
+    const onClose = vi.fn();
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(responseJSON(200, initialDevices))
+        .mockResolvedValueOnce(responseJSON(500, { error: "playback_failed" }))
+    );
+
+    render(
+      <DevicePickerDialog
+        item={makeItem({ title: "Galaxy Quest" })}
+        open={true}
+        onClose={onClose}
+        onDispatched={onDispatched}
+      />
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
+      })
+    );
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    expect(mocks.toast.error).toHaveBeenCalledWith(
+      "Couldn't start playback. Please try again."
+    );
+    expect(mocks.clearAuth).not.toHaveBeenCalled();
+    expect(onDispatched).not.toHaveBeenCalled();
+  });
+
+  it("concurrent-dispatch under real dispatch: second tap while postPlay is in-flight is a no-op (postPlay called exactly once)", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    // Two fetches: initial devices load succeeds, then /api/play hangs forever.
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(responseJSON(200, initialDevices))
+      .mockImplementationOnce(() => new Promise(() => {})); // /api/play hangs
+
+    vi.stubGlobal("fetch", fetchFn);
+
+    render(
+      <DevicePickerDialog
+        item={makeItem({ title: "Galaxy Quest" })}
+        open={true}
+        onClose={onClose}
+        onDispatched={vi.fn()}
+      />
+    );
+
+    const tvButton = await screen.findByRole("button", {
+      name: "Cast Galaxy Quest to TV, Jellyfin Android TV",
+    });
+    const phoneButton = await screen.findByRole("button", {
+      name: "Cast Galaxy Quest to Phone, Jellyfin Mobile",
+    });
+
+    await user.click(tvButton);
+    // Second tap on a different row while the first is still in-flight
+    await user.click(phoneButton);
+
+    // Only two fetch calls total: the initial devices load + ONE play dispatch.
+    // If the guard were state-only (not ref), React 19's batching could allow
+    // a second postPlay to fire.
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    // The second call is the /api/play dispatch
+    const [, playCall] = fetchFn.mock.calls;
+    expect(playCall[0]).toBe("/api/play");
   });
 });

--- a/frontend/src/components/chat/__tests__/device-picker-dialog.test.tsx
+++ b/frontend/src/components/chat/__tests__/device-picker-dialog.test.tsx
@@ -515,7 +515,7 @@ describe("DevicePickerDialog — Offline banner rendering (test-only forceOfflin
     document.cookie = "";
   });
 
-  it("renders offline banner with aria-live=assertive and exact copy when forceOffline is true", async () => {
+  it("renders offline banner with role=alert (implicit aria-live=assertive) and exact copy when forceOffline is true", async () => {
     vi.stubGlobal(
       "fetch",
       mockFetchOnce(200, [makeDevice({ session_id: "tv", name: "TV" })])
@@ -536,9 +536,11 @@ describe("DevicePickerDialog — Offline banner rendering (test-only forceOfflin
     );
     expect(banner).toBeInTheDocument();
 
-    // aria-live="assertive" on the banner (or an enclosing element)
-    const liveRegion = banner.closest('[aria-live="assertive"]');
-    expect(liveRegion).not.toBeNull();
+    // role="alert" on an enclosing element — role="alert" implicitly sets
+    // aria-live="assertive" per the WAI-ARIA spec, so we assert the role
+    // rather than the explicit attribute to avoid double-announcement.
+    const alertRegion = banner.closest('[role="alert"]');
+    expect(alertRegion).not.toBeNull();
   });
 
   it("does NOT render offline banner when forceOffline is false/undefined", async () => {
@@ -641,7 +643,7 @@ describe("DevicePickerDialog — real dispatch (T4)", () => {
     expect(mocks.toast.success).not.toHaveBeenCalled();
   });
 
-  it("409 device_offline: picker stays open, offline banner appears (aria-live=assertive), device list re-fetched in place", async () => {
+  it("409 device_offline: picker stays open, offline banner appears (role=alert), device list re-fetched in place", async () => {
     const user = userEvent.setup();
     const onDispatched = vi.fn();
     const onClose = vi.fn();
@@ -674,11 +676,11 @@ describe("DevicePickerDialog — real dispatch (T4)", () => {
       })
     );
 
-    // Offline banner appears with aria-live=assertive
+    // Offline banner appears with role=alert (implicit aria-live=assertive)
     const banner = await screen.findByText(
       "That device just went offline — pick another"
     );
-    expect(banner.closest('[aria-live="assertive"]')).not.toBeNull();
+    expect(banner.closest('[role="alert"]')).not.toBeNull();
 
     // List refetched — fresh device row appears
     await screen.findByRole("button", {
@@ -803,13 +805,17 @@ describe("DevicePickerDialog — real dispatch (T4)", () => {
     // Second tap on a different row while the first is still in-flight
     await user.click(phoneButton);
 
-    // Only two fetch calls total: the initial devices load + ONE play dispatch.
-    // If the guard were state-only (not ref), React 19's batching could allow
-    // a second postPlay to fire.
-    expect(fetchFn).toHaveBeenCalledTimes(2);
-
-    // The second call is the /api/play dispatch
-    const [, playCall] = fetchFn.mock.calls;
-    expect(playCall[0]).toBe("/api/play");
+    // Exactly one POST to /api/play fired, regardless of call order. The
+    // earlier form (asserting fetchFn.mock.calls[1][0] === "/api/play") would
+    // silently pass if a future refactor inserted another request (e.g., a
+    // preflight) ahead of the dispatch.
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/api/play",
+      expect.objectContaining({ method: "POST" })
+    );
+    const playCalls = fetchFn.mock.calls.filter(
+      (call) => call[0] === "/api/play"
+    );
+    expect(playCalls).toHaveLength(1);
   });
 });

--- a/frontend/src/components/chat/card-detail.tsx
+++ b/frontend/src/components/chat/card-detail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useId, useState } from "react";
+import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
@@ -128,9 +129,8 @@ export function CardDetail({ item, open, onClose }: CardDetailProps) {
         item={item}
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
-        onDispatched={() => {
-          // T2 stub — T4 will replace with toast.success(`Now playing on ${deviceName}`)
-          setPickerOpen(false);
+        onDispatched={(deviceName) => {
+          toast.success(`Now playing on ${deviceName}`);
         }}
       />
     </>

--- a/frontend/src/components/chat/device-picker-dialog.tsx
+++ b/frontend/src/components/chat/device-picker-dialog.tsx
@@ -25,7 +25,14 @@ interface DevicePickerDialogProps {
   item: SearchResultItem;
   open: boolean;
   onClose: () => void;
-  onDispatched: (deviceName: string) => void | Promise<void>;
+  /**
+   * Called by the picker when postPlay has succeeded. Must be synchronous
+   * (return `void`). The picker invokes this without `await` and does NOT
+   * handle rejections — a Promise-returning handler could produce an
+   * unhandled rejection. If the parent needs async work on dispatch, it
+   * should schedule that work internally (e.g., wrap in a `.catch`).
+   */
+  onDispatched: (deviceName: string) => void;
   /**
    * Test-only: forces the offline-banner rendering path without requiring a
    * real 409 dispatch. The production path uses internal `showOfflineBanner`

--- a/frontend/src/components/chat/device-picker-dialog.tsx
+++ b/frontend/src/components/chat/device-picker-dialog.tsx
@@ -8,6 +8,7 @@ import {
   MonitorSmartphone,
   Loader2,
 } from "lucide-react";
+import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
@@ -15,8 +16,10 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
-import { fetchDevices } from "@/lib/api/devices";
+import { fetchDevices, postPlay } from "@/lib/api/devices";
+import { ApiAuthError, DeviceOfflineError } from "@/lib/api/types";
 import type { Device, DeviceType, SearchResultItem } from "@/lib/api/types";
+import { useAuth } from "@/lib/auth/auth-context";
 
 interface DevicePickerDialogProps {
   item: SearchResultItem;
@@ -50,12 +53,15 @@ export function DevicePickerDialog({
   const titleId = useId();
   const descId = useId();
 
+  const { clearAuth } = useAuth();
+
   const [loading, setLoading] = useState(false);
   const [devices, setDevices] = useState<Device[]>([]);
   const [fetchError, setFetchError] = useState(false);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
     null
   );
+  const [showOfflineBanner, setShowOfflineBanner] = useState(false);
 
   // Ref guards — see spec Technical Considerations.
   const mountedRef = useRef(true);
@@ -71,11 +77,12 @@ export function DevicePickerDialog({
     previousOpenRef.current = open;
     if (open) {
       // Clean slate on every open transition: ensure the first post-open
-      // paint shows the Loading skeleton, not stale devices or a stale
-      // error from the previous session.
+      // paint shows the Loading skeleton, not stale devices/errors/offline
+      // banner from the previous session.
       setLoading(true);
       setDevices([]);
       setFetchError(false);
+      setShowOfflineBanner(false);
     }
   }
 
@@ -133,17 +140,41 @@ export function DevicePickerDialog({
       dispatchInFlightRef.current = true;
       setSelectedSessionId(sessionId);
 
-      const device = devices.find((d) => d.session_id === sessionId);
       try {
-        if (device) {
-          await onDispatched(device.name);
+        const result = await postPlay({
+          item_id: item.jellyfin_id,
+          session_id: sessionId,
+        });
+        if (!mountedRef.current) return;
+        // Success — clear any prior offline state, notify parent, close picker
+        setShowOfflineBanner(false);
+        onDispatched(result.device_name);
+        onClose();
+      } catch (err) {
+        if (!mountedRef.current) return;
+        if (err instanceof ApiAuthError) {
+          // Revoked session — match use-chat.ts:314 pattern: clear auth context
+          // and surface a toast. Middleware handles redirect on next navigation.
+          clearAuth();
+          toast.error("Your session has expired. Please log in again.");
+          onClose();
+        } else if (err instanceof DeviceOfflineError) {
+          // 409 — stay open, show banner, refetch device list in place.
+          setShowOfflineBanner(true);
+          runFetch();
+        } else {
+          // PlaybackFailedError, NetworkError, or anything else — generic
+          // error toast with fixed copy (no err.message interpolation per
+          // Angua's ruling on information-disclosure via toast strings).
+          toast.error("Couldn't start playback. Please try again.");
+          onClose();
         }
       } finally {
         if (mountedRef.current) setSelectedSessionId(null);
         dispatchInFlightRef.current = false;
       }
     },
-    [devices, onDispatched]
+    [clearAuth, item.jellyfin_id, onClose, onDispatched, runFetch]
   );
 
   return (
@@ -160,7 +191,7 @@ export function DevicePickerDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {forceOffline && (
+        {(forceOffline || showOfflineBanner) && (
           <div
             role="alert"
             aria-live="assertive"

--- a/frontend/src/components/chat/device-picker-dialog.tsx
+++ b/frontend/src/components/chat/device-picker-dialog.tsx
@@ -28,7 +28,8 @@ interface DevicePickerDialogProps {
   onDispatched: (deviceName: string) => void | Promise<void>;
   /**
    * Test-only: forces the offline-banner rendering path without requiring a
-   * real 409 dispatch. T4 will add an internal state path for production use.
+   * real 409 dispatch. The production path uses internal `showOfflineBanner`
+   * state, set to true in `handleTap`'s `DeviceOfflineError` branch.
    */
   forceOffline?: boolean;
 }
@@ -105,10 +106,14 @@ export function DevicePickerDialog({
     } catch (err) {
       if (!mountedRef.current) return;
       if (myFetchId !== fetchIdRef.current) return;
-      // T2: all fetch errors (including ApiAuthError) surface as the generic
-      // fetch-error state so the user can Refresh after re-authenticating.
-      // T4 will split ApiAuthError into the clearAuth + toast flow used by
-      // the dispatch handler (see PR #209).
+      // Deliberate: runFetch errors (including ApiAuthError) surface as the
+      // generic fetch-error state with a Refresh button. The clearAuth + toast
+      // flow only fires from the dispatch path (handleTap), where the user's
+      // tap directly caused the 401. Here the user merely opened the dialog;
+      // forcing logout on passive auth failure would be disproportionate.
+      // If /api/devices starts returning 401 consistently, the user will hit
+      // it again via Refresh and the middleware auth guard will redirect on
+      // the next protected navigation.
       void err;
       setFetchError(true);
     } finally {
@@ -194,7 +199,6 @@ export function DevicePickerDialog({
         {(forceOffline || showOfflineBanner) && (
           <div
             role="alert"
-            aria-live="assertive"
             className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-foreground"
           >
             That device just went offline — pick another

--- a/frontend/src/lib/api/__tests__/devices.test.ts
+++ b/frontend/src/lib/api/__tests__/devices.test.ts
@@ -99,6 +99,16 @@ describe("fetchDevices", () => {
   });
 });
 
+// Important: these tests use `vi.spyOn(client, "apiPost")` to verify
+// `postPlay` routes through the shared `apiPost` helper (and therefore
+// carries CSRF). The spy + `await import("../devices")` pattern below works
+// because the module registry is NOT reset between tests — the imported
+// `postPlay` references the same `apiPost` instance the spy patches.
+//
+// If a future `beforeEach` adds `vi.resetModules()`, the spy and the
+// imported `postPlay` would point at different module instances and the
+// spy assertion would silently pass without actually verifying the call.
+// Do NOT add vi.resetModules() to this file without rethinking the pattern.
 describe("postPlay", () => {
   const validRequest: PlayRequest = {
     item_id: "f4e3d2c1",

--- a/frontend/src/lib/api/__tests__/devices.test.ts
+++ b/frontend/src/lib/api/__tests__/devices.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ApiAuthError } from "../types";
-import type { Device } from "../types";
+import {
+  ApiAuthError,
+  DeviceOfflineError,
+  PlaybackFailedError,
+} from "../types";
+import type { Device, PlayRequest } from "../types";
+import * as client from "../client";
 
 function mockFetch(status: number, body: unknown): void {
   vi.stubGlobal(
@@ -91,5 +96,78 @@ describe("fetchDevices", () => {
 
     await expect(fetchDevices()).rejects.toThrow(ApiAuthError);
     await expect(fetchDevices()).rejects.toHaveProperty("status", 403);
+  });
+});
+
+describe("postPlay", () => {
+  const validRequest: PlayRequest = {
+    item_id: "f4e3d2c1",
+    session_id: "a1b2c3d4",
+  };
+
+  beforeEach(() => {
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "csrf_token=test-csrf-value",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.cookie = "";
+  });
+
+  it("resolves to PlayResponse {status, device_name} on 200 and routes through apiPost (not raw fetch)", async () => {
+    mockFetch(200, { status: "ok", device_name: "Living Room TV" });
+    const apiPostSpy = vi.spyOn(client, "apiPost");
+
+    const { postPlay } = await import("../devices");
+    const result = await postPlay(validRequest);
+
+    expect(result).toEqual({ status: "ok", device_name: "Living Room TV" });
+
+    // Angua C1 — guard against a regression that bypasses apiPost (and therefore CSRF).
+    expect(apiPostSpy).toHaveBeenCalledTimes(1);
+    expect(apiPostSpy).toHaveBeenCalledWith("/api/play", validRequest);
+
+    // CSRF header present in the outgoing fetch call (apiPost's responsibility, re-asserted here).
+    const call = vi.mocked(fetch).mock.calls[0];
+    const headers = call[1]?.headers as Record<string, string>;
+    expect(headers["X-CSRF-Token"]).toBe("test-csrf-value");
+
+    // Body shape matches PlayRequest
+    expect(JSON.parse(call[1]?.body as string)).toEqual(validRequest);
+  });
+
+  it("rejects with ApiAuthError on 401 (passes through — T4 picker will handle re-login)", async () => {
+    mockFetch(401, { error: "jellyfin_auth_failed" });
+    const { postPlay } = await import("../devices");
+
+    await expect(postPlay(validRequest)).rejects.toThrow(ApiAuthError);
+    await expect(postPlay(validRequest)).rejects.toHaveProperty("status", 401);
+  });
+
+  it("rejects with DeviceOfflineError on 409", async () => {
+    mockFetch(409, { error: "device_offline" });
+    const { postPlay } = await import("../devices");
+
+    await expect(postPlay(validRequest)).rejects.toThrow(DeviceOfflineError);
+    await expect(postPlay(validRequest)).rejects.toHaveProperty("status", 409);
+  });
+
+  it("rejects with PlaybackFailedError on 500", async () => {
+    mockFetch(500, { error: "playback_failed" });
+    const { postPlay } = await import("../devices");
+
+    await expect(postPlay(validRequest)).rejects.toThrow(PlaybackFailedError);
+    await expect(postPlay(validRequest)).rejects.toHaveProperty("status", 500);
+  });
+
+  it("rejects with PlaybackFailedError on any other non-ok non-auth status (e.g., 502)", async () => {
+    mockFetch(502, { detail: "Bad gateway" });
+    const { postPlay } = await import("../devices");
+
+    await expect(postPlay(validRequest)).rejects.toThrow(PlaybackFailedError);
+    await expect(postPlay(validRequest)).rejects.toHaveProperty("status", 502);
   });
 });

--- a/frontend/src/lib/api/devices.ts
+++ b/frontend/src/lib/api/devices.ts
@@ -14,11 +14,16 @@ export async function fetchDevices(): Promise<Device[]> {
 /**
  * Dispatch a play command to a Jellyfin session.
  *
- * Error mapping (per backend/app/play/router.py contract):
- *   200 → PlayResponse
- *   401 → ApiAuthError (pass through; picker will call clearAuth + toast.error)
- *   409 → DeviceOfflineError (picker stays open, in-place refetch)
- *   500 / other → PlaybackFailedError (picker closes + toast.error)
+ * Error mapping (per backend/app/play/router.py contract + parseResponse):
+ *   200              → PlayResponse
+ *   401 / 403        → ApiAuthError (passed through; picker's handleTap
+ *                      calls clearAuth + toast.error on this class)
+ *   409              → DeviceOfflineError (picker stays open, in-place refetch)
+ *   Other HTTP 4xx/5xx → PlaybackFailedError (picker closes + toast.error)
+ *   Non-HTTP (e.g. NetworkError from networkFetch) → re-thrown unwrapped,
+ *                      handled by the picker's generic `else` branch as a
+ *                      playback failure. Deliberately not wrapped — the
+ *                      picker's catch treats any non-typed throw the same.
  *
  * Goes through `apiPost` (not raw `fetch`) so the CSRF header + session
  * cookie are always attached. Do not bypass this — the backend enforces

--- a/frontend/src/lib/api/devices.ts
+++ b/frontend/src/lib/api/devices.ts
@@ -1,6 +1,45 @@
-import { apiGet } from "./client";
-import type { Device } from "./types";
+import { apiGet, apiPost } from "./client";
+import {
+  ApiAuthError,
+  ApiError,
+  DeviceOfflineError,
+  PlaybackFailedError,
+} from "./types";
+import type { Device, PlayRequest, PlayResponse } from "./types";
 
 export async function fetchDevices(): Promise<Device[]> {
   return apiGet<Device[]>("/api/devices");
+}
+
+/**
+ * Dispatch a play command to a Jellyfin session.
+ *
+ * Error mapping (per backend/app/play/router.py contract):
+ *   200 → PlayResponse
+ *   401 → ApiAuthError (pass through; picker will call clearAuth + toast.error)
+ *   409 → DeviceOfflineError (picker stays open, in-place refetch)
+ *   500 / other → PlaybackFailedError (picker closes + toast.error)
+ *
+ * Goes through `apiPost` (not raw `fetch`) so the CSRF header + session
+ * cookie are always attached. Do not bypass this — the backend enforces
+ * CSRF on `/api/play` and a raw-fetch bypass would silently drop it.
+ */
+export async function postPlay(req: PlayRequest): Promise<PlayResponse> {
+  try {
+    return await apiPost<PlayResponse>("/api/play", req);
+  } catch (err) {
+    if (err instanceof ApiAuthError) {
+      // Preserve auth errors as-is — T4 picker distinguishes this from
+      // other failures to trigger the re-login flow.
+      throw err;
+    }
+    if (err instanceof ApiError) {
+      if (err.status === 409) {
+        throw new DeviceOfflineError(err.body);
+      }
+      throw new PlaybackFailedError(err.status, err.body);
+    }
+    // NetworkError or anything else — classify as playback failure.
+    throw err;
+  }
 }

--- a/frontend/src/lib/api/devices.ts
+++ b/frontend/src/lib/api/devices.ts
@@ -28,9 +28,14 @@ export async function postPlay(req: PlayRequest): Promise<PlayResponse> {
   try {
     return await apiPost<PlayResponse>("/api/play", req);
   } catch (err) {
+    // Catch ordering matters: ApiAuthError extends ApiError, so the
+    // ApiAuthError guard MUST run before the ApiError branch — otherwise
+    // auth errors would be swallowed into PlaybackFailedError and the picker
+    // would never trigger the re-login flow. Any future ApiError subclass
+    // with special handling belongs above this block.
     if (err instanceof ApiAuthError) {
-      // Preserve auth errors as-is — T4 picker distinguishes this from
-      // other failures to trigger the re-login flow.
+      // Preserve auth errors as-is — the picker distinguishes ApiAuthError
+      // in its handleTap catch to trigger clearAuth + the re-login toast.
       throw err;
     }
     if (err instanceof ApiError) {
@@ -39,7 +44,10 @@ export async function postPlay(req: PlayRequest): Promise<PlayResponse> {
       }
       throw new PlaybackFailedError(err.status, err.body);
     }
-    // NetworkError or anything else — classify as playback failure.
+    // NetworkError or anything non-ApiError — re-thrown unwrapped. The
+    // picker's handleTap `else` branch treats any non-typed error as a
+    // generic playback failure (shows the "Couldn't start playback" toast),
+    // so wrapping in PlaybackFailedError here would be redundant.
     throw err;
   }
 }

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -41,6 +41,25 @@ export class ApiAuthError extends ApiError {
   }
 }
 
+/** Raised when the chosen Jellyfin device is no longer reachable (HTTP 409). */
+export class DeviceOfflineError extends ApiError {
+  constructor(body: unknown) {
+    super(409, body);
+    this.name = "DeviceOfflineError";
+  }
+}
+
+/**
+ * Raised when the play dispatch failed for a reason other than auth or device
+ * offline (HTTP 500, transport error, unexpected backend state).
+ */
+export class PlaybackFailedError extends ApiError {
+  constructor(status: number, body: unknown) {
+    super(status, body);
+    this.name = "PlaybackFailedError";
+  }
+}
+
 // --- Device / Play types (Epic 4 Remote Control — mirroring backend models) ---
 
 /** Mirrors backend DeviceType literal from backend/app/jellyfin/device_models.py */
@@ -52,6 +71,18 @@ export interface Device {
   name: string;
   client: string;
   device_type: DeviceType;
+}
+
+/** Mirrors backend PlayRequest Pydantic model from backend/app/play/models.py */
+export interface PlayRequest {
+  item_id: string;
+  session_id: string;
+}
+
+/** Mirrors backend PlayResponse Pydantic model from backend/app/play/models.py */
+export interface PlayResponse {
+  status: string;
+  device_name: string;
 }
 
 // --- Chat / Search types (mirroring backend models) ---

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -50,8 +50,13 @@ export class DeviceOfflineError extends ApiError {
 }
 
 /**
- * Raised when the play dispatch failed for a reason other than auth or device
- * offline (HTTP 500, transport error, unexpected backend state).
+ * Raised when the play dispatch failed with an HTTP error other than auth or
+ * device offline (e.g., HTTP 500, unexpected backend state).
+ *
+ * Note: actual network/transport failures are raised as `NetworkError` (by
+ * `networkFetch` in `client.ts`) and are NOT converted to
+ * `PlaybackFailedError` — callers that want a single type should wrap
+ * `postPlay` in their own try/catch.
  */
 export class PlaybackFailedError extends ApiError {
   constructor(status: number, body: unknown) {


### PR DESCRIPTION
Closes #198
Closes Epic 4 (Remote Control / Cast to TV)

## Summary

Second of two PRs closing Epic 4. Replaces T2's stubbed dispatch (shipped in #208) with real `postPlay` calls and full error-contract routing. **Merging this PR closes Epic 4.**

- Supersedes #209 — that PR was auto-closed when its stacked base `feat/cast-to-tv-picker` was deleted on #208 merge; GitHub refused to reopen/retarget, so this is the replacement.
- Rebased onto main (post-#208) with one conflict resolution in `device-picker-dialog.tsx` (kept main's no-reset open-effect + added `setShowOfflineBanner(false)` to the previousOpenRef reset block).

## Commits

| SHA | Scope | Notes |
|---|---|---|
| `c89d579` | `feat(play)` | `postPlay()` client + `PlayRequest`/`PlayResponse` types + `DeviceOfflineError`/`PlaybackFailedError` classes |
| `9786389` | `feat(play)` | Wire real dispatch into picker: 200/409/401/500 routing + sonner error toasts + `clearAuth` on 401 + success toast in card-detail |
| `ba7a557` | `fix(play)` | Council review fixes (7 inline items) |
| `8191814` | `fix(play)` | Copilot review fixes (3 doc/type corrections) |

## Error-contract routing (matches backend PR #203)

| Status | Frontend path |
|---|---|
| 200 | `onDispatched(device_name)` → parent fires `toast.success('Now playing on {device_name}')` → picker closes |
| 401 | Close picker + `clearAuth()` + `toast.error('Your session has expired. Please log in again.')` |
| 409 | Stay open + `role="alert"` banner + refetch device list in place |
| 500 / other | Close picker + `toast.error("Couldn't start playback. Please try again.")` |

## Security posture (carried over from #208 review)

- `postPlay` routes through `apiPost` — CSRF header always attached. Verified by `vi.spyOn(apiPost)` test.
- Toast strings are all static literals — no `err.message` interpolation (Angua's ruling on info-disclosure via toast strings).
- 401 handling matches the `use-chat.ts:314` pattern.

## Test plan

- [x] `npm run test` — 204/204 green
- [x] `npm run type-check` — clean
- [x] `npm run lint` — 0 errors (2 pre-existing warnings unrelated)
- [ ] Live-Jellyfin E2E walkthrough — deferred to #195 per original design-doc scoping

## Related issues

- Closes #198 (T4 ticket)
- Design doc: `docs/superpowers/specs/2026-04-22-epic-4-remote-control-design.md` (#196)
- Deferred integration coverage: #195 (fake playback client)
- Follow-ups filed during Epic 4 implementation:
  - #205 (shared auth-expiry hook on third caller)
  - #206 (`make deps-sync`)
  - #207 (Playwright focus-return E2E)
  - #210 (card-detail React.useEffect aliasing)
  - #213 (403 CSRF-missing triggers clearAuth — cross-endpoint follow-up)
  - #214 (banner em-dash screen-reader compat)
  - #215 (ARCHITECTURE.md clearAuth vs backend-session docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
