### PR TITLE
fix(perms): request minimal fields for permission ID lookups

### DIFF
--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -166,18 +166,23 @@ class JellyfinClient:
         start_index: int = 0,
         limit: int = 50,
         recursive: bool = True,
+        fields: str | None = None,
     ) -> PaginatedItems:
         """Get library items for a user (paginated).
 
         Uses /Users/{userId}/Items so Jellyfin enforces per-user permissions.
         Raises JellyfinAuthError if the token is invalid/expired.
         Raises JellyfinConnectionError if Jellyfin is unreachable.
+
+        ``fields`` overrides the requested optional fields. Pass ``""`` for
+        ID-only lookups (e.g. permission checks) where rich metadata would
+        be discarded; defaults to ``_ITEM_FIELDS`` for full metadata.
         """
         params: dict[str, str | int | bool] = {
             "StartIndex": start_index,
             "Limit": limit,
             "Recursive": recursive,
-            "Fields": _ITEM_FIELDS,
+            "Fields": _ITEM_FIELDS if fields is None else fields,
         }
         if item_types:
             params["IncludeItemTypes"] = ",".join(item_types)
@@ -197,6 +202,7 @@ class JellyfinClient:
         *,
         item_types: list[str] | None = None,
         page_size: int = 200,
+        fields: str | None = None,
     ) -> AsyncIterator[PaginatedItems]:
         """Auto-paginate library items, yielding each page.
 
@@ -221,6 +227,7 @@ class JellyfinClient:
                 item_types=item_types,
                 start_index=start_index,
                 limit=page_size,
+                fields=fields,
             )
             page_number += 1
             logger.debug(

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -32,6 +32,11 @@ _ITEM_FIELDS = (
     "Overview,Genres,ProductionYear,Tags,Studios,CommunityRating,RunTimeTicks,People"
 )
 
+# Pass to get_items() / get_all_items() when only item IDs are needed
+# (e.g. permission ID lookups). Jellyfin still returns Id/Name/Type because
+# those are base fields, but skips the heavy optional metadata.
+FIELDS_IDS_ONLY: str = ""
+
 
 class JellyfinClient:
     """Async client for the Jellyfin REST API."""
@@ -210,6 +215,9 @@ class JellyfinClient:
         Stops when all items have been fetched (start_index >= total_count).
         Propagates JellyfinAuthError and JellyfinConnectionError without
         catching them — the caller handles partial failure.
+
+        ``fields`` is forwarded verbatim to every get_items() call;
+        see get_items() for semantics (None = full _ITEM_FIELDS).
 
         Token is passed through to get_items() on each call, never stored.
         """

