### PR TITLE
feat(sync): persist crew metadata (directors, writers, composers)

### DIFF
--- a/backend/app/library/hashing.py
+++ b/backend/app/library/hashing.py
@@ -18,21 +18,18 @@ if TYPE_CHECKING:
 def compute_content_hash(item: LibraryItemRow) -> str:
     """Compute a deterministic SHA-256 hash from a library item's fields.
 
-    # TODO: Replace with text_builder from Spec 07
-    # When the text_builder module lands (app/ollama/text_builder.py),
-    # replace this placeholder with hashing the composite text output.
-    # A template change will cause all hashes to differ, triggering a
-    # full re-embed — this is intentional.
-
     Field ordering (deterministic):
-    1. title
-    2. overview (or empty string)
-    3. production_year (or empty string)
-    4. genres (sorted JSON array)
-    5. tags (sorted JSON array)
-    6. studios (sorted JSON array)
-    7. community_rating (or empty string)
-    8. people (sorted JSON array)
+     1. title
+     2. overview (or empty string)
+     3. production_year (or empty string)
+     4. genres (sorted JSON array)
+     5. tags (sorted JSON array)
+     6. studios (sorted JSON array)
+     7. community_rating (or empty string)
+     8. people (sorted JSON array)
+     9. directors (sorted JSON array)
+    10. writers (sorted JSON array)
+    11. composers (sorted JSON array)
 
     All JSON arrays are sorted to ensure determinism regardless of input order.
     """
@@ -45,6 +42,9 @@ def compute_content_hash(item: LibraryItemRow) -> str:
         json.dumps(sorted(item.studios)),
         str(item.community_rating) if item.community_rating is not None else "",
         json.dumps(sorted(item.people)),
+        json.dumps(sorted(item.directors)),
+        json.dumps(sorted(item.writers)),
+        json.dumps(sorted(item.composers)),
     ]
     composite = "|".join(parts)
     return hashlib.sha256(composite.encode()).hexdigest()

--- a/backend/app/library/models.py
+++ b/backend/app/library/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
@@ -14,8 +14,9 @@ class LibraryItemRow:
     """A library item row as stored in the database.
 
     People contains actor names only (filtered from Jellyfin's full People list).
-    JSON array fields (genres, tags, studios, people) are serialized to/from
-    JSON strings by the store layer.
+    directors, writers, composers hold the respective crew role names.
+    JSON array fields (genres, tags, studios, people, directors, writers,
+    composers) are serialized to/from JSON strings by the store layer.
     """
 
     jellyfin_id: str
@@ -30,6 +31,9 @@ class LibraryItemRow:
     content_hash: str  # SHA-256 hex digest
     synced_at: int  # Unix epoch seconds
     runtime_minutes: int | None = None
+    directors: list[str] = field(default_factory=list)
+    writers: list[str] = field(default_factory=list)
+    composers: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/app/library/store.py
+++ b/backend/app/library/store.py
@@ -35,7 +35,10 @@ CREATE TABLE IF NOT EXISTS library_items (
     people            TEXT NOT NULL DEFAULT '[]',
     content_hash      TEXT NOT NULL,
     synced_at         INTEGER NOT NULL,
-    deleted_at        INTEGER
+    deleted_at        INTEGER,
+    directors         TEXT NOT NULL DEFAULT '[]',
+    writers           TEXT NOT NULL DEFAULT '[]',
+    composers         TEXT NOT NULL DEFAULT '[]'
 )
 """
 
@@ -142,6 +145,15 @@ class LibraryStore:
             )
             await self._db.commit()
 
+        # Migration: add crew columns if table predates #216
+        for col in ("directors", "writers", "composers"):
+            if col not in existing_columns:
+                await self._db.execute(
+                    f"ALTER TABLE library_items ADD COLUMN {col} "
+                    "TEXT NOT NULL DEFAULT '[]'"
+                )
+                await self._db.commit()
+
         await self._db.execute(_CREATE_SYNC_RUNS)
         await self._db.execute(_CREATE_INDEX_SYNC_RUNS_STARTED)
         await self._db.commit()
@@ -176,6 +188,9 @@ class LibraryStore:
           9: content_hash   TEXT NOT NULL
          10: synced_at      INTEGER NOT NULL
          11: runtime_minutes INTEGER (nullable)
+         12: directors      TEXT (JSON array)
+         13: writers        TEXT (JSON array)
+         14: composers      TEXT (JSON array)
         """
         return LibraryItemRow(
             jellyfin_id=row[0],
@@ -190,6 +205,9 @@ class LibraryStore:
             content_hash=row[9],
             synced_at=row[10],
             runtime_minutes=row[11],
+            directors=json.loads(row[12]),
+            writers=json.loads(row[13]),
+            composers=json.loads(row[14]),
         )
 
     async def _get_hashes_for_ids(self, ids: list[str]) -> dict[str, str]:
