### PR TITLE
fix(ui): set text-foreground + placeholder colour on chat textarea

### DIFF
--- a/frontend/src/components/chat/chat-input.tsx
+++ b/frontend/src/components/chat/chat-input.tsx
@@ -88,7 +88,7 @@ export function ChatInput({ onSend, isStreaming }: ChatInputProps) {
           rows={1}
           disabled={isStreaming}
           aria-label="Chat message"
-          className="flex-1 resize-none rounded-xl border bg-muted px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+          className="flex-1 resize-none rounded-xl border bg-muted px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
           style={{ overflow: "hidden" }}
         />
         <button


### PR DESCRIPTION
## Summary

- Adds \`text-foreground\` and \`placeholder:text-muted-foreground\` to the \`ChatInput\` textarea (\`frontend/src/components/chat/chat-input.tsx:91\`).
- Fixes invisible-typed-text bug — typed query characters were rendering same-colour-as-background under certain dark-mode conditions, identical root cause to #232.
- Third instance of the same missing-text-colour pattern; #233 tracks the deeper \`globals.css\` reconciliation.

## What changed

\`\`\`diff
-className="flex-1 resize-none rounded-xl border bg-muted px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+className="flex-1 resize-none rounded-xl border bg-muted px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
\`\`\`

Pairing rationale (shadcn convention):
- \`bg-muted\` + \`text-foreground\` → high-contrast typed content
- \`bg-muted\` + \`placeholder:text-muted-foreground\` → lower-contrast hint text

## Test plan

- [x] \`npx prettier --check\` passes
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean
- [ ] Manual: type into the chat input on a dark-OS browser, confirm characters visible
- [ ] Manual: confirm placeholder \`Ask for movie recommendations...\` is visible (muted) when input is empty

## Related

- #232 — the original chip + Jellyfin link fix (same pattern)
- #233 — globals.css dual-theme reconciliation (root cause)
- #234 — device-picker defensive \`text-foreground\` (sibling tech debt)
- #235 — outline-button consolidation onto shared \`Button\` component

🤖 Generated with [Claude Code](https://claude.com/claude-code)