--- a/backend/app/permissions/service.py
+++ b/backend/app/permissions/service.py
@@ -7,6 +7,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from app.jellyfin.client import FIELDS_IDS_ONLY
 from app.jellyfin.errors import (
     JellyfinAuthError,
     JellyfinConnectionError,
@@ -61,7 +62,7 @@ class PermissionService:
         """
         ids: set[str] = set()
         async for page in self._jf_client.get_all_items(
-            token=token, user_id=user_id, item_types=["Movie"], fields=""
+            token=token, user_id=user_id, item_types=["Movie"], fields=FIELDS_IDS_ONLY
         ):
             for item in page.items:
                 ids.add(item.id)

--- a/backend/app/permissions/service.py
+++ b/backend/app/permissions/service.py
@@ -53,11 +53,15 @@ class PermissionService:
     async def _fetch_permitted_ids(self, user_id: str, token: str) -> frozenset[str]:
         """Fetch all item IDs the user can access from Jellyfin.
 
-        Only fetches Movie items. Returns a frozenset for immutable cache storage.
+        Only fetches Movie items. Requests ``fields=""`` so Jellyfin omits
+        Overview/Genres/Tags/Studios/People — payload we never read here and
+        which dominates parse latency on large libraries.
+
+        Returns a frozenset for immutable cache storage.
         """
         ids: set[str] = set()
         async for page in self._jf_client.get_all_items(
-            token=token, user_id=user_id, item_types=["Movie"]
+            token=token, user_id=user_id, item_types=["Movie"], fields=""
         ):
             for item in page.items:
                 ids.add(item.id)

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -491,6 +491,32 @@ class TestGetItems:
         assert "Overview" in params["Fields"]
         assert "Genres" in params["Fields"]
 
+    async def test_get_items_explicit_empty_fields_skips_extended_metadata(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Callers that only need IDs can pass fields="" to skip rich metadata."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
+            request=_FAKE_REQUEST,
+        )
+        await jf_client.get_items("tok-123", "uid-1", fields="")
+        params = mock_http.request.call_args.kwargs["params"]
+        assert params["Fields"] == ""
+
+    async def test_get_items_custom_fields_value_forwarded(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """An arbitrary fields override is passed through verbatim."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
+            request=_FAKE_REQUEST,
+        )
+        await jf_client.get_items("tok-123", "uid-1", fields="Genres,Tags")
+        params = mock_http.request.call_args.kwargs["params"]
+        assert params["Fields"] == "Genres,Tags"
+
     async def test_get_items_uses_per_user_endpoint(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
@@ -552,6 +578,7 @@ class TestGetAllItems:
             start_index: int = 0,
             limit: int = 50,
             recursive: bool = True,
+            fields: str | None = None,
         ) -> PaginatedItems:
             nonlocal call_count
             call_count += 1
@@ -613,6 +640,7 @@ class TestGetAllItems:
             start_index: int = 0,
             limit: int = 50,
             recursive: bool = True,
+            fields: str | None = None,
         ) -> PaginatedItems:
             nonlocal call_count
             call_count += 1
@@ -638,3 +666,29 @@ class TestGetAllItems:
         assert "Studios" in _ITEM_FIELDS
         assert "CommunityRating" in _ITEM_FIELDS
         assert "People" in _ITEM_FIELDS
+
+    async def test_get_all_items_forwards_fields_to_get_items(
+        self, jf_client: JellyfinClient
+    ) -> None:
+        """fields kwarg on get_all_items must propagate to each get_items call."""
+        empty_page = PaginatedItems(Items=[], TotalRecordCount=0, StartIndex=0)
+        captured_fields: list[str | None] = []
+
+        async def mock_get_items(
+            token: str,
+            user_id: str,
+            *,
+            item_types: list[str] | None = None,
+            start_index: int = 0,
+            limit: int = 50,
+            recursive: bool = True,
+            fields: str | None = None,
+        ) -> PaginatedItems:
+            captured_fields.append(fields)
+            return empty_page
+
+        with patch.object(jf_client, "get_items", side_effect=mock_get_items):
+            async for _ in jf_client.get_all_items("tok-123", "uid-1", fields=""):
+                pass
+
+        assert captured_fields == [""]

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -670,8 +670,19 @@ class TestGetAllItems:
     async def test_get_all_items_forwards_fields_to_get_items(
         self, jf_client: JellyfinClient
     ) -> None:
-        """fields kwarg on get_all_items must propagate to each get_items call."""
-        empty_page = PaginatedItems(Items=[], TotalRecordCount=0, StartIndex=0)
+        """fields kwarg on get_all_items must propagate to *every* get_items call."""
+        # Two non-empty pages so the loop iterates more than once — proves the
+        # forwarding contract holds for subsequent pages, not just the first.
+        page1 = PaginatedItems(
+            Items=[LibraryItem(Id="a", Name="A", Type="Movie")],
+            TotalRecordCount=2,
+            StartIndex=0,
+        )
+        page2 = PaginatedItems(
+            Items=[LibraryItem(Id="b", Name="B", Type="Movie")],
+            TotalRecordCount=2,
+            StartIndex=1,
+        )
         captured_fields: list[str | None] = []
 
         async def mock_get_items(
@@ -685,10 +696,12 @@ class TestGetAllItems:
             fields: str | None = None,
         ) -> PaginatedItems:
             captured_fields.append(fields)