@@ -256,6 +274,9 @@ class LibraryStore:
                     item.content_hash,
                     item.synced_at,
                     item.runtime_minutes,
+                    json.dumps(item.directors),
+                    json.dumps(item.writers),
+                    json.dumps(item.composers),
                 )
             )
 
@@ -266,8 +287,9 @@ class LibraryStore:
                     """INSERT INTO library_items
                        (jellyfin_id, title, overview, production_year,
                         genres, tags, studios, community_rating,
-                        people, content_hash, synced_at, runtime_minutes)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        people, content_hash, synced_at, runtime_minutes,
+                        directors, writers, composers)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                        ON CONFLICT(jellyfin_id) DO UPDATE SET
                         title = excluded.title,
                         overview = excluded.overview,
@@ -279,7 +301,10 @@ class LibraryStore:
                         people = excluded.people,
                         content_hash = excluded.content_hash,
                         synced_at = excluded.synced_at,
-                        runtime_minutes = excluded.runtime_minutes""",
+                        runtime_minutes = excluded.runtime_minutes,
+                        directors = excluded.directors,
+                        writers = excluded.writers,
+                        composers = excluded.composers""",
                     params_list,
                 )
             except Exception:
@@ -294,7 +319,8 @@ class LibraryStore:
         cursor = await self._conn.execute(
             """SELECT jellyfin_id, title, overview, production_year,
                       genres, tags, studios, community_rating,
-                      people, content_hash, synced_at, runtime_minutes
+                      people, content_hash, synced_at, runtime_minutes,
+                      directors, writers, composers
                FROM library_items WHERE jellyfin_id = ?""",
             (jellyfin_id,),
         )
@@ -321,7 +347,8 @@ class LibraryStore:
             cursor = await self._conn.execute(
                 f"""SELECT jellyfin_id, title, overview, production_year,
                           genres, tags, studios, community_rating,
-                          people, content_hash, synced_at, runtime_minutes
+                          people, content_hash, synced_at, runtime_minutes,
+                          directors, writers, composers
                    FROM library_items WHERE jellyfin_id IN ({placeholders})""",
                 batch,
             )

--- a/backend/app/library/store.py
+++ b/backend/app/library/store.py
@@ -145,7 +145,7 @@ class LibraryStore:
             )
             await self._db.commit()
 
-        # Migration: add crew columns if table predates #216
+        # Migration: add crew columns for pre-existing tables
         for col in ("directors", "writers", "composers"):
             if col not in existing_columns:
                 await self._db.execute(

--- a/backend/app/library/store.py
+++ b/backend/app/library/store.py
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS library_items (
     people            TEXT NOT NULL DEFAULT '[]',
     content_hash      TEXT NOT NULL,
     synced_at         INTEGER NOT NULL,
+    runtime_minutes   INTEGER,
     deleted_at        INTEGER,
     directors         TEXT NOT NULL DEFAULT '[]',
     writers           TEXT NOT NULL DEFAULT '[]',

--- a/backend/app/sync/engine.py
+++ b/backend/app/sync/engine.py
@@ -6,15 +6,15 @@ Fetches Jellyfin library, diffs against store, enqueues changes.
 from __future__ import annotations
 
 import asyncio
-import hashlib
+import dataclasses
 import logging
 import os
 import time
 from typing import TYPE_CHECKING
 
 from app.jellyfin.errors import JellyfinConnectionError, JellyfinError
+from app.library.hashing import compute_content_hash
 from app.library.models import LibraryItemRow
-from app.library.text_builder import build_composite_text
 from app.sync.models import (
     SYNC_STATUS_COMPLETED,
     SYNC_STATUS_FAILED,
@@ -35,15 +35,38 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
-def to_library_row(item: LibraryItem, content_hash: str) -> LibraryItemRow:
+_CREW_ROLE_MAP = {
+    "Actor": "people",
+    "Director": "directors",
+    "Writer": "writers",
+    "Composer": "composers",
+}
+
+
+def to_library_row(item: LibraryItem) -> LibraryItemRow:
     """Convert a Jellyfin LibraryItem to a LibraryItemRow for storage.
 
