### PR TITLE
feat(search): genre amplification (template v5) + soft genre rerank

### DIFF
--- a/backend/app/ollama/text_builder.py
+++ b/backend/app/ollama/text_builder.py
@@ -41,7 +41,8 @@ def _build_genre_prefix_section(genres: list[str]) -> str | None:
     Surfaces genre signal at the start of the composite text so
     nomic-embed-text weights it more strongly than the labeled
     ``Genres:`` line, which would otherwise be diluted by long
-    plot/cast text.
+    plot/cast text. ``genres`` is expected to be already cleaned of
+    empty/whitespace entries by ``build_sections``.
     """
     if not genres:
         return None
@@ -106,6 +107,11 @@ def build_sections(
     ``check_template_version`` re-enqueues every item for re-embedding
     on its next startup/cycle.
     """
+    # Clean once; both the v5 prefix and the labeled Genres: section
+    # share this cleaned list so empty/whitespace entries don't bake
+    # malformed text into the embedding document.
+    genres = [g for g in genres if g and g.strip()]
+
     sections: list[str] = []
 
     genre_prefix = _build_genre_prefix_section(genres)

--- a/backend/app/ollama/text_builder.py
+++ b/backend/app/ollama/text_builder.py
@@ -14,7 +14,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-TEMPLATE_VERSION: int = 4
+TEMPLATE_VERSION: int = 5
 """Template version constant. Bumping this signals that all embeddings
 built with an older version are stale and should be regenerated.
 
@@ -25,11 +25,28 @@ Version history:
   3 — Added runtime section to composite text (Spec 19).
   4 — Added cast, directors, writers, composers, studios, tags sections
       (#217).
+  5 — Prepend a natural-language genre prefix (e.g. "A comedy, science
+      fiction film.") so the embedding model surfaces genre signal at
+      the start of the document instead of burying it mid-text.
 """
 
 _CAST_CAP = 10
 
 _LENGTH_WARNING_THRESHOLD = 6000
+
+
+def _build_genre_prefix_section(genres: list[str]) -> str | None:
+    """Build the v5 natural-language genre prefix, or None if no genres.
+
+    Surfaces genre signal at the start of the composite text so
+    nomic-embed-text weights it more strongly than the labeled
+    ``Genres:`` line, which would otherwise be diluted by long
+    plot/cast text.
+    """
+    if not genres:
+        return None
+    article = "An" if genres[0][:1].lower() in {"a", "e", "i", "o", "u"} else "A"
+    return f"{article} {', '.join(g.lower() for g in genres)} film."
 
 
 def _build_title_section(name: str) -> str:
@@ -89,7 +106,13 @@ def build_sections(
     ``check_template_version`` re-enqueues every item for re-embedding
     on its next startup/cycle.
     """
-    sections: list[str] = [_build_title_section(title)]
+    sections: list[str] = []
+
+    genre_prefix = _build_genre_prefix_section(genres)
+    if genre_prefix is not None:
+        sections.append(genre_prefix)
+
+    sections.append(_build_title_section(title))
 
     ov = _build_overview_section(overview)
     if ov is not None:

--- a/backend/app/search/genre_keywords.py
+++ b/backend/app/search/genre_keywords.py
@@ -17,6 +17,18 @@ import re
 # (keyword, canonical-genre-group). Detection uses word-boundary regex so
 # ``warning`` does not match ``war`` and ``scientific`` does not match
 # ``science fiction``.
+#
+# The canonical genre strings on the right-hand side must match what
+# Jellyfin actually emits in ``LibraryItem.genres`` for this deployment.
+# Jellyfin's metadata plugins vary — TMDb-backed libraries typically use
+# ``Science Fiction``, while the built-in Emby-style plugin uses
+# ``Sci-Fi & Fantasy``. Both forms are listed here so the rerank
+# survives either casing. If a deployment sees no rerank lift on a
+# valid genre query, that is the first place to look.
+#
+# ``rom-com`` and ``romcom`` deliberately appear twice each — once for
+# the ``Romance`` group and once for ``Comedy`` — so they enforce both
+# as independent tier-1 requirements.
 _KEYWORD_GROUPS: tuple[tuple[str, frozenset[str]], ...] = (
     # sci-fi family
     ("sci-fi", frozenset({"Science Fiction", "Sci-Fi & Fantasy"})),

--- a/backend/app/search/genre_keywords.py
+++ b/backend/app/search/genre_keywords.py
@@ -1,0 +1,74 @@
+"""Map free-text query phrasing to canonical Jellyfin genre groups.
+
+Used by the search service to apply a soft genre rerank: candidates whose
+genre tags match the query are bucket-sorted to the top of the cosine
+result set, preserving cosine order within each tier.
+
+Each entry pairs a query keyword with a frozenset of *acceptable*
+canonical genres. A candidate matches the entry if its ``genres`` list
+contains any one of them. ``rom-com`` and ``romcom`` appear twice
+because they imply both Romance and Comedy as independent requirements.
+"""
+
+from __future__ import annotations
+
+import re
+
+# (keyword, canonical-genre-group). Detection uses word-boundary regex so
+# ``warning`` does not match ``war`` and ``scientific`` does not match
+# ``science fiction``.
+_KEYWORD_GROUPS: tuple[tuple[str, frozenset[str]], ...] = (
+    # sci-fi family
+    ("sci-fi", frozenset({"Science Fiction", "Sci-Fi & Fantasy"})),
+    ("scifi", frozenset({"Science Fiction", "Sci-Fi & Fantasy"})),
+    ("science fiction", frozenset({"Science Fiction", "Sci-Fi & Fantasy"})),
+    # rom-com → both Romance AND Comedy as independent groups
+    ("rom-com", frozenset({"Romance"})),
+    ("rom-com", frozenset({"Comedy"})),
+    ("romcom", frozenset({"Romance"})),
+    ("romcom", frozenset({"Comedy"})),
+    # core genres
+    ("comedy", frozenset({"Comedy"})),
+    ("horror", frozenset({"Horror"})),
+    ("romance", frozenset({"Romance"})),
+    ("action", frozenset({"Action"})),
+    ("thriller", frozenset({"Thriller"})),
+    ("drama", frozenset({"Drama"})),
+    ("animation", frozenset({"Animation"})),
+    ("animated", frozenset({"Animation"})),
+    ("documentary", frozenset({"Documentary"})),
+    ("fantasy", frozenset({"Fantasy", "Sci-Fi & Fantasy"})),
+    ("family", frozenset({"Family"})),
+    ("war", frozenset({"War"})),
+    ("western", frozenset({"Western"})),
+    ("crime", frozenset({"Crime"})),
+    ("mystery", frozenset({"Mystery"})),
+    ("music", frozenset({"Music"})),
+    ("musical", frozenset({"Music"})),
+    ("history", frozenset({"History"})),
+    ("historical", frozenset({"History"})),
+    ("anime", frozenset({"Anime", "Animation"})),
+    ("adventure", frozenset({"Adventure"})),
+)
+
+
+_COMPILED: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = tuple(
+    (re.compile(rf"\b{re.escape(kw)}\b", re.IGNORECASE), groups)
+    for kw, groups in _KEYWORD_GROUPS
+)
+
+
+def detect_query_genres(query: str) -> list[frozenset[str]]:
+    """Return deduped, deterministically-ordered canonical genre groups
+    detected in the query.
+
+    Each group is a frozenset of acceptable canonical genres; a candidate
+    matches the group if its ``genres`` list contains any one of them.
+    An empty list means no genre keywords were found — callers should
+    skip the rerank entirely in that case.
+    """
+    matched: set[frozenset[str]] = set()
+    for pattern, groups in _COMPILED:
+        if pattern.search(query):
+            matched.add(groups)
+    return sorted(matched, key=lambda fs: tuple(sorted(fs)))

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -7,6 +7,7 @@ import time
 from typing import TYPE_CHECKING
 
 from app.ollama.errors import OllamaConnectionError, OllamaError, OllamaTimeoutError
+from app.search.genre_keywords import detect_query_genres
 from app.search.models import (
     QUERY_PREFIX,
     SearchResponse,
@@ -16,6 +17,9 @@ from app.search.models import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from app.library.models import LibraryItemRow
     from app.library.store import LibraryStore
     from app.ollama.client import OllamaEmbeddingClient
     from app.permissions.service import PermissionService
@@ -36,7 +40,7 @@ class SearchService:
         vec_repo: SqliteVecRepository,
         permission_service: PermissionService,
         library_store: LibraryStore,
-        overfetch_multiplier: int = 3,
+        overfetch_multiplier: int = 5,
         jellyfin_web_url: str | None = None,
     ) -> None:
         self._ollama = ollama_client
@@ -96,6 +100,8 @@ class SearchService:
             raise SearchUnavailableError("Embedding service returned an error") from exc
 
         # Over-fetch to compensate for items removed by permission filtering
+        # and to give the genre rerank room to find tier-1 matches at lower
+        # cosine ranks.
         fetch_limit = limit * self._overfetch
         candidates = await self._vec_repo.search(
             embedding_result.vector, limit=fetch_limit
@@ -110,15 +116,21 @@ class SearchService:
             user_id, token, candidate_ids
         )
         filtered_count = total_candidates - len(permitted_ids)
-        permitted_ids = permitted_ids[:limit]
 
         score_map = {c.jellyfin_id: c.score for c in candidates}
 
+        # Fetch metadata for ALL permitted candidates (not just the top
+        # ``limit``) so the genre rerank can see each candidate's genres.
         items = await self._library.get_many(permitted_ids)
         item_map = {item.jellyfin_id: item for item in items}
 
+        # Soft genre rerank: bucket-sort by genre match while preserving
+        # cosine order (the input ``permitted_ids`` order) within each tier.
+        ordered_ids = self._rerank_by_genre(query, permitted_ids, item_map)
+        ordered_ids = ordered_ids[:limit]
+
         results: list[SearchResultItem] = []
-        for jid in permitted_ids:
+        for jid in ordered_ids:
             item = item_map.get(jid)
             if item is None:
                 continue
@@ -159,6 +171,46 @@ class SearchService:
             filtered_count=filtered_count,
             query_time_ms=elapsed_ms,
         )
+
+    @staticmethod
+    def _rerank_by_genre(
+        query: str,
+        permitted_ids: list[str],
+        item_map: Mapping[str, LibraryItemRow],
+    ) -> list[str]:
+        """Bucket-sort permitted IDs by genre match against the query.
+
+        - Tier 1: candidate genres match **every** detected genre group
+        - Tier 2: matches **at least one** group
+        - Tier 3: matches **none**
+
+        Cosine order is preserved within each tier (input order is
+        cosine-ordered). If no genre keywords are detected in the
+        query, returns ``permitted_ids`` unchanged.
+        """
+        groups = detect_query_genres(query)
+        if not groups:
+            return permitted_ids
+
+        tier1: list[str] = []
+        tier2: list[str] = []
+        tier3: list[str] = []
+        for jid in permitted_ids:
+            item = item_map.get(jid)
+            if item is None:
+                # Lost between permission filter and metadata fetch — keep
+                # at the back rather than dropping outright.
+                tier3.append(jid)
+                continue
+            item_genres = set(item.genres or [])
+            matches = sum(1 for g in groups if g & item_genres)
+            if matches == len(groups):
+                tier1.append(jid)
+            elif matches > 0:
+                tier2.append(jid)
+            else:
+                tier3.append(jid)
+        return tier1 + tier2 + tier3
 
     async def _determine_status(self) -> SearchStatus:
         """Check embedding completeness and return status (cached 30s)."""

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,7 +12,10 @@ dependencies = [
     "cryptography>=44.0.0",
     "aiosqlite>=0.20.0",
     "slowapi>=0.1.9",
-    "sqlite-vec>=0.1.6",
+    # Pinned to 0.1.6: 0.1.7 broke DELETE on the vec0 PRIMARY KEY column,
+    # which the repository's DELETE+INSERT upsert pattern depends on.
+    # Track the underlying fix and re-bump (or rewrite the upsert) later.
+    "sqlite-vec==0.1.6",
 ]
 
 [project.optional-dependencies]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "slowapi>=0.1.9",
     # Pinned to 0.1.6: 0.1.7 broke DELETE on the vec0 PRIMARY KEY column,
     # which the repository's DELETE+INSERT upsert pattern depends on.
-    # Track the underlying fix and re-bump (or rewrite the upsert) later.
+    # Tracked in #227 — once the upsert is rewritten as UPDATE-or-INSERT,
+    # this pin can be removed.
     "sqlite-vec==0.1.6",
 ]
 

--- a/backend/tests/test_embedding_worker.py
+++ b/backend/tests/test_embedding_worker.py
@@ -119,7 +119,8 @@ class TestBuildText:
         row = _make_row()
         text = EmbeddingWorker._build_text(row)
         assert text == (
-            "search_document: Title: Galaxy Quest."
+            "search_document: A comedy, sci-fi film."
+            " Title: Galaxy Quest."
             " A comedy about sci-fi actors in space."
             " Genres: Comedy, Sci-Fi."
             " Year: 1999."
@@ -137,7 +138,9 @@ class TestBuildText:
         row = _make_row(overview=None)
         text = EmbeddingWorker._build_text(row)
         assert "Title: Galaxy Quest." in text
-        assert "A comedy" not in text
+        # The narrative overview ("about sci-fi actors in space") is absent;
+        # the v5 genre prefix ("A comedy, sci-fi film.") is still expected.
+        assert "about sci-fi actors in space" not in text
 
     def test_empty_overview(self) -> None:
         row = _make_row(overview="   ")

--- a/backend/tests/test_genre_keywords.py
+++ b/backend/tests/test_genre_keywords.py
@@ -1,0 +1,75 @@
+"""Unit tests for query-genre keyword detection."""
+
+from __future__ import annotations
+
+from app.search.genre_keywords import detect_query_genres
+
+
+class TestDetectQueryGenres:
+    """Map free-text query phrasing to canonical Jellyfin genre groups.
+
+    Each detected keyword expands to a frozenset of acceptable canonical
+    genres (e.g. "sci-fi" → {Science Fiction, Sci-Fi & Fantasy}). The
+    function returns a deduped, deterministically-ordered list of groups.
+    """
+
+    def test_no_genre_keywords_returns_empty(self) -> None:
+        assert detect_query_genres("something good") == []
+        assert detect_query_genres("") == []
+
+    def test_single_keyword_comedy(self) -> None:
+        groups = detect_query_genres("a comedy")
+        assert groups == [frozenset({"Comedy"})]
+
+    def test_sci_fi_hyphenated_maps_to_science_fiction(self) -> None:
+        groups = detect_query_genres("sci-fi adventure")
+        # sci-fi → Science Fiction (and the synonym genre Sci-Fi & Fantasy
+        # that some Jellyfin libraries use)
+        assert frozenset({"Science Fiction", "Sci-Fi & Fantasy"}) in groups
+
+    def test_scifi_unhyphenated_maps_to_science_fiction(self) -> None:
+        groups = detect_query_genres("scifi")
+        assert frozenset({"Science Fiction", "Sci-Fi & Fantasy"}) in groups
+
+    def test_full_phrase_science_fiction_matches(self) -> None:
+        groups = detect_query_genres("a science fiction film")
+        assert frozenset({"Science Fiction", "Sci-Fi & Fantasy"}) in groups
+
+    def test_two_genres_returns_two_groups(self) -> None:
+        groups = detect_query_genres("sci-fi comedy")
+        assert frozenset({"Science Fiction", "Sci-Fi & Fantasy"}) in groups
+        assert frozenset({"Comedy"}) in groups
+        assert len(groups) == 2
+
+    def test_synonyms_for_same_genre_dedupe(self) -> None:
+        # "sci-fi" and "scifi" both map to the same group; should not
+        # appear twice.
+        groups = detect_query_genres("sci-fi scifi science fiction movie")
+        sf = frozenset({"Science Fiction", "Sci-Fi & Fantasy"})
+        assert groups.count(sf) == 1
+
+    def test_word_boundary_avoids_false_positives(self) -> None:
+        # "warning" should not match "war"; "scientific" should not match
+        # "science fiction" or "sci-fi"; "drama" should not match within
+        # arbitrary text fragments.
+        assert detect_query_genres("warning lights are on") == []
+        assert detect_query_genres("a scientific documentary about") == [
+            frozenset({"Documentary"})
+        ]
+
+    def test_case_insensitive(self) -> None:
+        groups = detect_query_genres("HORROR Comedy")
+        assert frozenset({"Horror"}) in groups
+        assert frozenset({"Comedy"}) in groups
+
+    def test_rom_com_shorthand(self) -> None:
+        groups = detect_query_genres("a rom-com please")
+        assert frozenset({"Romance"}) in groups
+        assert frozenset({"Comedy"}) in groups
+
+    def test_output_is_deterministic(self) -> None:
+        # Same input → same output, same order. Repeated calls must agree.
+        for _ in range(3):
+            assert detect_query_genres("sci-fi comedy horror") == detect_query_genres(
+                "sci-fi comedy horror"
+            )

--- a/backend/tests/test_genre_keywords.py
+++ b/backend/tests/test_genre_keywords.py
@@ -56,6 +56,12 @@ class TestDetectQueryGenres:
         assert detect_query_genres("a scientific documentary about") == [
             frozenset({"Documentary"})
         ]
+        # "star wars" must not trip the {War} group: the "s" in "wars"
+        # is the boundary stopper.
+        assert detect_query_genres("a film like star wars") == []
+        assert detect_query_genres("star trek style adventure") == [
+            frozenset({"Adventure"})
+        ]
 
     def test_case_insensitive(self) -> None:
         groups = detect_query_genres("HORROR Comedy")

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -14,7 +14,7 @@ def _make_service(
     vec_repo: AsyncMock | None = None,
     permissions: AsyncMock | None = None,
     library: AsyncMock | None = None,
-    overfetch: int = 3,
+    overfetch: int = 5,
 ) -> SearchService:
     """Build a SearchService with mocked dependencies.
 

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -94,6 +94,37 @@ class TestSearchAppliesOverfetchMultiplier:
         _, kwargs = vec_repo.search.call_args
         assert kwargs.get("limit") == 15  # 5 * 3
 
+    async def test_default_overfetch_is_5(self) -> None:
+        """Default multiplier bumped 3 → 5 in v5 to give the genre rerank
+        more headroom to find tier-1 matches at lower cosine ranks."""
+        from app.search.service import SearchService
+
+        ollama = AsyncMock()
+        ollama.embed.return_value = make_embedding_result()
+        vec_repo = AsyncMock()
+        vec_repo.count.return_value = 100
+        vec_repo.search.return_value = []
+        permissions = AsyncMock()
+        permissions.filter_permitted.return_value = []
+        library = AsyncMock()
+        library.get_many.return_value = []
+        library.get_queue_counts.return_value = {
+            "pending": 0,
+            "processing": 0,
+            "failed": 0,
+        }
+
+        service = SearchService(
+            ollama_client=ollama,
+            vec_repo=vec_repo,
+            permission_service=permissions,
+            library_store=library,
+        )
+        await service.search("test", limit=10, user_id="u1", token="tok")
+
+        _, kwargs = vec_repo.search.call_args
+        assert kwargs.get("limit") == 50  # 10 * 5
+
 
 class TestSearchEnrichesWithMetadata:
     async def test_results_have_metadata_fields(self) -> None:
@@ -451,6 +482,143 @@ class TestSearchExcludeIds:
         assert len(result.results) == 1
         candidate_ids = permissions.filter_permitted.call_args[0][2]
         assert "m1" in candidate_ids
+
+
+class TestGenreRerank:
+    """v5 — when the query mentions a genre, candidates whose genres match
+    are bucket-sorted to the top of the result set, preserving cosine
+    order within each tier. Without genre keywords in the query, behaviour
+    is unchanged."""
+
+    async def test_rerank_bumps_genre_match_above_non_match(self) -> None:
+        """Cosine order: m1 (highest), m2, m3. Genre tags:
+        - m1 = ['Comedy']                    (matches comedy only)
+        - m2 = ['Comedy', 'Science Fiction'] (matches both — tier 1)
+        - m3 = ['Action']                    (matches none — tier 3)
+        Query 'sci-fi comedy' → output order should be m2, m1, m3.
+        """
+        ollama = AsyncMock()
+        ollama.embed.return_value = make_embedding_result()
+        vec_repo = AsyncMock()
+        vec_repo.count.return_value = 100
+        vec_repo.search.return_value = [
+            make_search_result("m1", 0.90),
+            make_search_result("m2", 0.80),
+            make_search_result("m3", 0.70),
+        ]
+        permissions = AsyncMock()
+        permissions.filter_permitted.return_value = ["m1", "m2", "m3"]
+        library = AsyncMock()
+        library.get_many.return_value = [
+            make_library_item("m1", title="Stand-Up Special", genres=["Comedy"]),
+            make_library_item(
+                "m2", title="Galaxy Quest", genres=["Comedy", "Science Fiction"]
+            ),
+            make_library_item("m3", title="Die Hard", genres=["Action"]),
+        ]
+        library.get_queue_counts.return_value = {
+            "pending": 0,
+            "processing": 0,
+            "failed": 0,
+        }
+
+        service = _make_service(
+            ollama=ollama,
+            vec_repo=vec_repo,
+            permissions=permissions,
+            library=library,
+        )
+        result = await service.search(
+            "sci-fi comedy", limit=10, user_id="u1", token="tok"
+        )
+
+        ids = [r.jellyfin_id for r in result.results]
+        assert ids == ["m2", "m1", "m3"]
+
+    async def test_no_genre_keyword_preserves_cosine_order(self) -> None:
+        ollama = AsyncMock()
+        ollama.embed.return_value = make_embedding_result()
+        vec_repo = AsyncMock()
+        vec_repo.count.return_value = 100
+        vec_repo.search.return_value = [
+            make_search_result("m1", 0.90),
+            make_search_result("m2", 0.80),
+            make_search_result("m3", 0.70),
+        ]
+        permissions = AsyncMock()
+        permissions.filter_permitted.return_value = ["m1", "m2", "m3"]
+        library = AsyncMock()
+        library.get_many.return_value = [
+            make_library_item("m1", genres=["Comedy"]),
+            make_library_item("m2", genres=["Comedy", "Science Fiction"]),
+            make_library_item("m3", genres=["Action"]),
+        ]
+        library.get_queue_counts.return_value = {
+            "pending": 0,
+            "processing": 0,
+            "failed": 0,
+        }
+
+        service = _make_service(
+            ollama=ollama,
+            vec_repo=vec_repo,
+            permissions=permissions,
+            library=library,
+        )
+        # Query with no detectable genre keyword — order untouched
+        result = await service.search(
+            "something good", limit=10, user_id="u1", token="tok"
+        )
+
+        ids = [r.jellyfin_id for r in result.results]
+        assert ids == ["m1", "m2", "m3"]
+
+    async def test_rerank_preserves_cosine_order_within_tier(self) -> None:
+        """Two candidates in tier 1 (both match all detected genres);
+        their relative order should be by cosine score (highest first)."""
+        ollama = AsyncMock()
+        ollama.embed.return_value = make_embedding_result()
+        vec_repo = AsyncMock()
+        vec_repo.count.return_value = 100
+        vec_repo.search.return_value = [
+            # Higher cosine but only matches one genre
+            make_search_result("standup", 0.95),
+            # Lower cosine, matches both — should still come above standup
+            make_search_result("galaxy_quest", 0.70),
+            # Even lower, matches both — third
+            make_search_result("evolution", 0.60),
+        ]
+        permissions = AsyncMock()
+        permissions.filter_permitted.return_value = [
+            "standup",
+            "galaxy_quest",
+            "evolution",
+        ]
+        library = AsyncMock()
+        library.get_many.return_value = [
+            make_library_item("standup", genres=["Comedy"]),
+            make_library_item("galaxy_quest", genres=["Comedy", "Science Fiction"]),
+            make_library_item("evolution", genres=["Comedy", "Science Fiction"]),
+        ]
+        library.get_queue_counts.return_value = {
+            "pending": 0,
+            "processing": 0,
+            "failed": 0,
+        }
+
+        service = _make_service(
+            ollama=ollama,
+            vec_repo=vec_repo,
+            permissions=permissions,
+            library=library,
+        )
+        result = await service.search(
+            "sci-fi comedy", limit=10, user_id="u1", token="tok"
+        )
+
+        ids = [r.jellyfin_id for r in result.results]
+        # tier 1 (galaxy_quest, evolution by cosine), then tier 2 (standup)
+        assert ids == ["galaxy_quest", "evolution", "standup"]
 
 
 class TestSearchResponseMetadata:

--- a/backend/tests/test_text_builder.py
+++ b/backend/tests/test_text_builder.py
@@ -197,6 +197,39 @@ class TestGenrePrefix:
         assert not text.lower().startswith("a ")
         assert text == "Title: Untagged Movie."
 
+    def test_vowel_article_for_single_vowel_initial_genre(self) -> None:
+        """Genres starting with a vowel get ``An`` instead of ``A``.
+        Locked here so the article rule can't silently regress."""
+        text = build_sections(
+            title="Indiana Jones",
+            overview=None,
+            genres=["Action"],
+            production_year=None,
+        )
+        assert text.startswith("An action film. ")
+
+    def test_empty_string_genre_entries_are_dropped(self) -> None:
+        """Whitespace/empty-string entries should not produce ``A  film.``."""
+        text = build_sections(
+            title="Edge Case",
+            overview=None,
+            genres=["", "Comedy", "  "],
+            production_year=None,
+        )
+        assert text.startswith("A comedy film. ")
+        # No double space, no empty filler word
+        assert "  " not in text.split("Title:")[0]
+
+    def test_only_empty_string_genres_omits_prefix(self) -> None:
+        """If every genre entry is empty/whitespace, no prefix at all."""
+        text = build_sections(
+            title="No Genres Tagged",
+            overview=None,
+            genres=["", "  "],
+            production_year=None,
+        )
+        assert text == "Title: No Genres Tagged."
+
     def test_prefix_precedes_overview(self) -> None:
         text = build_sections(
             title="Galaxy Quest",

--- a/backend/tests/test_text_builder.py
+++ b/backend/tests/test_text_builder.py
@@ -119,8 +119,8 @@ class TestBuildSectionsNewFields:
         assert text == "Title: Alien."
 
     def test_section_ordering(self) -> None:
-        """Sections appear in: title, overview, genres, year, runtime,
-        cast, directed by, written by, music by, studios, tags."""
+        """Sections appear in: genre-prefix, title, overview, genres, year,
+        runtime, cast, directed by, written by, music by, studios, tags."""
         text = build_sections(
             title="Alien",
             overview="Space horror.",
@@ -135,7 +135,7 @@ class TestBuildSectionsNewFields:
             tags=["classic"],
         )
         assert text == (
-            "Title: Alien. Space horror. Genres: Horror. Year: 1979. "
+            "A horror film. Title: Alien. Space horror. Genres: Horror. Year: 1979. "
             "Runtime: 117 minutes. Cast: Sigourney Weaver. "
             "Directed by: Ridley Scott. Written by: Dan O'Bannon. "
             "Music by: Jerry Goldsmith. Studios: 20th Century Fox. Tags: classic."
@@ -145,8 +145,70 @@ class TestBuildSectionsNewFields:
 class TestTemplateVersion:
     """TEMPLATE_VERSION drift detection."""
 
-    def test_is_version_4(self) -> None:
-        assert TEMPLATE_VERSION == 4
+    def test_is_version_5(self) -> None:
+        assert TEMPLATE_VERSION == 5
+
+
+class TestGenrePrefix:
+    """v5 — natural-language genre prefix prepended when genres are present.
+
+    Surfaces genre signal at the start of the composite text so the
+    embedding model weights it more strongly than mid-text labels in the
+    Genres: section, which get diluted by long plot/cast text.
+    """
+
+    def test_single_genre_produces_lowercased_prefix(self) -> None:
+        text = build_sections(
+            title="Bill Engvall: Here's Your Sign",
+            overview=None,
+            genres=["Comedy"],
+            production_year=None,
+        )
+        assert text.startswith("A comedy film. ")
+
+    def test_multiple_genres_comma_joined_lowercased(self) -> None:
+        text = build_sections(
+            title="Galaxy Quest",
+            overview=None,
+            genres=["Comedy", "Science Fiction", "Adventure"],
+            production_year=None,
+        )
+        assert text.startswith("A comedy, science fiction, adventure film. ")
+
+    def test_genres_still_appear_in_labeled_section(self) -> None:
+        """The labeled Genres: line is preserved — prefix is reinforcement,
+        not replacement."""
+        text = build_sections(
+            title="Galaxy Quest",
+            overview=None,
+            genres=["Comedy", "Science Fiction"],
+            production_year=None,
+        )
+        assert text.startswith("A comedy, science fiction film. ")
+        assert "Genres: Comedy, Science Fiction." in text
+
+    def test_no_genres_omits_prefix(self) -> None:
+        text = build_sections(
+            title="Untagged Movie",
+            overview=None,
+            genres=[],
+            production_year=None,
+        )
+        assert not text.lower().startswith("a ")
+        assert text == "Title: Untagged Movie."
+
+    def test_prefix_precedes_overview(self) -> None:
+        text = build_sections(
+            title="Galaxy Quest",
+            overview="Aliens recruit washed-up actors to fight a real war.",
+            genres=["Comedy", "Science Fiction"],
+            production_year=1999,
+        )
+        # Order: prefix → title → overview → genres → year
+        prefix_idx = text.index("A comedy, science fiction film.")
+        title_idx = text.index("Title: Galaxy Quest.")
+        overview_idx = text.index("Aliens recruit")
+        assert prefix_idx < title_idx < overview_idx
 
 
 # ---------------------------------------------------------------------------
@@ -165,7 +227,8 @@ class TestBuildSections:
             production_year=1999,
         )
         assert text == (
-            "Title: Galaxy Quest. A great comedy about actors in space. "
+            "A comedy, sci-fi film. Title: Galaxy Quest. "
+            "A great comedy about actors in space. "
             "Genres: Comedy, Sci-Fi. Year: 1999."
         )
 
@@ -208,7 +271,9 @@ class TestMissingFieldCombinations:
             genres=["Sci-Fi", "Horror"],
             production_year=1979,
         )
-        assert text == "Title: Alien. Genres: Sci-Fi, Horror. Year: 1979."
+        assert text == (
+            "A sci-fi, horror film. Title: Alien. Genres: Sci-Fi, Horror. Year: 1979."
+        )
 
     def test_empty_genres_omits_genres(self) -> None:
         text = build_sections(
@@ -230,7 +295,8 @@ class TestMissingFieldCombinations:
             production_year=None,
         )
         assert text == (
-            "Title: Alien. In space, no one can hear you scream. "
+            "A sci-fi, horror film. Title: Alien. "
+            "In space, no one can hear you scream. "
             "Genres: Sci-Fi, Horror."
         )
         assert "Year:" not in text
@@ -251,7 +317,7 @@ class TestMissingFieldCombinations:
             genres=["Sci-Fi", "Horror"],
             production_year=None,
         )