-            return empty_page
+            return page1 if start_index == 0 else page2
 
         with patch.object(jf_client, "get_items", side_effect=mock_get_items):
-            async for _ in jf_client.get_all_items("tok-123", "uid-1", fields=""):
+            async for _ in jf_client.get_all_items(
+                "tok-123", "uid-1", page_size=1, fields=""
+            ):
                 pass
 
-        assert captured_fields == [""]
+        assert captured_fields == ["", ""]

--- a/backend/tests/test_permission_service.py
+++ b/backend/tests/test_permission_service.py
@@ -300,3 +300,25 @@ class TestInvalidateUserCache:
     def test_invalidate_unknown_user_is_noop(self, service: PermissionService) -> None:
         """Invalidating a non-existent user shouldn't raise."""
         service.invalidate_user_cache("nonexistent")  # Should not raise
+
+
+class TestFetchPayloadShape:
+    """Permission lookups only need IDs — verify we don't request rich metadata."""
+
+    async def test_fetch_uses_minimal_fields(self) -> None:
+        """_fetch_permitted_ids must request fields="" so Jellyfin omits Overview,
+        Genres, Tags, Studios, People — the heavy fields we never read here.
+        """
+        captured_kwargs: dict[str, object] = {}
+
+        async def _capturing_get_all_items(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield _make_page(["a", "b"])
+
+        client = AsyncMock()
+        client.get_all_items = _capturing_get_all_items
+        svc = PermissionService(jellyfin_client=client, cache_ttl_seconds=300)
+
+        await svc.filter_permitted("user1", "tok", ["a"])
+
+        assert captured_kwargs.get("fields") == ""

--- a/backend/tests/test_permission_service.py
+++ b/backend/tests/test_permission_service.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.jellyfin.client import FIELDS_IDS_ONLY
 from app.jellyfin.errors import (
     JellyfinAuthError,
     JellyfinConnectionError,
@@ -321,4 +322,5 @@ class TestFetchPayloadShape:
 
         await svc.filter_permitted("user1", "tok", ["a"])
 
-        assert captured_kwargs.get("fields") == ""
+        assert captured_kwargs.get("fields") == FIELDS_IDS_ONLY
+        assert FIELDS_IDS_ONLY == ""  # Lock the contract — Jellyfin convention


### PR DESCRIPTION
## Summary
- Permission cache hydration was paginating Jellyfin with the full `_ITEM_FIELDS` set (Overview, Genres, Tags, Studios, People) for the entire library, then discarding everything but `item.id`. On a 1805-movie library this took ~50s per cache miss, blocking the first chat request and causing the SSE stream to stall before any text reached the UI.
- `JellyfinClient.get_items` / `get_all_items` now accept an optional `fields` override; `PermissionService` passes `fields=""` so Jellyfin returns only the base fields (`Id`, `Name`, `Type`, …).
- `SyncEngine` still gets the full `_ITEM_FIELDS` by default — no behaviour change there.

## Live measurement
Direct curl against the running Jellyfin (200-item page, 1805-movie library):

| | Old (`Fields=Overview,Genres,...,People`) | New (`Fields=""`) |
|---|---|---|
| Latency | **5.07 s** | **0.06 s** |
| Payload | 1,448,050 B | 236,203 B |

For 10 pages: ~50 s → ~0.6 s.

## Test plan
- [x] Pre-flight curl confirmed Jellyfin honours `Fields=` (returns base fields only)
- [x] 4 new failing tests added (RED), implementation made them pass (GREEN)
- [x] Full unit suite: **801 passed, 83 deselected**
- [x] `ruff check` / `ruff format --check` / `pyright` on changed files clean
- [x] Backend container rebuilt; `/health` returns 200, ollama+jellyfin reachable
- [ ] Reviewer should send a chat against the live deployment and confirm SSE stream returns metadata + text within seconds (previously stalled)

## Risk / rollback
Single commit, no schema or data migration. `git revert` and rebuild the backend container; the permission cache is in-memory and resets on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)