-    Extracts actor names from the people list (filtering by Type == "Actor").
+    Buckets `item.people` by ``Type`` into ``people`` (actors), ``directors``,
+    ``writers``, and ``composers``. Other crew roles are discarded. The
+    returned row's ``content_hash`` is computed internally via
+    ``compute_content_hash`` so callers never have to keep hash derivation
+    and row construction in sync.
     """
-    people = [
-        p["Name"] for p in item.people if p.get("Type") == "Actor" and "Name" in p
-    ]
-    return LibraryItemRow(
+    buckets: dict[str, list[str]] = {
+        "people": [],
+        "directors": [],
+        "writers": [],
+        "composers": [],
+    }
+    for person in item.people:
+        name = person.get("Name")
+        if not name:
+            continue
+        bucket = _CREW_ROLE_MAP.get(person.get("Type", ""))
+        if bucket is not None:
+            buckets[bucket].append(name)
+
+    row = LibraryItemRow(
         jellyfin_id=item.id,
         title=item.name,
         overview=item.overview,
@@ -52,11 +75,15 @@ def to_library_row(item: LibraryItem, content_hash: str) -> LibraryItemRow:
         tags=item.tags,
         studios=item.studios,
         community_rating=item.community_rating,
-        people=people,
-        content_hash=content_hash,
+        people=buckets["people"],
+        content_hash="",
         synced_at=int(time.time()),
         runtime_minutes=item.runtime_minutes,
+        directors=buckets["directors"],
+        writers=buckets["writers"],
+        composers=buckets["composers"],
     )
+    return dataclasses.replace(row, content_hash=compute_content_hash(row))
 
 
 class SyncEngine:
@@ -108,11 +135,6 @@ class SyncEngine:
     async def get_last_run(self) -> SyncRunRow | None:
         """Return the most recent sync run, or None."""
         return await self._library_store.get_last_sync_run()
-
-    @staticmethod
-    def _compute_hash(text: str) -> str:
-        """Compute a SHA-256 hex digest from the given text."""
-        return hashlib.sha256(text.encode()).hexdigest()
 
     async def run_sync(self) -> SyncResult:
         """Execute an incremental library sync.
@@ -183,28 +205,22 @@ class SyncEngine:
                     for item in page.items:
                         # Track as seen regardless of processing success —
                         # an item present in Jellyfin should not be tombstoned
-                        # just because build_composite_text failed on it
+                        # just because row construction failed on it
                         seen_ids.add(item.id)
                         try:
-                            composite_result = build_composite_text(item)
-                            content_hash = self._compute_hash(composite_result.text)
+                            row = to_library_row(item)
                             state.items_processed += 1
 
                             old_hash = existing_hashes.get(item.id)
                             if old_hash is None:
-                                # New item
                                 state.items_created += 1
-                                row = to_library_row(item, content_hash)
                                 rows_to_upsert.append(row)
                                 ids_to_enqueue.append(item.id)
