### PR TITLE
fix(ui): set explicit text-foreground on chat chip + Jellyfin link

### DIFF
--- a/frontend/src/components/chat/card-detail.tsx
+++ b/frontend/src/components/chat/card-detail.tsx
@@ -117,7 +117,7 @@ export function CardDetail({ item, open, onClose }: CardDetailProps) {
                 href={item.jellyfin_web_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex min-h-11 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent"
+                className="inline-flex min-h-11 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground"
               >
                 View in Jellyfin
               </a>

--- a/frontend/src/components/chat/empty-state.tsx
+++ b/frontend/src/components/chat/empty-state.tsx
@@ -31,7 +31,7 @@ export function EmptyState({ onSend }: EmptyStateProps) {
             key={chip}
             type="button"
             onClick={() => onSend(chip)}
-            className="rounded-full border bg-background px-4 py-2 text-sm hover:bg-accent hover:text-accent-foreground transition-colors"
+            className="rounded-full border bg-background px-4 py-2 text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
           >
             {chip}
           </button>


### PR DESCRIPTION
## Summary

- Adds `text-foreground` to the suggestion chips in `EmptyState` and the "View in Jellyfin" link in `CardDetail`, so the default-state text colour is explicit rather than inherited from the ancestor cascade.
- Resolves the bug where chip / link text rendered invisible (same colour as background) in certain theme configurations.

## Background

The shadcn convention is that every `bg-X` utility should be paired with a matching `text-X-foreground`. Two components were missing the default-state pairing — they only set the *hover* text colour. When the cascade-inherited body `color` is disturbed (forced-colors mode, OS dark mode interacting with the dual-theme system in `globals.css`, etc.), the text colour collapses to match the background.

## What changed

- `frontend/src/components/chat/empty-state.tsx` — chip button gets `text-foreground`
- `frontend/src/components/chat/card-detail.tsx` — Jellyfin link gets `text-foreground hover:text-accent-foreground`

`device-picker-dialog.tsx` was audited and **does not** need this fix: its buttons have no direct text content; all visible text lives in inner `<span>`s with explicit `text-foreground` / `text-muted-foreground` already.

## What this does *not* fix (separate issue to follow)

The deeper problem is in `frontend/src/app/globals.css`, which contains two competing theme systems:

1. A hand-rolled `@theme {}` block with hex values plus a `prefers-color-scheme: dark` media query targeting `--color-*` (lines 7–67)
2. A shadcn-init `@theme inline {}` plus `:root` / `.dark` blocks targeting `--background`, `--foreground` etc. via `oklch()` (lines 69–191)

The `.dark` class is never toggled anywhere in the app, and `@theme inline` re-aliases `--color-background → var(--background)` — which means utility classes are permanently locked to light-mode values regardless of OS preference, while the bare `body { ... }` rule still flips on dark OS. This produces the inheritance disturbance that exposes any component missing an explicit `text-*` class.

A follow-up GitHub issue will track the reconciliation of these two systems.

## Test plan

- [x] `npx prettier --check` passes on modified files
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` — only pre-existing warning unrelated to this change
- [x] `npx vitest run src/components/chat/__tests__/card-detail.test.tsx` — 18/18 pass
- [ ] Manual: load chat empty state on a dark-OS machine, confirm chip text visible
- [ ] Manual: open a movie card detail, confirm "View in Jellyfin" text visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)