-        assert text == "Title: Alien. Genres: Sci-Fi, Horror."
+        assert text == ("A sci-fi, horror film. Title: Alien. Genres: Sci-Fi, Horror.")
 
     def test_only_year_no_overview_no_genres(self) -> None:
         text = build_sections(
@@ -324,6 +390,7 @@ class TestBuildSectionsSnapshots:
             production_year=1979,
         )
         assert text == (
+            "A science fiction, horror film. "
             "Title: Alien. In space, no one can hear you scream. A crew aboard a "
             "deep-space vessel encounters a terrifying alien lifeform. "
             "Genres: Science Fiction, Horror. Year: 1979."
@@ -347,7 +414,7 @@ class TestBuildSectionsSnapshots:
             production_year=2020,
         )
         expected = (
-            f"Title: The Long Film. {long_overview.strip()} "
+            f"An adventure film. Title: The Long Film. {long_overview.strip()} "
             "Genres: Adventure. Year: 2020."
         )
         assert text == expected
@@ -368,6 +435,7 @@ class TestBuildSectionsSnapshots:
             production_year=2023,
         )
         assert text == (
+            "An action, comedy, drama, horror, romance, sci-fi, thriller film. "
             "Title: Genre Mashup. "
             "Genres: Action, Comedy, Drama, Horror, Romance, Sci-Fi, Thriller. "
             "Year: 2023."

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -41,7 +41,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
-    { name = "sqlite-vec", specifier = ">=0.1.6" },
+    { name = "sqlite-vec", specifier = "==0.1.6" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
 provides-extras = ["dev"]
@@ -731,14 +731,14 @@ wheels = [
 
 [[package]]
 name = "sqlite-vec"
-version = "0.1.7"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/50/7ad59cfd3003a2110cc366e526293de4c2520486f5ddaa8dc78b265f8d3e/sqlite_vec-0.1.7-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:c34a136caecff4ae17d4c0cc268fcda89764ee870039caa21431e8e3fb2f4d48", size = 131171, upload-time = "2026-03-17T07:42:50.438Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/c9/1cd2f59b539096cd2ce6b540247b2dfe3c47ba04d9368b5e8e3dc86498d4/sqlite_vec-0.1.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6d272593d1b45ec7ea289b160ee6e5fafbaa6e1f5ba15f1305c012b0bda43653", size = 165434, upload-time = "2026-03-17T07:42:51.555Z" },
-    { url = "https://files.pythonhosted.org/packages/75/91/30c3c382140dcc7bc6e3a07eac7ca610a2b5b70eb9bc7066dc3e7f748d58/sqlite_vec-0.1.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d27746d8e254a390bd15574aed899a0b9bb915b5321eb130a9c09722898cc03", size = 160076, upload-time = "2026-03-17T07:42:52.451Z" },
-    { url = "https://files.pythonhosted.org/packages/59/56/6ff304d917ee79da769708dad0aed5fd34c72cbd0ae5e38bcc56cdc652a4/sqlite_vec-0.1.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:ad654283cb9c059852ce2d82018c757b06a705ada568f8b126022a131189818e", size = 163388, upload-time = "2026-03-17T07:42:53.516Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/27/fb1b6e3f9072854fe405f7aa99c46d4b465e84c9cec2ff7778edf29ecbbd/sqlite_vec-0.1.7-py3-none-win_amd64.whl", hash = "sha256:0c67877a87cb49426237b950237e82dbeb77778ab2ba89bea859f391fd169382", size = 292804, upload-time = "2026-03-17T07:42:54.325Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ed/aabc328f29ee6814033d008ec43e44f2c595447d9cccd5f2aabe60df2933/sqlite_vec-0.1.6-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:77491bcaa6d496f2acb5cc0d0ff0b8964434f141523c121e313f9a7d8088dee3", size = 164075, upload-time = "2024-11-20T16:40:29.847Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/57/05604e509a129b22e303758bfa062c19afb020557d5e19b008c64016704e/sqlite_vec-0.1.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fdca35f7ee3243668a055255d4dee4dea7eed5a06da8cad409f89facf4595361", size = 165242, upload-time = "2024-11-20T16:40:31.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/48/dbb2cc4e5bad88c89c7bb296e2d0a8df58aab9edc75853728c361eefc24f/sqlite_vec-0.1.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b0519d9cd96164cd2e08e8eed225197f9cd2f0be82cb04567692a0a4be02da3", size = 103704, upload-time = "2024-11-20T16:40:33.729Z" },
+    { url = "https://files.pythonhosted.org/packages/80/76/97f33b1a2446f6ae55e59b33869bed4eafaf59b7f4c662c8d9491b6a714a/sqlite_vec-0.1.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:823b0493add80d7fe82ab0fe25df7c0703f4752941aee1c7b2b02cec9656cb24", size = 151556, upload-time = "2024-11-20T16:40:35.387Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/98/e8bc58b178266eae2fcf4c9c7a8303a8d41164d781b32d71097924a6bebe/sqlite_vec-0.1.6-py3-none-win_amd64.whl", hash = "sha256:c65bcfd90fa2f41f9000052bcb8bb75d38240b2dae49225389eca6c3136d3f0c", size = 281540, upload-time = "2024-11-20T16:40:37.296Z" },
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,12 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      # Next.js's rewrites() runs at build time; the URL is baked into the
+      # standalone bundle. Pass BACKEND_URL as a build arg so the runtime
+      # ``environment:`` value below isn't silently overridden by the
+      # Dockerfile's ARG default (``http://localhost:8000``).
+      args:
+        BACKEND_URL: http://backend:8000
     environment:
       - BACKEND_URL=http://backend:8000
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,6 +24,9 @@ CMD ["npm", "run", "dev"]
 # =============================================================================
 FROM base AS build
 
+ARG BACKEND_URL=http://localhost:8000
+ENV BACKEND_URL=${BACKEND_URL}
+
 COPY . .
 ENV NODE_ENV=production
 RUN npm run build


### PR DESCRIPTION
## Problem

Live test: a sci-fi comedy query returned 6 stand-up comedy specials and 2 Rifftrax shows in the top 10. None of Galaxy Quest, Spaceballs, Men in Black, or Ghostbusters were even in the top 30. Probing the vector DB:

| Movie | "sci-fi comedy" | "a funny science fiction movie" | "space comedy adventure" |
|---|---|---|---|
| **Galaxy Quest** | not in top 200 | not in top 200 | #188 |
| **Spaceballs** | #95 | #124 | #12 |
| **Men in Black** | #97 | #52 | #96 |
| **Ghostbusters** | #119 | #88 | not in top 200 |

The composite text v4 buries `Genres: Comedy, Science Fiction` mid-document among 500+ chars of plot/cast/crew text. nomic-embed-text averages tokens, so the genre signal gets diluted relative to a stand-up special whose entire composite is dense in "comedy."

## Fix

### A. Template v5 — natural-language genre prefix

Prepend `"A {genre1}, {genre2} film. "` (or `"An …"` for vowel-initial genres) to each composite text. Galaxy Quest now starts:

```
A comedy, science fiction, adventure film. Title: Galaxy Quest. <plot> Genres: Comedy, Science Fiction, Adventure. Year: 1999. ...
```

Bumps `TEMPLATE_VERSION` 4 → 5. The embedding worker detects the version mismatch and re-enqueues all items on next startup (the same path used for the v3 → v4 migration).

### B. Soft genre rerank in the search pipeline

Detect genre keywords in the query (`sci-fi`, `comedy`, `horror`, `rom-com`, …) via word-boundary regex, then bucket-sort the cosine over-fetch into three tiers:

- **Tier 1**: candidate genres include at least one canonical genre from **every** detected query group
- **Tier 2**: matches **at least one** group
- **Tier 3**: matches **none**

Cosine order is preserved within each tier. If the query has no detectable genre keyword, the pipeline behaves exactly as before.

`SEARCH_OVERFETCH_MULTIPLIER` default bumped 3 → 5 so the rerank has headroom to find tier-1 matches at lower cosine ranks.

## Files changed

- `backend/app/ollama/text_builder.py` — `_build_genre_prefix_section`, version bump
- `backend/app/search/genre_keywords.py` (new) — keyword/canonical-genre map + word-boundary detector
- `backend/app/search/service.py` — rerank flow, default overfetch=5, fetches metadata before slicing to limit
- Tests: `test_genre_keywords.py` (new, 11 cases), `test_text_builder.py` (5 new + v4 string assertions updated), `test_search_service.py` (4 new), `test_embedding_worker.py` (snapshot updated)

## Test plan

- [x] Pre-fix probe confirmed canonical sci-fi comedies rank #95-200+ for natural queries
- [x] 821 unit tests pass (was 819; +11 new genre-keyword tests +9 new search/text-builder tests; -2 snapshot tests folded into the new shape)
- [x] `ruff check` / `ruff format --check` / `pyright` clean on the changed files
- [x] Backend container rebuilt; `template_version_stale stored=4 current=5 — re-enqueuing all items` logged; 1805 items re-enqueued
- [ ] Reviewer: after re-embed completes, send a chat asking for a sci-fi comedy and confirm the top recommendations look like a movie person's picks (Galaxy Quest, Spaceballs, Men in Black, Ghostbusters, Earth Girls Are Easy, Evolution …) rather than stand-up specials

## Risk / rollback

`git revert` and rebuild. The embedding worker detects the version downgrade (5 → 4) and re-embeds back to v4. ~10-20 min of GPU time, no data loss. vec0 schema unchanged.

## Decisions worth flagging in review

- **Hardcoded keyword map** vs. extracting from the live Jellyfin genre set at startup. Hardcoded is predictable and easy to grow; happy to revisit if the map drifts.
- **Article rule** (`A` vs `An`) is letter-based on the first genre. Covers Action / Adventure / Animation / Anime correctly; would mis-call a hypothetical genre starting with "Sci" if pronounced "sky" — non-issue today.
- **Bucket sort over score adjustment** — easier to reason about than tuning weights, but means tier-1 results can have lower cosine than tier-2/3. Cosine is still primary signal *within* each tier.

## Follow-ups (not bundled)

- `feat: pre-warm permission cache on login` (separate problem, separate PR)
- `feat: extend genre keyword map dynamically from Jellyfin's live genre set`
- `feat: include `Tags` in v5 prefix amplification` (would catch "satire", "parody", "space opera" — but bloats the prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)