-                            elif old_hash != content_hash:
-                                # Changed item
+                            elif old_hash != row.content_hash:
                                 state.items_updated += 1
-                                row = to_library_row(item, content_hash)
                                 rows_to_upsert.append(row)
                                 ids_to_enqueue.append(item.id)
                             else:
-                                # Unchanged
                                 state.items_unchanged += 1
                         except Exception:
                             _logger.warning(

--- a/backend/tests/integration/test_jellyfin_library.py
+++ b/backend/tests/integration/test_jellyfin_library.py
@@ -6,17 +6,15 @@ Uses the existing fixture chain: jellyfin -> admin_auth_token -> test_users.
 
 from __future__ import annotations
 
-import dataclasses
 from typing import TYPE_CHECKING
 
 import pytest
 
-from app.library.hashing import compute_content_hash
 from app.sync.engine import to_library_row
 
 if TYPE_CHECKING:
     from app.jellyfin.client import JellyfinClient
-    from app.jellyfin.models import AuthResult, LibraryItem, PaginatedItems
+    from app.jellyfin.models import AuthResult, PaginatedItems
     from app.library.models import LibraryItemRow
     from app.library.store import LibraryStore
 
@@ -24,15 +22,6 @@ from tests.integration.conftest import (
     EXPECTED_MOVIES,
     EXPECTED_SHOWS,
 )
-
-
-def _to_library_row(item: LibraryItem) -> LibraryItemRow:
-    """Convert a LibraryItem to a LibraryItemRow using the sync engine's converter."""
-    # Build a temporary row to compute a content hash, then replace the
-    # placeholder. Note: SyncEngine uses build_composite_text + SHA-256;
-    # this uses compute_content_hash which is sufficient for test assertions.
-    temp = to_library_row(item, "placeholder")
-    return dataclasses.replace(temp, content_hash=compute_content_hash(temp))
 
 
 @pytest.mark.integration
@@ -73,7 +62,7 @@ async def test_fetch_and_store_cycle(
     ):
         total_items = page.total_count
         for item in page.items:
-            all_rows.append(_to_library_row(item))
+            all_rows.append(to_library_row(item))
 
     if all_rows:
         await library_store.upsert_many(all_rows)

--- a/backend/tests/test_library_store.py
+++ b/backend/tests/test_library_store.py
@@ -34,6 +34,9 @@ def _make_item(
     content_hash: str = "abc123hash",
     synced_at: int | None = None,
     runtime_minutes: int | None = 117,
+    directors: list[str] | None = None,
+    writers: list[str] | None = None,
+    composers: list[str] | None = None,
 ) -> LibraryItemRow:
     """Helper to build LibraryItemRow with sensible defaults."""
     return LibraryItemRow(
@@ -49,6 +52,9 @@ def _make_item(
         content_hash=content_hash,
         synced_at=synced_at if synced_at is not None else _now(),
         runtime_minutes=runtime_minutes,
+        directors=directors if directors is not None else ["Ridley Scott"],
+        writers=writers if writers is not None else ["Dan O'Bannon"],
+        composers=composers if composers is not None else ["Jerry Goldsmith"],
     )
 
 
@@ -101,6 +107,54 @@ class TestInit:
         s = LibraryStore("/tmp/nonexistent.db")
         with pytest.raises(RuntimeError, match="LibraryStore not initialised"):
             _ = s._conn
+
+    async def test_crew_columns_exist_on_fresh_db(self, store: LibraryStore) -> None:
+        """directors, writers, composers columns are present on a fresh init."""
+        cursor = await store._conn.execute("PRAGMA table_info(library_items)")
+        rows = await cursor.fetchall()
+        columns = {row[1] for row in rows}
+        assert "directors" in columns
+        assert "writers" in columns
+        assert "composers" in columns
+
+    async def test_crew_columns_added_to_legacy_db(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Opening a pre-existing DB without crew columns adds them via ALTER TABLE."""
+        import aiosqlite
+
+        db_path = tmp_path / "legacy.db"
+        async with aiosqlite.connect(str(db_path)) as conn:
+            await conn.execute(
+                "CREATE TABLE library_items ("
+                " jellyfin_id TEXT PRIMARY KEY,"
+                " title TEXT NOT NULL,"
+                " overview TEXT,"
+                " production_year INTEGER,"
+                " genres TEXT NOT NULL DEFAULT '[]',"
+                " tags TEXT NOT NULL DEFAULT '[]',"
+                " studios TEXT NOT NULL DEFAULT '[]',"
+                " community_rating REAL,"
+                " people TEXT NOT NULL DEFAULT '[]',"
+                " content_hash TEXT NOT NULL,"
+                " synced_at INTEGER NOT NULL,"
+                " deleted_at INTEGER,"
+                " runtime_minutes INTEGER"
+                ")"
+            )
+            await conn.commit()
+
+        s = LibraryStore(str(db_path))
+        await s.init()
+        try:
+            cursor = await s._conn.execute("PRAGMA table_info(library_items)")
+            rows = await cursor.fetchall()
+            columns = {row[1] for row in rows}
+            assert "directors" in columns
+            assert "writers" in columns
+            assert "composers" in columns
+        finally:
+            await s.close()
 
 
 class TestUpsertMany:
@@ -179,6 +233,36 @@ class TestGet:
         assert fetched is not None
         assert fetched.runtime_minutes == 90
 
+    async def test_crew_fields_round_trip(self, store: LibraryStore) -> None:
+        """directors, writers, composers persist and reload intact."""
+        item = _make_item(
+            jellyfin_id="jf-crew",
+            directors=["Roger Corman"],
+            writers=["Charles B. Griffith", "Robert Towne"],
+            composers=["Les Baxter"],
+        )
+        await store.upsert_many([item])
+        fetched = await store.get("jf-crew")
+        assert fetched is not None
+        assert fetched.directors == ["Roger Corman"]
+        assert fetched.writers == ["Charles B. Griffith", "Robert Towne"]
+        assert fetched.composers == ["Les Baxter"]
+
+    async def test_empty_crew_fields_round_trip(self, store: LibraryStore) -> None:
+        """Empty crew lists round-trip as empty arrays, not NULL."""
+        item = _make_item(
+            jellyfin_id="jf-no-crew",
+            directors=[],
+            writers=[],
+            composers=[],
+        )
+        await store.upsert_many([item])
+        fetched = await store.get("jf-no-crew")
+        assert fetched is not None
+        assert fetched.directors == []
+        assert fetched.writers == []
+        assert fetched.composers == []
+
     async def test_runtime_minutes_null_round_trips(self, store: LibraryStore) -> None:
         item = _make_item(jellyfin_id="jf-no-runtime", runtime_minutes=None)
         await store.upsert_many([item])
@@ -256,6 +340,27 @@ class TestContentHash:
         item1 = _make_item(title="Alien")
         item2 = _make_item(title="Aliens")
         assert compute_content_hash(item1) != compute_content_hash(item2)
+
+    def test_different_directors_different_hash(self) -> None:
+        item1 = _make_item(directors=["Ridley Scott"])
+        item2 = _make_item(directors=["James Cameron"])
+        assert compute_content_hash(item1) != compute_content_hash(item2)
+
+    def test_different_writers_different_hash(self) -> None:
+        item1 = _make_item(writers=["Dan O'Bannon"])
+        item2 = _make_item(writers=["Someone Else"])
+        assert compute_content_hash(item1) != compute_content_hash(item2)
+
+    def test_different_composers_different_hash(self) -> None:
+        item1 = _make_item(composers=["Jerry Goldsmith"])
+        item2 = _make_item(composers=["John Williams"])
+        assert compute_content_hash(item1) != compute_content_hash(item2)
+
+    def test_crew_order_irrelevant(self) -> None:
+        """Hash is stable under reordering of crew lists."""
+        item1 = _make_item(directors=["A", "B"], writers=["X", "Y"])
+        item2 = _make_item(directors=["B", "A"], writers=["Y", "X"])
+        assert compute_content_hash(item1) == compute_content_hash(item2)
 
 
 class TestPeopleFiltering:

--- a/backend/tests/test_library_store.py
+++ b/backend/tests/test_library_store.py
@@ -297,6 +297,21 @@ class TestGetMany:
         results = await store.get_many([])
         assert results == []
 
+    async def test_crew_fields_round_trip(self, store: LibraryStore) -> None:
+        """get_many hydrates directors, writers, composers (distinct SELECT path)."""
+        item = _make_item(
+            jellyfin_id="jf-gm-crew",
+            directors=["Roger Corman"],
+            writers=["Charles B. Griffith"],
+            composers=["Les Baxter"],
+        )
+        await store.upsert_many([item])
+        results = await store.get_many(["jf-gm-crew"])
+        assert len(results) == 1
+        assert results[0].directors == ["Roger Corman"]
+        assert results[0].writers == ["Charles B. Griffith"]
+        assert results[0].composers == ["Les Baxter"]
+
 
 class TestGetAllHashes:
     """get_all_hashes() hash mapping."""
@@ -335,6 +350,7 @@ class TestContentHash:
         hash1 = compute_content_hash(item)
         hash2 = compute_content_hash(item)
         assert hash1 == hash2
+        assert len(hash1) == 64  # SHA-256 hex digest
 
     def test_different_input_different_hash(self) -> None:
         item1 = _make_item(title="Alien")

--- a/backend/tests/test_sync_engine.py
+++ b/backend/tests/test_sync_engine.py
@@ -284,6 +284,19 @@ class TestToLibraryRowCrewExtraction:
         assert row.writers == []
         assert row.composers == []
 
+    def test_empty_name_excluded(self) -> None:
+        """Entries with missing/empty Name are discarded from every bucket."""
+        item = _make_library_item(
+            people=[
+                {"Name": "", "Type": "Actor"},
+                {"Type": "Director"},
+                {"Name": "Real Person", "Type": "Actor"},
+            ]
+        )
+        row = to_library_row(item)
+        assert row.people == ["Real Person"]
+        assert row.directors == []
+
     def test_row_content_hash_matches_compute_content_hash(self) -> None:
         """to_library_row must compute content_hash via compute_content_hash."""
         item = _make_library_item()

--- a/backend/tests/test_sync_engine.py
+++ b/backend/tests/test_sync_engine.py
@@ -12,7 +12,8 @@ import pytest
 
 from app.jellyfin.errors import JellyfinConnectionError
 from app.jellyfin.models import LibraryItem, PaginatedItems
-from app.sync.engine import SyncEngine
+from app.library.hashing import compute_content_hash
+from app.sync.engine import SyncEngine, to_library_row
 from app.sync.models import (
     SYNC_STATUS_COMPLETED,
     SYNC_STATUS_FAILED,
@@ -215,6 +216,82 @@ def _make_mock_client(
 
 
 # ---------------------------------------------------------------------------
+# to_library_row — per-Type crew extraction
+# ---------------------------------------------------------------------------
+
+
+class TestToLibraryRowCrewExtraction:
+    """Verify to_library_row extracts crew roles from Jellyfin's People array."""
+
+    def test_extracts_actors_into_people(self) -> None:
+        item = _make_library_item(
+            people=[
+                {"Name": "Sigourney Weaver", "Type": "Actor"},
+                {"Name": "Ridley Scott", "Type": "Director"},
+            ]
+        )
+        row = to_library_row(item)
+        assert row.people == ["Sigourney Weaver"]
+
+    def test_extracts_directors(self) -> None:
+        item = _make_library_item(
+            people=[
+                {"Name": "Ridley Scott", "Type": "Director"},
+                {"Name": "Sigourney Weaver", "Type": "Actor"},
+            ]
+        )
+        row = to_library_row(item)
+        assert row.directors == ["Ridley Scott"]
+
+    def test_extracts_writers(self) -> None:
+        item = _make_library_item(
+            people=[
+                {"Name": "Dan O'Bannon", "Type": "Writer"},
+                {"Name": "Ronald Shusett", "Type": "Writer"},
+            ]
+        )
+        row = to_library_row(item)
+        assert row.writers == ["Dan O'Bannon", "Ronald Shusett"]
+
+    def test_extracts_composers(self) -> None:
+        item = _make_library_item(
+            people=[
+                {"Name": "Jerry Goldsmith", "Type": "Composer"},
+            ]
+        )
+        row = to_library_row(item)
+        assert row.composers == ["Jerry Goldsmith"]
+
+    def test_unknown_types_discarded(self) -> None:
+        """Types we don't bucket (e.g. Producer, GuestStar) don't land anywhere."""
+        item = _make_library_item(
+            people=[
+                {"Name": "Some Producer", "Type": "Producer"},
+                {"Name": "Guest Star", "Type": "GuestStar"},
+            ]
+        )
+        row = to_library_row(item)
+        assert row.people == []
+        assert row.directors == []
+        assert row.writers == []
+        assert row.composers == []
+
+    def test_empty_people_gives_empty_crew(self) -> None:
+        item = _make_library_item(people=[])
+        row = to_library_row(item)
+        assert row.people == []
+        assert row.directors == []
+        assert row.writers == []
+        assert row.composers == []
+
+    def test_row_content_hash_matches_compute_content_hash(self) -> None:
+        """to_library_row must compute content_hash via compute_content_hash."""
+        item = _make_library_item()
+        row = to_library_row(item)
+        assert row.content_hash == compute_content_hash(row)
+
+
+# ---------------------------------------------------------------------------
 # Task 3.0 tests — SyncEngine core
 # ---------------------------------------------------------------------------
 
@@ -266,11 +343,8 @@ async def test_sync_unchanged_items() -> None:
     item = _make_library_item("jf-001", "Movie One")
     page = _make_paginated([item])
 
-    # Pre-compute the hash the engine will produce
-    from app.ollama.text_builder import build_composite_text
-
-    text = build_composite_text(item).text
-    expected_hash = SyncEngine._compute_hash(text)
+    # Pre-compute the hash the engine will produce from the row
+    expected_hash = to_library_row(item).content_hash
 
     store = _make_mock_store()
     store.get_all_hashes.return_value = {"jf-001": expected_hash}
@@ -370,16 +444,17 @@ async def test_sync_per_item_failure() -> None:
 
     engine = SyncEngine(store, client, settings)
 
-    # Make build_composite_text fail for the second item
-    def _patched_build(item: LibraryItem):  # type: ignore[type-arg]
+    # Make row construction fail for the second item; delegate to the
+    # real function (bound via module-level import) for the others.
+    _real_to_row = to_library_row
+
+    def _patched_to_row(item: LibraryItem):  # type: ignore[type-arg]
         if item.id == "jf-002":
             msg = "Simulated failure"
             raise ValueError(msg)
-        from app.ollama.text_builder import build_composite_text as _real
+        return _real_to_row(item)
 
-        return _real(item)
-
-    with patch("app.sync.engine.build_composite_text", side_effect=_patched_build):
+    with patch("app.sync.engine.to_library_row", side_effect=_patched_to_row):
         result = await engine.run_sync()
 
     assert result.items_failed == 1
@@ -474,22 +549,6 @@ async def test_sync_missing_admin_user_id() -> None:
 
     with pytest.raises(SyncConfigError, match="not configured"):
         await engine.run_sync()
-
-
-def test_hash_determinism() -> None:
-    """Same input text produces the same hash."""
-    text = "Title: Test Movie. A great overview. Genres: Action, Sci-Fi. Year: 2024."
-    h1 = SyncEngine._compute_hash(text)
-    h2 = SyncEngine._compute_hash(text)
-    assert h1 == h2
-    assert len(h1) == 64  # SHA-256 hex digest
-
-
-def test_hash_different_input() -> None:
-    """Different input text produces different hashes."""
-    h1 = SyncEngine._compute_hash("Movie A")
-    h2 = SyncEngine._compute_hash("Movie B")
-    assert h1 != h2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Sync-side groundwork for #216. Persists per-role crew metadata (directors, writers, composers) that Jellyfin already returns but the sync engine was previously discarding. No embedding behaviour change — that's #217.

- **Additive schema:** three new `TEXT NOT NULL DEFAULT '[]'` columns on `library_items`, with a runtime `PRAGMA table_info` + `ALTER TABLE ADD COLUMN` migration for legacy databases (matches the existing `deleted_at` / `runtime_minutes` migration pattern).
- **`LibraryItemRow` widened** with `directors`, `writers`, `composers` fields.
- **Sync engine bucket:** `to_library_row` now groups `item.people` by `Type` into Actor/Director/Writer/Composer rather than dropping everything non-Actor.
- **Hash rewire:** `SyncEngine.run_sync` now derives `content_hash` via `hashing.compute_content_hash(row)` instead of `SyncEngine._compute_hash(composite_text)`. This is the mechanism that triggers a one-time re-sync of every existing item on first startup after deploy, backfilling the new columns. It also resolves a stale TODO in `hashing.py`.
- **API tightening:** `to_library_row(item)` no longer takes a `content_hash` parameter — it computes its own. The chicken-and-egg wrapper `_to_library_row` in the integration tests collapses to a direct call.

Closes #216. Supersedes #99 (already closed). Unblocks #217 (template v4 embedding enrichment). Resolves #183 (`_to_library_row` dedupe).

## On the hash rewire (worth calling out)

The sync engine previously computed `content_hash` by hashing the embedding's composite text. That coupled change-detection to the embedding template — a coupling that would have caused nothing to re-sync when we added new columns, because the new fields weren't in the composite text.

The new derivation hashes `LibraryItemRow` fields directly via the already-existing (but previously unused in production) `hashing.compute_content_hash`. This:

- Decouples schema change detection from embedding template version.
- Triggers the desired one-time full re-sync on deploy (every existing item's old composite-text hash differs from the new row-based hash → classified as "updated" → upserted → new columns populated).
- Resolves the stale `# TODO: Replace with text_builder from Spec 07` in `hashing.py:21`.

Re-embedding is independent (driven by `_vec_meta.template_version` drift), so this change doesn't touch embeddings at all.

## Test plan

- [x] Unit: `make test` (backend) — 789 pass / 7 skipped / 5 Ollama-deselected
- [x] Unit: `test_library_store.py` — new `TestContentHash` crew-hash cases, `TestInit` fresh-DB + legacy-DB migration cases, round-trip cases
- [x] Unit: `test_sync_engine.py` — new `TestToLibraryRowCrewExtraction` suite covering Actor/Director/Writer/Composer bucketing, unknown-type discard, empty `people`, and content-hash delegation
- [x] Lint: `ruff check` / `ruff format --check` clean
- [x] Types: `pyright .` clean
- [ ] Integration: `make test-integration-full` — not yet run locally; will rely on CI
- [ ] Manual smoke: after merge, trigger `/api/admin/sync` and inspect:
  ```sh
  sqlite3 data/library.db \
    "SELECT jellyfin_id, directors, writers, composers FROM library_items LIMIT 5;"
  ```

## Review requests

- **@PCritchfield / watch-vimes:** schema change + hash change + one-time re-sync behavior are in the data-integrity veto domain — requesting a review-only pass before merge per charter.

## Rollback

Revert this commit. The new columns remain in the DB (SQLite doesn't drop cleanly) but are unreferenced. Content-hash reverts to composite-text derivation; existing items' hashes will differ once and trigger a single re-upsert cycle, then stabilize. No data loss possible — all items are re-derivable from Jellyfin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)