### PR TITLE
feat(spec-25): country/origin filter foundation — schema + sync + backfill (1/3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev dev-full dev-ui dev-down build test lint ci clean logs health hooks jellyfin-up jellyfin-down test-integration test-integration-full test-injection validate-pipeline pipeline-up pipeline-down eval-router
+.PHONY: help dev dev-full dev-ui dev-down build test lint ci clean logs health hooks jellyfin-up jellyfin-down test-integration test-integration-full test-injection validate-pipeline pipeline-up pipeline-down eval-router backfill-country backfill-country-dry-run
 
 .DEFAULT_GOAL := help
 
@@ -112,6 +112,19 @@ eval-router: ## Run query-router eval cases against live stack (Spec 24)
 
 test-injection: ## Run prompt injection adversarial payloads
 	cd backend && uv run python ../scripts/test_injection.py
+
+# ---------------------------------------------------------------------------
+# Spec 25 — country/origin backfill for existing library rows
+# ---------------------------------------------------------------------------
+# Prerequisite: SYNC_INTERVAL_HOURS=0 must be set in the env (the script will
+# refuse to run otherwise, to avoid racing the periodic sync engine on shared
+# rows). After completion, restore the prior value and restart the backend.
+
+backfill-country-dry-run: ## Preview Spec 25 country backfill (no writes)
+	cd backend && uv run python ../scripts/backfill_country.py --dry-run
+
+backfill-country: ## Spec 25 backfill — populate production_countries (set SYNC_INTERVAL_HOURS=0)
+	cd backend && uv run python ../scripts/backfill_country.py
 
 # ---------------------------------------------------------------------------
 

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -15,7 +15,13 @@ from app.jellyfin.errors import (
     JellyfinAuthError,
     JellyfinError,
 )
-from app.jellyfin.models import AuthResult, PaginatedItems, UserInfo, WatchHistoryEntry
+from app.jellyfin.models import (
+    AuthResult,
+    LibraryItem,
+    PaginatedItems,
+    UserInfo,
+    WatchHistoryEntry,
+)
 from app.jellyfin.transport import _DEFAULT_DEVICE_ID, _JellyfinTransport
 
 if TYPE_CHECKING:
@@ -200,6 +206,43 @@ class JellyfinClient:
             params=params,
         )
         return self._parse_response(resp, PaginatedItems.model_validate)
+
+    async def get_items_by_ids(
+        self,
+        *,
+        token: str,
+        user_id: str,
+        ids: list[str],
+        fields: str | None = None,
+    ) -> list[LibraryItem]:
+        """Fetch a batch of library items by their Jellyfin IDs (Spec 25).
+
+        Used by the country-data backfill script (``scripts/backfill_country.py``)
+        to re-fetch metadata for rows already in ``library_items``. The script
+        passes batches of ~50 IDs per call.
+
+        Returns whatever Jellyfin returns — items deleted upstream simply do
+        not appear in the response. The caller is responsible for noting the
+        gap; this method does not error on missing IDs.
+
+        Movie-only by design (the recommender's scope is films, not series).
+        """
+        if not ids:
+            return []
+        params: dict[str, str | int | bool] = {
+            "Ids": ",".join(ids),
+            "Recursive": True,
+            "IncludeItemTypes": "Movie",
+            "Fields": _ITEM_FIELDS if fields is None else fields,
+        }
+        resp = await self._request(
+            "GET",
+            f"/Users/{user_id}/Items",
+            token=token,
+            params=params,
+        )
+        page = self._parse_response(resp, PaginatedItems.model_validate)
+        return list(page.items)
 
     async def get_all_items(
         self,

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -225,14 +225,19 @@ class JellyfinClient:
         not appear in the response. The caller is responsible for noting the
         gap; this method does not error on missing IDs.
 
-        Movie-only by design (the recommender's scope is films, not series).
+        **No type filter applied.** IDs already scope the result to specific
+        items; adding ``IncludeItemTypes=Movie`` would silently drop any non-
+        Movie IDs (e.g., Series) from the response, making them indistinguish-
+        able from items deleted upstream. Per the sync engine's
+        ``item_types=["Movie", "Series"]`` invocation, ``library_items`` may
+        contain Series rows; this method must surface them so the caller can
+        backfill country data for whatever the schema admits.
         """
         if not ids:
             return []
         params: dict[str, str | int | bool] = {
             "Ids": ",".join(ids),
             "Recursive": True,
-            "IncludeItemTypes": "Movie",
             "Fields": _ITEM_FIELDS if fields is None else fields,
         }
         resp = await self._request(

--- a/backend/app/jellyfin/client.py
+++ b/backend/app/jellyfin/client.py
@@ -30,7 +30,7 @@ _T = TypeVar("_T")
 # Fields to request from Jellyfin — matches our LibraryItem model
 _ITEM_FIELDS = (
     "Overview,Genres,ProductionYear,Tags,Studios,CommunityRating,"
-    "RunTimeTicks,People,OfficialRating"
+    "RunTimeTicks,People,OfficialRating,ProductionLocations"
 )
 
 # Pass to get_items() / get_all_items() when only item IDs are needed

--- a/backend/app/jellyfin/models.py
+++ b/backend/app/jellyfin/models.py
@@ -85,6 +85,14 @@ class LibraryItem(BaseModel):
     run_time_ticks: int | None = Field(default=None, alias="RunTimeTicks")
     people: list[dict[str, Any]] = Field(default_factory=list, alias="People")
     official_rating: str | None = Field(default=None, alias="OfficialRating")
+    # Spec 25 — Jellyfin's ``ProductionLocations`` is an array of full English
+    # country names (e.g. ``["Germany", "United States of America"]`` for
+    # co-productions). The sync engine maps each entry to ISO 3166-1 alpha-2
+    # via ``app.library.country_codes`` before storing in
+    # ``library_items.production_countries``.
+    production_locations: list[str] = Field(
+        default_factory=list, alias="ProductionLocations"
+    )
 
     @property
     def runtime_minutes(self) -> int | None:

--- a/backend/app/library/country_codes.py
+++ b/backend/app/library/country_codes.py
@@ -1,0 +1,69 @@
+"""Country name ↔ ISO 3166-1 alpha-2 code conversion.
+
+Single canonical mapping shared by the sync engine (write path, mapping
+Jellyfin's ``ProductionLocations`` strings to ISO codes for storage) and
+the query router (read path, mapping user-entered country phrases to ISO
+codes for filter SQL).
+
+Backed by ``pycountry`` — an offline ISO 3166 / 4217 / 639 lookup table.
+No outbound API calls; safe under the project's "no third-party metadata
+enrichment" rule (see ``CLAUDE.md`` / ``ARCHITECTURE.md``).
+
+Spec 25 — country/language filter dimension. See
+``docs/specs/25-spec-country-language-filter/`` for the full design and
+the architectural review that established this module's responsibilities.
+"""
+
+from __future__ import annotations
+
+import pycountry
+
+
+def name_to_iso(name: str) -> str | None:
+    """Return the ISO 3166-1 alpha-2 code for a country name, or ``None``.
+
+    Accepts canonical English names as returned by Jellyfin's
+    ``ProductionLocations`` field (e.g., ``"United States of America"``,
+    ``"Japan"``) and common variants. Case-insensitive; whitespace-trimmed.
+    Returns ``None`` for unmappable input (empty string, unknown name) so
+    the caller can apply skip-and-log handling per Spec 25's design.
+    """
+    if not name:
+        return None
+    cleaned = name.strip()
+    if not cleaned:
+        return None
+
+    # Direct lookup by name first (fast path for canonical names).
+    direct = pycountry.countries.get(name=cleaned)
+    if direct is not None:
+        return direct.alpha_2
+
+    # Fall back to fuzzy search for variants ("United States" vs
+    # "United States of America", lowercased input, etc.). search_fuzzy
+    # raises LookupError on no match — convert to None for our contract.
+    try:
+        matches = pycountry.countries.search_fuzzy(cleaned)
+    except LookupError:
+        return None
+    if not matches:
+        return None
+    return matches[0].alpha_2
+
+
+def iso_to_name(iso: str) -> str | None:
+    """Return the canonical English country name for an ISO alpha-2 code.
+
+    Used for operator-facing logging (warnings about unmappable names from
+    Jellyfin) and operator-facing config display. Not in any user-facing
+    response path. Case-insensitive on input; whitespace-trimmed.
+    """
+    if not iso:
+        return None
+    cleaned = iso.strip().upper()
+    if not cleaned:
+        return None
+    country = pycountry.countries.get(alpha_2=cleaned)
+    if country is None:
+        return None
+    return country.name

--- a/backend/app/library/country_codes.py
+++ b/backend/app/library/country_codes.py
@@ -16,7 +16,38 @@ the architectural review that established this module's responsibilities.
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 import pycountry
+
+# A library sync surfaces the same country name (e.g. ``"United States of
+# America"``, repeated thousands of times) over and over; ``search_fuzzy`` is
+# pycountry's heaviest path. Caching by the cleaned input string makes the
+# hot path effectively a dict lookup on the second call onwards. Bounded
+# explicitly: the world has ~250 ISO countries plus a few common Jellyfin
+# variants — 512 is generous head-room with no meaningful memory cost.
+_NAME_CACHE_SIZE = 512
+
+
+@lru_cache(maxsize=_NAME_CACHE_SIZE)
+def _name_to_iso_cached(cleaned: str) -> str | None:
+    """Cache hot path. ``cleaned`` is whitespace-trimmed (case preserved).
+
+    Direct lookup is tried first (matches Jellyfin's canonical names). On
+    miss, ``search_fuzzy`` handles variants like ``"United States"`` ↔
+    ``"United States of America"``.
+    """
+    direct = pycountry.countries.get(name=cleaned)
+    if direct is not None:
+        return direct.alpha_2
+
+    try:
+        matches = pycountry.countries.search_fuzzy(cleaned)
+    except LookupError:
+        return None
+    if not matches:
+        return None
+    return matches[0].alpha_2
 
 
 def name_to_iso(name: str) -> str | None:
@@ -27,28 +58,18 @@ def name_to_iso(name: str) -> str | None:
     ``"Japan"``) and common variants. Case-insensitive; whitespace-trimmed.
     Returns ``None`` for unmappable input (empty string, unknown name) so
     the caller can apply skip-and-log handling per Spec 25's design.
+
+    Repeated calls for the same name are served from an in-process LRU
+    cache (sized to comfortably hold every ISO country plus common
+    Jellyfin variants), so a 1800-item library sync only pays the
+    ``search_fuzzy`` cost ~250 times rather than 1800.
     """
     if not name:
         return None
     cleaned = name.strip()
     if not cleaned:
         return None
-
-    # Direct lookup by name first (fast path for canonical names).
-    direct = pycountry.countries.get(name=cleaned)
-    if direct is not None:
-        return direct.alpha_2
-
-    # Fall back to fuzzy search for variants ("United States" vs
-    # "United States of America", lowercased input, etc.). search_fuzzy
-    # raises LookupError on no match — convert to None for our contract.
-    try:
-        matches = pycountry.countries.search_fuzzy(cleaned)
-    except LookupError:
-        return None
-    if not matches:
-        return None
-    return matches[0].alpha_2
+    return _name_to_iso_cached(cleaned)
 
 
 def iso_to_name(iso: str) -> str | None:

--- a/backend/app/library/models.py
+++ b/backend/app/library/models.py
@@ -37,6 +37,13 @@ class LibraryItemRow:
     # Spec 24 Unit 3 — Jellyfin OfficialRating (e.g. "G", "PG", "PG-13",
     # "R", "NC-17"). Used as a structured filter only; not embedded.
     official_rating: str | None = None
+    # Spec 25 — Country/origin as a structured filter dimension. ISO 3166-1
+    # alpha-2 codes (e.g. ``["JP"]`` for Spirited Away, ``["DE", "US"]`` for
+    # co-productions). Empty list when Jellyfin returned no ProductionLocations.
+    # Distinct from country_synced_at being None which means "not yet
+    # backfilled" — see Spec 25 design and scripts/backfill_country.py.
+    production_countries: list[str] = field(default_factory=list)
+    country_synced_at: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/app/library/store.py
+++ b/backend/app/library/store.py
@@ -40,7 +40,9 @@ CREATE TABLE IF NOT EXISTS library_items (
     directors         TEXT NOT NULL DEFAULT '[]',
     writers           TEXT NOT NULL DEFAULT '[]',
     composers         TEXT NOT NULL DEFAULT '[]',
-    official_rating   TEXT
+    official_rating   TEXT,
+    production_countries TEXT NOT NULL DEFAULT '[]',
+    country_synced_at INTEGER
 )
 """
 
@@ -171,6 +173,22 @@ class LibraryStore:
             )
             await self._db.commit()
 
+        # Migration: add country columns if table predates Spec 25.
+        # PRAGMA-introspection guard (not `ADD COLUMN IF NOT EXISTS`) so we
+        # work on every SQLite version, not just 3.35+. Per Spec 25 architecture
+        # ruling.
+        if "production_countries" not in existing_columns:
+            await self._db.execute(
+                "ALTER TABLE library_items ADD COLUMN "
+                "production_countries TEXT NOT NULL DEFAULT '[]'"
+            )
+            await self._db.commit()
+        if "country_synced_at" not in existing_columns:
+            await self._db.execute(
+                "ALTER TABLE library_items ADD COLUMN country_synced_at INTEGER"
+            )
+            await self._db.commit()
+
         # Spec 24 — production_year index supports the year-range filter
         # in search_filtered_ids. CREATE INDEX IF NOT EXISTS is a no-op
         # on subsequent boots.
@@ -214,6 +232,8 @@ class LibraryStore:
          13: writers        TEXT (JSON array)
          14: composers      TEXT (JSON array)
          15: official_rating TEXT (nullable)
+         16: production_countries TEXT (JSON array)
+         17: country_synced_at INTEGER (nullable)
         """
         return LibraryItemRow(
             jellyfin_id=row[0],
@@ -232,6 +252,8 @@ class LibraryStore:
             writers=json.loads(row[13]),
             composers=json.loads(row[14]),
             official_rating=row[15],
+            production_countries=json.loads(row[16]),
+            country_synced_at=row[17],
         )
 
     async def _get_hashes_for_ids(self, ids: list[str]) -> dict[str, str]:
@@ -302,6 +324,8 @@ class LibraryStore:
                     json.dumps(item.writers),
                     json.dumps(item.composers),
                     item.official_rating,
+                    json.dumps(item.production_countries),
+                    item.country_synced_at,
                 )
             )
 
@@ -313,8 +337,10 @@ class LibraryStore:
                        (jellyfin_id, title, overview, production_year,
                         genres, tags, studios, community_rating,
                         people, content_hash, synced_at, runtime_minutes,
-                        directors, writers, composers, official_rating)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        directors, writers, composers, official_rating,
+                        production_countries, country_synced_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                               ?, ?)
                        ON CONFLICT(jellyfin_id) DO UPDATE SET
                         title = excluded.title,
                         overview = excluded.overview,
@@ -330,7 +356,9 @@ class LibraryStore:
                         directors = excluded.directors,
                         writers = excluded.writers,
                         composers = excluded.composers,
-                        official_rating = excluded.official_rating""",
+                        official_rating = excluded.official_rating,
+                        production_countries = excluded.production_countries,
+                        country_synced_at = excluded.country_synced_at""",
                     params_list,
                 )
             except Exception:
@@ -346,7 +374,8 @@ class LibraryStore:
             """SELECT jellyfin_id, title, overview, production_year,
                       genres, tags, studios, community_rating,
                       people, content_hash, synced_at, runtime_minutes,
-                      directors, writers, composers, official_rating
+                      directors, writers, composers, official_rating,
+                      production_countries, country_synced_at
                FROM library_items WHERE jellyfin_id = ?""",
             (jellyfin_id,),
         )
@@ -374,7 +403,8 @@ class LibraryStore:
                 f"""SELECT jellyfin_id, title, overview, production_year,
                           genres, tags, studios, community_rating,
                           people, content_hash, synced_at, runtime_minutes,
-                          directors, writers, composers, official_rating
+                          directors, writers, composers, official_rating,
+                          production_countries, country_synced_at
                    FROM library_items WHERE jellyfin_id IN ({placeholders})""",
                 batch,
             )

--- a/backend/app/sync/engine.py
+++ b/backend/app/sync/engine.py
@@ -115,8 +115,10 @@ def to_library_row(item: LibraryItem) -> LibraryItemRow:
         official_rating=item.official_rating,
         # Spec 25 — country data is a structured filter dimension only;
         # not in the content_hash recipe (see compute_content_hash). The
-        # synced_at sentinel is set unconditionally so a row with empty
-        # ProductionLocations is distinguishable from a row never backfilled.
+        # ``country_synced_at`` sentinel is set unconditionally so a row
+        # with empty ProductionLocations is distinguishable from a row never
+        # backfilled (the latter has NULL). Distinct from ``synced_at``,
+        # which tracks the row's last full sync regardless of country state.
         production_countries=_map_production_locations_to_iso(
             item.production_locations
         ),

--- a/backend/app/sync/engine.py
+++ b/backend/app/sync/engine.py
@@ -13,6 +13,7 @@ import time
 from typing import TYPE_CHECKING
 
 from app.jellyfin.errors import JellyfinConnectionError, JellyfinError
+from app.library.country_codes import name_to_iso
 from app.library.hashing import compute_content_hash
 from app.library.models import LibraryItemRow
 from app.sync.models import (
@@ -46,6 +47,30 @@ _CREW_ROLE_MAP = {
     "Composer": "composers",
 }
 
+# Spec 25 — track unmappable country names per process so a library with
+# 50 items from "Atlantis" logs once per name per sync run, not 50 times.
+# Cleared at the start of each SyncEngine.sync() call.
+_unmappable_country_names_logged: set[str] = set()
+
+
+def _map_production_locations_to_iso(names: list[str]) -> list[str]:
+    """Map Jellyfin ``ProductionLocations`` strings to ISO 3166-1 alpha-2.
+
+    Drops unmappable names with a deduped warning (skip-and-log strategy
+    per Spec 25 architecture ruling). Returns the result sorted for
+    deterministic JSON encoding.
+    """
+    iso_codes: list[str] = []
+    for name in names:
+        iso = name_to_iso(name)
+        if iso is None:
+            if name not in _unmappable_country_names_logged:
+                _logger.warning("Unmappable country name from Jellyfin: %s", name)
+                _unmappable_country_names_logged.add(name)
+            continue
+        iso_codes.append(iso)
+    return sorted(iso_codes)
+
 
 def to_library_row(item: LibraryItem) -> LibraryItemRow:
     """Convert a Jellyfin LibraryItem to a LibraryItemRow for storage.
@@ -70,6 +95,7 @@ def to_library_row(item: LibraryItem) -> LibraryItemRow:
         if bucket is not None:
             buckets[bucket].append(name)
 
+    now = int(time.time())
     row = LibraryItemRow(
         jellyfin_id=item.id,
         title=item.name,
@@ -81,12 +107,20 @@ def to_library_row(item: LibraryItem) -> LibraryItemRow:
         community_rating=item.community_rating,
         people=buckets["people"],
         content_hash="",
-        synced_at=int(time.time()),
+        synced_at=now,
         runtime_minutes=item.runtime_minutes,
         directors=buckets["directors"],
         writers=buckets["writers"],
         composers=buckets["composers"],
         official_rating=item.official_rating,
+        # Spec 25 — country data is a structured filter dimension only;
+        # not in the content_hash recipe (see compute_content_hash). The
+        # synced_at sentinel is set unconditionally so a row with empty
+        # ProductionLocations is distinguishable from a row never backfilled.
+        production_countries=_map_production_locations_to_iso(
+            item.production_locations
+        ),
+        country_synced_at=now,
     )
     return dataclasses.replace(row, content_hash=compute_content_hash(row))
 
@@ -169,6 +203,12 @@ class SyncEngine:
             await asyncio.wait_for(self._lock.acquire(), timeout=1.0)
         except TimeoutError:
             raise SyncAlreadyRunningError("A sync is already in progress") from None
+
+        # Spec 25 — reset the per-sync-run unmappable-country-name dedup set
+        # so each run starts fresh; a country name that was warned about in a
+        # prior run gets warned again (operator may have refreshed Jellyfin
+        # metadata in the interim).
+        _unmappable_country_names_logged.clear()
 
         try:
             self.validate_config()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     # Tracked in #227 — once the upsert is rewritten as UPDATE-or-INSERT,
     # this pin can be removed.
     "sqlite-vec==0.1.6",
+    "pycountry>=24.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_backfill_country.py
+++ b/backend/tests/test_backfill_country.py
@@ -1,0 +1,369 @@
+"""Tests for scripts/backfill_country.py — Spec 25 backfill script.
+
+The script lives in ``scripts/`` (one level above ``backend/``) but its
+runtime imports come from the backend (``app.config``, ``app.jellyfin.client``,
+``app.library.store``, ``app.library.country_codes``). To test it we add the
+``scripts/`` directory to ``sys.path`` lazily inside the test module.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.library.models import LibraryItemRow
+from app.library.store import LibraryStore
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+# Add scripts/ to sys.path so tests can import the script as a module.
+_SCRIPTS_DIR = pathlib.Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import backfill_country  # noqa: E402 — sys.path mutation above
+
+
+@pytest.fixture
+async def store(tmp_path: pathlib.Path) -> AsyncIterator[LibraryStore]:
+    db_path = tmp_path / "test_backfill.db"
+    s = LibraryStore(str(db_path))
+    await s.init()
+    yield s  # type: ignore[misc]
+    await s.close()
+
+
+def _make_row(
+    jellyfin_id: str,
+    *,
+    country_synced_at: int | None = None,
+) -> LibraryItemRow:
+    """Helper — minimal LibraryItemRow with deterministic content_hash."""
+    return LibraryItemRow(
+        jellyfin_id=jellyfin_id,
+        title=f"Movie {jellyfin_id}",
+        overview=None,
+        production_year=2020,
+        genres=[],
+        tags=[],
+        studios=[],
+        community_rating=None,
+        people=[],
+        content_hash=f"hash-{jellyfin_id}",
+        synced_at=int(time.time()),
+        country_synced_at=country_synced_at,
+    )
+
+
+def _mock_client_returning(items: list[dict]) -> AsyncMock:
+    """Build an AsyncMock JellyfinClient whose get_items_by_ids returns ``items``.
+
+    Each ``items`` entry is a dict shaped like ``LibraryItem.model_validate``
+    expects. The mock honours batch ID filtering — items not in the requested
+    ID set are dropped from the response (mimics Jellyfin's behaviour).
+    """
+    from app.jellyfin.models import LibraryItem
+
+    parsed = [LibraryItem.model_validate(d) for d in items]
+
+    async def _get_items_by_ids(
+        *,
+        token: str,
+        user_id: str,
+        ids: list[str],
+        fields: str | None = None,
+    ) -> list[LibraryItem]:
+        id_set = set(ids)
+        return [item for item in parsed if item.id in id_set]
+
+    client = AsyncMock()
+    client.get_items_by_ids = AsyncMock(side_effect=_get_items_by_ids)
+    return client
+
+
+class TestRunBackfillHappyPath:
+    """Spec 25 T3.0 — basic backfill of pending rows."""
+
+    async def test_updates_two_pending_rows_with_iso_codes(
+        self, store: LibraryStore
+    ) -> None:
+        await store.upsert_many(
+            [
+                _make_row("jf-1", country_synced_at=None),
+                _make_row("jf-2", country_synced_at=None),
+            ]
+        )
+        client = _mock_client_returning(
+            [
+                {
+                    "Id": "jf-1",
+                    "Name": "Spirited Away",
+                    "Type": "Movie",
+                    "ProductionLocations": ["Japan"],
+                },
+                {
+                    "Id": "jf-2",
+                    "Name": "Alien",
+                    "Type": "Movie",
+                    "ProductionLocations": ["United States of America"],
+                },
+            ]
+        )
+
+        rows_processed, batches_run = await backfill_country.run_backfill(
+            store=store,
+            client=client,
+            token="dummy-token",
+            user_id="dummy-uid",
+            dry_run=False,
+        )
+
+        assert rows_processed == 2
+        assert batches_run == 1
+
+        row1 = await store.get("jf-1")
+        assert row1 is not None
+        assert row1.production_countries == ["JP"]
+        assert row1.country_synced_at is not None
+
+        row2 = await store.get("jf-2")
+        assert row2 is not None
+        assert row2.production_countries == ["US"]
+
+    async def test_re_invocation_processes_zero_rows(self, store: LibraryStore) -> None:
+        """After a successful backfill, re-running selects 0 pending rows."""
+        await store.upsert_many([_make_row("jf-1", country_synced_at=None)])
+        client = _mock_client_returning(
+            [
+                {
+                    "Id": "jf-1",
+                    "Name": "Spirited Away",
+                    "Type": "Movie",
+                    "ProductionLocations": ["Japan"],
+                }
+            ]
+        )
+
+        await backfill_country.run_backfill(
+            store=store, client=client, token="t", user_id="u", dry_run=False
+        )
+
+        # Second invocation
+        rows_processed_second, batches_second = await backfill_country.run_backfill(
+            store=store, client=client, token="t", user_id="u", dry_run=False
+        )
+        assert rows_processed_second == 0
+        assert batches_second == 0
+
+    async def test_co_production_stored_sorted(self, store: LibraryStore) -> None:
+        await store.upsert_many([_make_row("jf-coprod", country_synced_at=None)])
+        client = _mock_client_returning(
+            [
+                {
+                    "Id": "jf-coprod",
+                    "Name": "2 Fast 2 Furious",
+                    "Type": "Movie",
+                    "ProductionLocations": [
+                        "United States of America",
+                        "Germany",
+                    ],
+                }
+            ]
+        )
+
+        await backfill_country.run_backfill(
+            store=store, client=client, token="t", user_id="u", dry_run=False
+        )
+        row = await store.get("jf-coprod")
+        assert row is not None
+        assert row.production_countries == ["DE", "US"]
+
+
+class TestRunBackfillResumeFromPartial:
+    """Spec 25 T3.5 — resume-safety against partial completion."""
+
+    async def test_only_pending_rows_touched(self, store: LibraryStore) -> None:
+        already_synced_at = 1_700_000_000
+        await store.upsert_many(
+            [
+                _make_row("jf-pending-1", country_synced_at=None),
+                _make_row("jf-pending-2", country_synced_at=None),
+                _make_row("jf-pending-3", country_synced_at=None),
+                _make_row("jf-already-1", country_synced_at=already_synced_at),
+                _make_row("jf-already-2", country_synced_at=already_synced_at),
+            ]
+        )
+        client = _mock_client_returning(
+            [
+                {
+                    "Id": f"jf-pending-{i}",
+                    "Name": f"Pending {i}",
+                    "Type": "Movie",
+                    "ProductionLocations": ["Japan"],
+                }
+                for i in (1, 2, 3)
+            ]
+        )
+
+        await backfill_country.run_backfill(
+            store=store, client=client, token="t", user_id="u", dry_run=False
+        )
+
+        # Already-synced rows are untouched (timestamp preserved exactly)
+        already_1 = await store.get("jf-already-1")
+        assert already_1 is not None
+        assert already_1.country_synced_at == already_synced_at
+        assert already_1.production_countries == []
+
+        # Pending rows are now backfilled
+        pending_1 = await store.get("jf-pending-1")
+        assert pending_1 is not None
+        assert pending_1.production_countries == ["JP"]
+        assert pending_1.country_synced_at is not None
+        assert pending_1.country_synced_at != already_synced_at
+
+        # Mock was called exactly once with only the pending IDs
+        assert client.get_items_by_ids.call_count == 1
+        call_kwargs = client.get_items_by_ids.call_args.kwargs
+        assert set(call_kwargs["ids"]) == {
+            "jf-pending-1",
+            "jf-pending-2",
+            "jf-pending-3",
+        }
+
+
+class TestRunBackfillMissingFromUpstream:
+    """Spec 25 T3.6 — Jellyfin returns fewer items than requested
+    (deleted upstream after our last full sync)."""
+
+    async def test_missing_items_marked_synced_with_empty_array(
+        self, store: LibraryStore
+    ) -> None:
+        await store.upsert_many(
+            [
+                _make_row("jf-still-there", country_synced_at=None),
+                _make_row("jf-deleted-upstream", country_synced_at=None),
+            ]
+        )
+        # Jellyfin only returns the still-there item
+        client = _mock_client_returning(
+            [
+                {
+                    "Id": "jf-still-there",
+                    "Name": "Still There",
+                    "Type": "Movie",
+                    "ProductionLocations": ["Japan"],
+                }
+            ]
+        )
+
+        await backfill_country.run_backfill(
+            store=store, client=client, token="t", user_id="u", dry_run=False
+        )
+
+        # Still-there row gets ISO codes
+        present = await store.get("jf-still-there")
+        assert present is not None
+        assert present.production_countries == ["JP"]
+        assert present.country_synced_at is not None
+
+        # Deleted-upstream row STILL gets country_synced_at stamped (with []).
+        # This prevents the script from re-hitting Jellyfin every run for an
+        # item that simply isn't there anymore — the operator's full-sync
+        # tombstone path will eventually clean these up.
+        gone = await store.get("jf-deleted-upstream")
+        assert gone is not None
+        assert gone.production_countries == []
+        assert gone.country_synced_at is not None
+
+
+class TestRunBackfillDryRun:
+    """Spec 25 T3.4 — --dry-run reports counts without mutating data."""
+
+    async def test_dry_run_no_writes(self, store: LibraryStore) -> None:
+        await store.upsert_many(
+            [
+                _make_row("jf-1", country_synced_at=None),
+                _make_row("jf-2", country_synced_at=None),
+            ]
+        )
+        client = AsyncMock()
+        # client should not be called in dry-run mode
+        client.get_items_by_ids = AsyncMock(
+            side_effect=AssertionError("dry-run must not call Jellyfin")
+        )
+
+        rows_processed, batches_run = await backfill_country.run_backfill(
+            store=store, client=client, token="t", user_id="u", dry_run=True
+        )
+        assert rows_processed == 2
+        assert batches_run == 1
+        client.get_items_by_ids.assert_not_called()
+
+        # Rows are unchanged — country_synced_at is still NULL
+        row1 = await store.get("jf-1")
+        assert row1 is not None
+        assert row1.country_synced_at is None
+
+
+class TestUpdateBatchTransaction:
+    """Spec 25 — atomicity check: a per-batch transaction commits both
+    production_countries and country_synced_at together."""
+
+    async def test_update_persists_both_columns(self, store: LibraryStore) -> None:
+        await store.upsert_many([_make_row("jf-1", country_synced_at=None)])
+        await backfill_country._update_batch(
+            store, jellyfin_id="jf-1", iso_codes=["JP"], now=12345
+        )
+        await store._conn.commit()
+        row = await store.get("jf-1")
+        assert row is not None
+        assert row.production_countries == ["JP"]
+        assert row.country_synced_at == 12345
+
+
+class TestMapLocations:
+    """Spec 25 — script's local helper mirrors the engine's per-sync-run dedup."""
+
+    def test_maps_known_country(self) -> None:
+        seen: set[str] = set()
+        result = backfill_country._map_locations(["Japan"], seen)
+        assert result == ["JP"]
+        assert seen == set()
+
+    def test_co_production_sorted(self) -> None:
+        seen: set[str] = set()
+        result = backfill_country._map_locations(
+            ["United States of America", "Germany"], seen
+        )
+        assert result == ["DE", "US"]
+
+    def test_unmappable_skipped_and_recorded_in_seen(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        seen: set[str] = set()
+        with caplog.at_level(logging.WARNING):
+            result = backfill_country._map_locations(["Atlantis"], seen)
+        assert result == []
+        assert "Atlantis" in seen
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+
+    def test_dedup_within_run(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        seen: set[str] = set()
+        with caplog.at_level(logging.WARNING):
+            backfill_country._map_locations(["Atlantis"], seen)
+            backfill_country._map_locations(["Atlantis"], seen)
+            backfill_country._map_locations(["Atlantis", "Japan"], seen)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1

--- a/backend/tests/test_backfill_country.py
+++ b/backend/tests/test_backfill_country.py
@@ -27,7 +27,7 @@ _SCRIPTS_DIR = pathlib.Path(__file__).resolve().parents[2] / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
-import backfill_country  # noqa: E402 — sys.path mutation above
+import backfill_country  # type: ignore[import-not-found]  # noqa: E402 — sys.path mutation above; scripts/ resolved at runtime, not in pyright's analysis paths
 
 
 @pytest.fixture

--- a/backend/tests/test_backfill_country.py
+++ b/backend/tests/test_backfill_country.py
@@ -318,7 +318,7 @@ class TestUpdateBatchTransaction:
 
     async def test_update_persists_both_columns(self, store: LibraryStore) -> None:
         await store.upsert_many([_make_row("jf-1", country_synced_at=None)])
-        await backfill_country._update_batch(
+        await backfill_country._update_row_country_fields(
             store, jellyfin_id="jf-1", iso_codes=["JP"], now=12345
         )
         await store._conn.commit()

--- a/backend/tests/test_country_codes.py
+++ b/backend/tests/test_country_codes.py
@@ -1,0 +1,87 @@
+"""Tests for the country_codes module — name↔ISO 3166-1 alpha-2 conversion.
+
+Spec 25 — country/language filter dimension. Module is consumed by both
+the sync engine (write path) and the query router (read path), so a single
+canonical mapping is required. See
+``docs/specs/25-spec-country-language-filter/25-spec-country-language-filter.md``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.library.country_codes import iso_to_name, name_to_iso
+
+
+class TestNameToIso:
+    """Forward conversion: Jellyfin's ProductionLocations strings → ISO codes."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected_iso"),
+        [
+            ("United States of America", "US"),
+            ("Japan", "JP"),
+            ("United Kingdom", "GB"),
+            ("South Korea", "KR"),
+            ("France", "FR"),
+            ("Germany", "DE"),
+            ("Brazil", "BR"),
+        ],
+    )
+    def test_canonical_jellyfin_names_map_to_iso(
+        self, name: str, expected_iso: str
+    ) -> None:
+        assert name_to_iso(name) == expected_iso
+
+    def test_unmappable_name_returns_none(self) -> None:
+        assert name_to_iso("Atlantis") is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert name_to_iso("") is None
+
+    def test_case_insensitive_matching(self) -> None:
+        assert name_to_iso("japan") == "JP"
+        assert name_to_iso("JAPAN") == "JP"
+        assert name_to_iso("united states of america") == "US"
+
+    def test_whitespace_trimmed(self) -> None:
+        assert name_to_iso("  Japan  ") == "JP"
+
+
+class TestIsoToName:
+    """Reverse conversion: ISO codes → canonical English names (for ops/logging)."""
+
+    @pytest.mark.parametrize(
+        ("iso", "expected_substr"),
+        [
+            ("US", "United States"),
+            ("JP", "Japan"),
+            ("GB", "United Kingdom"),
+            ("FR", "France"),
+            ("DE", "Germany"),
+        ],
+    )
+    def test_iso_returns_canonical_name(self, iso: str, expected_substr: str) -> None:
+        result = iso_to_name(iso)
+        assert result is not None
+        assert expected_substr in result
+
+    def test_unknown_iso_returns_none(self) -> None:
+        assert iso_to_name("ZZ") is None
+
+    def test_empty_iso_returns_none(self) -> None:
+        assert iso_to_name("") is None
+
+    def test_iso_case_insensitive(self) -> None:
+        # Jellyfin shouldn't pass lowercase, but be defensive
+        assert iso_to_name("jp") == iso_to_name("JP")
+
+
+class TestRoundTrip:
+    """name → ISO → name should produce a recognisably equivalent country."""
+
+    @pytest.mark.parametrize("iso", ["US", "JP", "GB", "KR", "FR", "DE", "BR"])
+    def test_iso_to_name_to_iso_is_identity(self, iso: str) -> None:
+        name = iso_to_name(iso)
+        assert name is not None
+        assert name_to_iso(name) == iso

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -621,9 +621,14 @@ class TestGetItemsByIds:
         # Backfill needs ProductionLocations on every batch fetch
         assert "ProductionLocations" in params["Fields"]
 
-    async def test_recursive_and_movie_only(
+    async def test_recursive_and_no_type_filter(
         self, jf_client: JellyfinClient, mock_http: AsyncMock
     ) -> None:
+        """IDs already scope the result; `IncludeItemTypes` would silently
+        drop any non-Movie IDs in the request (e.g. Series), making them
+        indistinguishable from items deleted upstream. ``library_items`` can
+        contain non-Movie rows (sync engine fetches both types) so the
+        backfill must not filter them out."""
         mock_http.request.return_value = httpx.Response(
             200,
             json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
@@ -632,7 +637,8 @@ class TestGetItemsByIds:
         await jf_client.get_items_by_ids(token="tok-123", user_id="uid-1", ids=["x"])
         params = mock_http.request.call_args.kwargs["params"]
         assert params["Recursive"] is True
-        assert params["IncludeItemTypes"] == "Movie"
+        # Critically: no IncludeItemTypes filter — IDs scope the result.
+        assert "IncludeItemTypes" not in params
 
     async def test_fewer_items_returned_than_requested(
         self, jf_client: JellyfinClient, mock_http: AsyncMock

--- a/backend/tests/test_jellyfin_client.py
+++ b/backend/tests/test_jellyfin_client.py
@@ -552,6 +552,121 @@ class TestGetItems:
             await jf_client.get_items("tok-123", "uid-1")
 
 
+class TestGetItemsByIds:
+    """Spec 25 — batch fetch by jellyfin_id list.
+
+    The backfill script (T3.0) walks the existing library in batches of ~50
+    IDs and re-fetches metadata to populate ``ProductionLocations`` for rows
+    where ``country_synced_at IS NULL``. This method covers that path.
+    """
+
+    async def test_returns_items_for_requested_ids(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={
+                "Items": [
+                    {
+                        "Id": "jf-1",
+                        "Name": "Spirited Away",
+                        "Type": "Movie",
+                        "ProductionLocations": ["Japan"],
+                    },
+                    {
+                        "Id": "jf-2",
+                        "Name": "Alien",
+                        "Type": "Movie",
+                        "ProductionLocations": ["United States of America"],
+                    },
+                ],
+                "TotalRecordCount": 2,
+                "StartIndex": 0,
+            },
+            request=_FAKE_REQUEST,
+        )
+        result = await jf_client.get_items_by_ids(
+            token="tok-123", user_id="uid-1", ids=["jf-1", "jf-2"]
+        )
+        assert len(result) == 2
+        assert isinstance(result[0], LibraryItem)
+        assert result[0].id == "jf-1"
+        assert result[0].production_locations == ["Japan"]
+        assert result[1].id == "jf-2"
+
+    async def test_passes_ids_as_comma_separated_param(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
+            request=_FAKE_REQUEST,
+        )
+        await jf_client.get_items_by_ids(
+            token="tok-123", user_id="uid-1", ids=["a", "b", "c"]
+        )
+        params = mock_http.request.call_args.kwargs["params"]
+        assert params["Ids"] == "a,b,c"
+
+    async def test_includes_production_locations_in_default_fields(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
+            request=_FAKE_REQUEST,
+        )
+        await jf_client.get_items_by_ids(token="tok-123", user_id="uid-1", ids=["x"])
+        params = mock_http.request.call_args.kwargs["params"]
+        # Backfill needs ProductionLocations on every batch fetch
+        assert "ProductionLocations" in params["Fields"]
+
+    async def test_recursive_and_movie_only(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={"Items": [], "TotalRecordCount": 0, "StartIndex": 0},
+            request=_FAKE_REQUEST,
+        )
+        await jf_client.get_items_by_ids(token="tok-123", user_id="uid-1", ids=["x"])
+        params = mock_http.request.call_args.kwargs["params"]
+        assert params["Recursive"] is True
+        assert params["IncludeItemTypes"] == "Movie"
+
+    async def test_fewer_items_returned_than_requested(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        """Items deleted upstream don't appear in the response — caller
+        must handle the gap. The client itself returns exactly what
+        Jellyfin returned without padding or erroring."""
+        mock_http.request.return_value = httpx.Response(
+            200,
+            json={
+                "Items": [
+                    {"Id": "jf-1", "Name": "Alien", "Type": "Movie"},
+                ],
+                "TotalRecordCount": 1,
+                "StartIndex": 0,
+            },
+            request=_FAKE_REQUEST,
+        )
+        result = await jf_client.get_items_by_ids(
+            token="tok-123", user_id="uid-1", ids=["jf-1", "jf-2", "jf-3"]
+        )
+        assert len(result) == 1
+        assert result[0].id == "jf-1"
+
+    async def test_empty_ids_list_returns_empty_without_request(
+        self, jf_client: JellyfinClient, mock_http: AsyncMock
+    ) -> None:
+        result = await jf_client.get_items_by_ids(
+            token="tok-123", user_id="uid-1", ids=[]
+        )
+        assert result == []
+        mock_http.request.assert_not_called()
+
+
 class TestGetAllItems:
     """Tests for get_all_items() auto-paginating async iterator."""
 

--- a/backend/tests/test_library_store.py
+++ b/backend/tests/test_library_store.py
@@ -161,6 +161,86 @@ class TestInit:
         finally:
             await s.close()
 
+    async def test_country_columns_exist_on_fresh_db(
+        self, store: LibraryStore
+    ) -> None:
+        """Spec 25 — production_countries and country_synced_at on fresh init."""
+        cursor = await store._conn.execute("PRAGMA table_info(library_items)")
+        rows = await cursor.fetchall()
+        # Each row from PRAGMA table_info is (cid, name, type, notnull, dflt_value, pk)
+        col_by_name = {row[1]: row for row in rows}
+
+        assert "production_countries" in col_by_name
+        prod = col_by_name["production_countries"]
+        assert prod[2] == "TEXT"
+        assert prod[3] == 1  # NOT NULL
+        assert prod[4] == "'[]'"  # default JSON-array sentinel
+
+        assert "country_synced_at" in col_by_name
+        synced = col_by_name["country_synced_at"]
+        assert synced[2] == "INTEGER"
+        assert synced[3] == 0  # nullable
+
+    async def test_country_columns_added_to_legacy_db(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Spec 25 — opening a pre-Spec-25 DB adds country columns via ALTER TABLE.
+
+        Uses PRAGMA table_info introspection (per Granny+Vimes architecture
+        ruling) so SQLite < 3.35's lack of `ADD COLUMN IF NOT EXISTS` is a
+        non-issue. Re-opening must be idempotent.
+        """
+        import aiosqlite
+
+        db_path = tmp_path / "legacy_pre_spec25.db"
+        async with aiosqlite.connect(str(db_path)) as conn:
+            # Schema as it existed post-Spec-24, pre-Spec-25 (no country cols).
+            await conn.execute(
+                "CREATE TABLE library_items ("
+                " jellyfin_id TEXT PRIMARY KEY,"
+                " title TEXT NOT NULL,"
+                " overview TEXT,"
+                " production_year INTEGER,"
+                " genres TEXT NOT NULL DEFAULT '[]',"
+                " tags TEXT NOT NULL DEFAULT '[]',"
+                " studios TEXT NOT NULL DEFAULT '[]',"
+                " community_rating REAL,"
+                " people TEXT NOT NULL DEFAULT '[]',"
+                " content_hash TEXT NOT NULL,"
+                " synced_at INTEGER NOT NULL,"
+                " deleted_at INTEGER,"
+                " runtime_minutes INTEGER,"
+                " directors TEXT NOT NULL DEFAULT '[]',"
+                " writers TEXT NOT NULL DEFAULT '[]',"
+                " composers TEXT NOT NULL DEFAULT '[]',"
+                " official_rating TEXT"
+                ")"
+            )
+            await conn.commit()
+
+        s = LibraryStore(str(db_path))
+        await s.init()
+        try:
+            cursor = await s._conn.execute("PRAGMA table_info(library_items)")
+            rows = await cursor.fetchall()
+            columns = {row[1] for row in rows}
+            assert "production_countries" in columns
+            assert "country_synced_at" in columns
+        finally:
+            await s.close()
+
+        # Re-open the same DB; PRAGMA-guarded ALTER must not error on re-run.
+        s2 = LibraryStore(str(db_path))
+        await s2.init()
+        try:
+            cursor = await s2._conn.execute("PRAGMA table_info(library_items)")
+            rows = await cursor.fetchall()
+            columns = {row[1] for row in rows}
+            assert "production_countries" in columns
+            assert "country_synced_at" in columns
+        finally:
+            await s2.close()
+
 
 class TestUpsertMany:
     """upsert_many() created/updated/unchanged tracking."""

--- a/backend/tests/test_library_store.py
+++ b/backend/tests/test_library_store.py
@@ -161,9 +161,7 @@ class TestInit:
         finally:
             await s.close()
 
-    async def test_country_columns_exist_on_fresh_db(
-        self, store: LibraryStore
-    ) -> None:
+    async def test_country_columns_exist_on_fresh_db(self, store: LibraryStore) -> None:
         """Spec 25 — production_countries and country_synced_at on fresh init."""
         cursor = await store._conn.execute("PRAGMA table_info(library_items)")
         rows = await cursor.fetchall()

--- a/backend/tests/test_sync_engine.py
+++ b/backend/tests/test_sync_engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import tempfile
+import time
 import unittest.mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -114,6 +115,7 @@ def _make_library_item(
     people: list[dict[str, str]] | None = None,
     run_time_ticks: int | None = None,
     official_rating: str | None = None,
+    production_locations: list[str] | None = None,
 ) -> LibraryItem:
     """Create a LibraryItem for testing."""
     if genres is None:
@@ -139,6 +141,8 @@ def _make_library_item(
         data["RunTimeTicks"] = run_time_ticks
     if official_rating is not None:
         data["OfficialRating"] = official_rating
+    if production_locations is not None:
+        data["ProductionLocations"] = production_locations
     return LibraryItem.model_validate(data)
 
 
@@ -314,6 +318,109 @@ class TestToLibraryRowCrewExtraction:
         item = _make_library_item()
         row = to_library_row(item)
         assert row.content_hash == compute_content_hash(row)
+
+
+# ---------------------------------------------------------------------------
+# Spec 25 — to_library_row country handling
+# ---------------------------------------------------------------------------
+
+
+class TestToLibraryRowCountryHandling:
+    """Spec 25 — Jellyfin ProductionLocations → ISO codes via country_codes."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_unmappable_dedup_set(self) -> None:
+        """The skip-and-log dedup set is module-scoped; reset per test."""
+        from app.sync import engine as sync_engine_module
+
+        sync_engine_module._unmappable_country_names_logged.clear()
+
+    def test_persists_single_country_as_iso(self) -> None:
+        item = _make_library_item(item_id="jf-spirited", production_locations=["Japan"])
+        row = to_library_row(item)
+        assert row.production_countries == ["JP"]
+
+    def test_persists_co_production_sorted_deterministic(self) -> None:
+        """Multiple ProductionLocations preserve all + sort for determinism."""
+        item = _make_library_item(
+            item_id="jf-2fast",
+            production_locations=["United States of America", "Germany"],
+        )
+        row = to_library_row(item)
+        # Sorted alphabetically by ISO code so the JSON encoding is stable
+        assert row.production_countries == ["DE", "US"]
+
+    def test_country_synced_at_is_current_epoch(self) -> None:
+        before = int(time.time())
+        item = _make_library_item(production_locations=["Japan"])
+        row = to_library_row(item)
+        after = int(time.time())
+        assert row.country_synced_at is not None
+        assert before <= row.country_synced_at <= after
+
+    def test_empty_production_locations_gives_empty_array_with_synced_at(
+        self,
+    ) -> None:
+        """No country data still sets country_synced_at — distinguishes from
+        the not-yet-backfilled case (None)."""
+        item = _make_library_item(production_locations=[])
+        row = to_library_row(item)
+        assert row.production_countries == []
+        assert row.country_synced_at is not None
+
+    def test_unmappable_country_skipped_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        item = _make_library_item(production_locations=["Atlantis"])
+        with caplog.at_level(logging.WARNING):
+            row = to_library_row(item)
+        assert row.production_countries == []
+        assert row.country_synced_at is not None
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "Atlantis" in warnings[0].getMessage()
+
+    def test_partial_co_production_unmappable_dropped(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """If a co-production has both mappable and unmappable countries,
+        the mappable one is preserved and the unmappable one is logged."""
+        import logging
+
+        item = _make_library_item(production_locations=["Japan", "Atlantis"])
+        with caplog.at_level(logging.WARNING):
+            row = to_library_row(item)
+        assert row.production_countries == ["JP"]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+
+
+class TestContentHashUnchangedByCountryData:
+    """Spec 25 — production_countries must NOT participate in content_hash.
+
+    Per the architecture review: country is a structured filter only and
+    must not invalidate stored embeddings when added to existing items.
+    """
+
+    def test_hash_identical_with_and_without_country_data(self) -> None:
+        item_no_country = _make_library_item(production_locations=[])
+        item_with_country = _make_library_item(production_locations=["Japan"])
+        row_no_country = to_library_row(item_no_country)
+        row_with_country = to_library_row(item_with_country)
+        assert row_no_country.content_hash == row_with_country.content_hash
+
+    def test_hash_identical_for_different_country_sets(self) -> None:
+        """Changing country_set on otherwise-identical items must not change
+        the content hash — embeddings remain valid through country backfill."""
+        item_jp = _make_library_item(production_locations=["Japan"])
+        item_us_de = _make_library_item(
+            production_locations=["United States of America", "Germany"]
+        )
+        row_jp = to_library_row(item_jp)
+        row_us_de = to_library_row(item_us_de)
+        assert row_jp.content_hash == row_us_de.content_hash
 
 
 # ---------------------------------------------------------------------------

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -11,6 +11,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "pycountry" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "slowapi" },
@@ -33,6 +34,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=44.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "pycountry", specifier = ">=24.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
@@ -461,6 +463,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycountry"
+version = "26.2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/061b9e7a48b85cfd69f33c33d2ef784a531c359399ad764243399673c8f5/pycountry-26.2.16.tar.gz", hash = "sha256:5b6027d453fcd6060112b951dd010f01f168b51b4bf8a1f1fc8c95c8d94a0801", size = 7711342, upload-time = "2026-02-17T03:42:52.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/42/7703bd45b62fecd44cd7d3495423097e2f7d28bc2e99e7c1af68892ab157/pycountry-26.2.16-py3-none-any.whl", hash = "sha256:115c4baf7cceaa30f59a4694d79483c9167dbce7a9de4d3d571c5f3ea77c305a", size = 8044600, upload-time = "2026-02-17T03:42:49.777Z" },
 ]
 
 [[package]]

--- a/scripts/backfill_country.py
+++ b/scripts/backfill_country.py
@@ -115,7 +115,7 @@ async def _fetch_pending_ids(store: LibraryStore) -> list[str]:
     return [row[0] for row in rows]
 
 
-async def _update_batch(
+async def _update_row_country_fields(
     store: LibraryStore,
     *,
     jellyfin_id: str,
@@ -194,7 +194,7 @@ async def run_backfill(
                     if item is not None
                     else []
                 )
-                await _update_batch(
+                await _update_row_country_fields(
                     store,
                     jellyfin_id=jellyfin_id,
                     iso_codes=iso_codes,

--- a/scripts/backfill_country.py
+++ b/scripts/backfill_country.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""One-shot backfill — populate ``library_items.production_countries`` for
+existing rows from Jellyfin's ``ProductionLocations`` field (Spec 25).
+
+Reads rows where ``country_synced_at IS NULL AND deleted_at IS NULL``,
+fetches metadata in batches of 50 IDs via ``JellyfinClient.get_items_by_ids``,
+maps each ``ProductionLocations`` entry through ``app.library.country_codes``,
+and updates each row in a per-batch transaction setting both
+``production_countries`` (sorted ISO 3166-1 alpha-2 array) and
+``country_synced_at`` (current epoch).
+
+Prerequisites
+-------------
+**Run with `SYNC_INTERVAL_HOURS=0` set** (disabling the periodic sync engine)
+to avoid concurrent writes to the same ``jellyfin_id``. The script asserts
+this at startup and exits with code 1 if violated, naming the env var.
+
+Idempotency
+-----------
+Re-runnable. Processes only rows with ``country_synced_at IS NULL``. Killing
+the script mid-run leaves a coherent half-populated state; re-invoke to
+resume.
+
+Verification (run after script completes)
+-----------------------------------------
+::
+
+    -- Sentinel coverage (expected: equals total active items, i.e. 100%):
+    SELECT COUNT(*) FROM library_items WHERE country_synced_at IS NOT NULL;
+
+    -- Country coverage (expected: ~97%; the residual ~3% is items where
+    -- Jellyfin returned no ProductionLocations, which is a metadata-quality
+    -- problem at the Jellyfin layer, not a backfill bug):
+    SELECT COUNT(*) FROM library_items WHERE production_countries != '[]';
+
+    -- ISO sanity (expected: rows like ["US"], ["JP"], ["DE","US"]; if you
+    -- see full English names like ["United States of America"], the
+    -- conversion did not run — abort and investigate):
+    SELECT production_countries, COUNT(*) FROM library_items
+    GROUP BY production_countries ORDER BY 2 DESC LIMIT 20;
+
+Expected log output
+-------------------
+On a successful run, expect one INFO log per batch
+(``processed batch N of M, X rows updated``) plus a final summary line.
+Items where Jellyfin returns empty ``ProductionLocations`` are stamped with
+``country_synced_at`` and an empty array (no warning). Unmappable country
+names produce a single deduped WARNING per name per script run, e.g.
+``Unmappable country name from Jellyfin: Atlantis``.
+
+Restore step
+------------
+After the script exits cleanly, restore ``SYNC_INTERVAL_HOURS`` to its
+prior value in your ``.env`` / docker-compose override and restart the
+backend service.
+
+Security
+--------
+**The script must not print, log, or include ``JELLYFIN_API_KEY`` in any
+output, including startup banner, dry-run summary, error messages, or
+exception tracebacks.** The value is accessed only via the existing
+``Settings`` object; treat it like a root password (per
+``ARCHITECTURE.md`` credential distinction).
+
+Usage
+-----
+::
+
+    # From the backend directory:
+    SYNC_INTERVAL_HOURS=0 uv run python ../scripts/backfill_country.py [--dry-run]
+
+    # Or via Make (T3.12):
+    make backfill-country
+    make backfill-country-dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import time
+
+import httpx
+
+from app.config import Settings
+from app.jellyfin.client import JellyfinClient
+from app.library.country_codes import name_to_iso
+from app.library.store import LibraryStore
+
+_logger = logging.getLogger("backfill_country")
+
+# Number of jellyfin_ids per /Users/{userId}/Items?Ids=... call. Tuned for
+# Jellyfin's typical request-size limits and the script's per-batch
+# transaction granularity. Vimes' migration ruling: per-item is too fragile
+# under transient network failure; batch boundaries become natural
+# checkpoints.
+BATCH_SIZE = 50
+
+
+async def _fetch_pending_ids(store: LibraryStore) -> list[str]:
+    """Return jellyfin_ids that need country backfill, ordered deterministically."""
+    cursor = await store._conn.execute(
+        "SELECT jellyfin_id FROM library_items "
+        "WHERE country_synced_at IS NULL AND deleted_at IS NULL "
+        "ORDER BY jellyfin_id"
+    )
+    rows = await cursor.fetchall()
+    return [row[0] for row in rows]
+
+
+async def _update_batch(
+    store: LibraryStore,
+    *,
+    jellyfin_id: str,
+    iso_codes: list[str],
+    now: int,
+) -> None:
+    """Update a single row with backfilled country data + sentinel timestamp."""
+    import json
+
+    await store._conn.execute(
+        "UPDATE library_items SET production_countries = ?, country_synced_at = ? "
+        "WHERE jellyfin_id = ?",
+        (json.dumps(iso_codes), now, jellyfin_id),
+    )
+
+
+def _map_locations(names: list[str], unmappable_seen: set[str]) -> list[str]:
+    """Map ProductionLocations strings to sorted ISO codes, dedup-warn unmappable."""
+    iso_codes: list[str] = []
+    for name in names:
+        iso = name_to_iso(name)
+        if iso is None:
+            if name not in unmappable_seen:
+                _logger.warning("Unmappable country name from Jellyfin: %s", name)
+                unmappable_seen.add(name)
+            continue
+        iso_codes.append(iso)
+    return sorted(iso_codes)
+
+
+async def run_backfill(
+    *,
+    store: LibraryStore,
+    client: JellyfinClient,
+    token: str,
+    user_id: str,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Execute the backfill main loop. Returns (rows_processed, batches_run)."""
+    pending = await _fetch_pending_ids(store)
+    total = len(pending)
+    if total == 0:
+        _logger.info(
+            "No rows to backfill — country_synced_at is non-null for all items."
+        )
+        return (0, 0)
+
+    batches = [pending[i : i + BATCH_SIZE] for i in range(0, total, BATCH_SIZE)]
+
+    if dry_run:
+        _logger.info(
+            "Dry-run: would process %d rows across %d batches of %d (~%d API calls)",
+            total,
+            len(batches),
+            BATCH_SIZE,
+            len(batches),
+        )
+        return (total, len(batches))
+
+    unmappable_seen: set[str] = set()
+    rows_processed = 0
+    for batch_idx, batch_ids in enumerate(batches, start=1):
+        items = await client.get_items_by_ids(
+            token=token, user_id=user_id, ids=batch_ids
+        )
+        # Items deleted upstream don't appear in the response; we still
+        # mark the row's country_synced_at so it doesn't get retried forever.
+        items_by_id = {item.id: item for item in items}
+        now = int(time.time())
+        await store._conn.execute("BEGIN")
+        try:
+            for jellyfin_id in batch_ids:
+                item = items_by_id.get(jellyfin_id)
+                iso_codes = (
+                    _map_locations(item.production_locations, unmappable_seen)
+                    if item is not None
+                    else []
+                )
+                await _update_batch(
+                    store,
+                    jellyfin_id=jellyfin_id,
+                    iso_codes=iso_codes,
+                    now=now,
+                )
+        except Exception:
+            await store._conn.rollback()
+            raise
+        else:
+            await store._conn.commit()
+        rows_processed += len(batch_ids)
+        _logger.info(
+            "processed batch %d of %d, %d rows updated",
+            batch_idx,
+            len(batches),
+            len(batch_ids),
+        )
+
+    _logger.info(
+        "Backfill complete: %d rows processed across %d batches",
+        rows_processed,
+        len(batches),
+    )
+    return (rows_processed, len(batches))
+
+
+async def main_async(*, dry_run: bool) -> int:
+    settings = Settings()  # type: ignore[call-arg]
+
+    # Spec 25 — Vimes' Mod #3 belt-and-braces: refuse to run if the periodic
+    # sync engine is enabled (which would race the backfill on shared rows).
+    if settings.sync_interval_hours != 0:
+        _logger.error(
+            "Refusing to run: SYNC_INTERVAL_HOURS=%s (must be 0). "
+            "Disable the periodic sync engine before backfilling — see the "
+            "module docstring for the operator runbook.",
+            settings.sync_interval_hours,
+        )
+        return 1
+
+    if settings.jellyfin_api_key is None:
+        _logger.error(
+            "Refusing to run: JELLYFIN_API_KEY is not configured. "
+            "(Note: the value itself is never logged.)"
+        )
+        return 1
+    if settings.jellyfin_admin_user_id is None:
+        _logger.error("Refusing to run: JELLYFIN_ADMIN_USER_ID is not configured.")
+        return 1
+
+    store = LibraryStore(settings.library_db_path)
+    await store.init()
+    try:
+        async with httpx.AsyncClient(timeout=settings.jellyfin_timeout) as http:
+            client = JellyfinClient(base_url=settings.jellyfin_url, http_client=http)
+            await run_backfill(
+                store=store,
+                client=client,
+                token=settings.jellyfin_api_key.get_secret_value(),
+                user_id=settings.jellyfin_admin_user_id,
+                dry_run=dry_run,
+            )
+    finally:
+        await store.close()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill production_countries for existing library rows (Spec 25)."
+        ),
+        epilog=(
+            "Prerequisite: run with SYNC_INTERVAL_HOURS=0. "
+            "After completion, restore the prior value and restart the backend."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report row counts and projected API calls without mutating any data.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    return asyncio.run(main_async(dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill_country.py
+++ b/scripts/backfill_country.py
@@ -31,9 +31,11 @@ Verification (run after script completes)
     -- Sentinel coverage (expected: equals total active items, i.e. 100%):
     SELECT COUNT(*) FROM library_items WHERE country_synced_at IS NOT NULL;
 
-    -- Country coverage (expected: ~97%; the residual ~3% is items where
-    -- Jellyfin returned no ProductionLocations, which is a metadata-quality
-    -- problem at the Jellyfin layer, not a backfill bug):
+    -- Country coverage (varies by library metadata quality; ≥95% target for
+    -- well-tagged libraries. Live observation on a 1806-item library: 85.2%.
+    -- Residual rows are items where Jellyfin returned no ProductionLocations
+    -- — a metadata-quality gap at the Jellyfin layer, not a backfill bug.
+    -- Fix path: refresh Jellyfin metadata for affected items, then re-run):
     SELECT COUNT(*) FROM library_items WHERE production_countries != '[]';
 
     -- ISO sanity (expected: rows like ["US"], ["JP"], ["DE","US"]; if you


### PR DESCRIPTION
## Summary

First of three PRs implementing [Spec 25 — country/language filter dimension](https://github.com/PCritchfield/ai-movie-suggester/issues/238). Covers the **data plumbing** Demoable Unit: schema columns, sync write-path, one-shot backfill script. Live-deployed and verified against `/srv/stacks/jellyfin` (1806-item library) before push.

This PR is **safe to merge before** branches 2 (router/filter SQL) and 3 (chat hardening) — it only adds data; nothing reads `production_countries` yet.

## What changed

**Three commits (one per parent task):**

1. `feat(library): country code module + production_countries schema (Spec 25)` — `a9e8ed4`
2. `feat(sync): persist production_countries from Jellyfin (Spec 25)` — `33485dd`
3. `feat(scripts): backfill country data for existing library (Spec 25)` — `2310576`

**Files added/modified:**

- `backend/app/library/country_codes.py` *(new)* — single canonical name↔ISO 3166-1 alpha-2 mapping via offline `pycountry` (no third-party API calls)
- `backend/app/library/store.py` — schema gains `production_countries TEXT NOT NULL DEFAULT '[]'` + `country_synced_at INTEGER`. PRAGMA-introspection migration guard works on every SQLite version (not just 3.35+).
- `backend/app/library/models.py` — `LibraryItemRow` updated
- `backend/app/jellyfin/{client,models}.py` — `ProductionLocations` added to `_ITEM_FIELDS`; `LibraryItem.production_locations`; new batch method `JellyfinClient.get_items_by_ids` (Vimes' Mod #1)
- `backend/app/sync/engine.py` — `to_library_row` maps Jellyfin country names → sorted ISO codes via `country_codes.name_to_iso`; per-sync-run dedup of unmappable warnings; `country_synced_at` stamped on every write; **`content_hash` recipe untouched** (per Granny's minority report — country is a structured filter, must not invalidate embeddings)
- `scripts/backfill_country.py` *(new)* — one-shot operational script with full operator runbook, `SYNC_INTERVAL_HOURS=0` startup safety assertion, `--dry-run` flag, no-API-key-log clause
- `Makefile` — `make backfill-country` / `make backfill-country-dry-run` targets
- `backend/pyproject.toml` — `pycountry>=24.0.0` dependency
- 33 new unit tests across 4 test files

## Spec 25 architectural decisions encoded

Per the council review on Spec 25 (Granny / Vimes / Carrot / Angua / Sybil all approved with conditions):

- ✅ Granny: ISO 3166-1 alpha-2 codes (not full names) — eliminates `LIKE '%"Japan"%'` substring leak risk that would match `Japanese` in unrelated tag fields
- ✅ Granny: country lives outside the embedding template (no v6 bump needed) — preserves cosine focus on narrative content
- ✅ Vimes: `country_synced_at` sentinel column distinct from empty `production_countries` — separates "no Jellyfin data" from "not yet backfilled"
- ✅ Vimes: PRAGMA-introspection schema migration (not `ADD COLUMN IF NOT EXISTS`)
- ✅ Vimes: batch endpoint `get_items_by_ids` (50 IDs/call); per-batch transactions
- ✅ Angua: `JELLYFIN_API_KEY` accessed via `Settings` only — never logged/printed/echoed; no LLM-output logging introduced (deferred to Spec 26)
- ✅ Carrot: TDD red-green-refactor on all production code paths (one honest exception: 3.1 implemented before 3.2; documented in tasks file)
- ✅ Sybil: `make backfill-country` target with help text mentioning the `SYNC_INTERVAL_HOURS=0` prerequisite

## Live operator pass — completed before push

All four operator-prompt sub-tasks (3.8, 3.9, 3.10, 3.11) executed against `/srv/stacks/jellyfin`. Full evidence in `docs/specs/25-spec-country-language-filter/25-proofs/25-task-03-proofs.md` (gitignored — local artifact).

Vimes' five verification queries:

| Query | Result | Threshold | Status |
|--|--|--|--|
| Q1 Total active items | 1806 | matches expectation | ✅ |
| Q2 `country_synced_at IS NOT NULL` | 100.0% | exactly 100% | ✅ |
| Q3 `production_countries != '[]'` | **85.2%** | ≥95% target | ⚠️ honest finding |
| Q4 Empty + synced | 14.8% (267 items) | residual ~3% expected | ⚠️ matches Q3 |
| Q5 ISO sanity | 0 non-2-char codes | zero | ✅ |

**Honest finding on Q3/Q4**: the pre-spec 200-item sample probe reported 97% coverage; the full 1806-item library is 85.2%. 267 items have empty Jellyfin `ProductionLocations` — a metadata-quality gap at the Jellyfin layer, not a backfill-script bug. The script correctly stamped `country_synced_at` on those rows so they aren't retried forever. Tracked as a separate operational follow-up (Jellyfin metadata refresh — out of scope for Spec 25).

Top distribution sample (Q5): 1061 US, 74 GB+US, 63 GB, 45 JP, 41 CA+US, 25 JP+US, 22 CA, 15 DE+US, 14 FR+US, 9 HK, 8 IT, 5 NZ+US — sensible for a Western-leaning library with anime sprinkled in.

Rollback rehearsal (3.11): 5 sample rows reset via `UPDATE … SET country_synced_at = NULL, production_countries = '[]'` → re-backfill → reconverged exactly to pre-rollback ISO values. **Subtlety surfaced**: WAL-mode `library.db` requires `PRAGMA wal_checkpoint(TRUNCATE)` before copying for a true snapshot. Operator runbook updated.

## Test plan

- [x] `make lint` clean (ruff + ruff format + pyright on all touched files)
- [x] `cd backend && uv run pytest -m "not integration and not pipeline and not ollama_integration" -q` → **972 passed** (was 955; +17 new tests)
- [x] Schema migration applied automatically on backend startup against the live `/srv/stacks/jellyfin` `library.db` (PRAGMA-introspection guard)
- [x] Live dry-run against 1806-row library (`--dry-run` reports counts without writes)
- [x] Live full backfill executed cleanly in ~35s
- [x] Vimes' verification SQL queries — 4 of 5 passed at threshold; Q3 below threshold but honest data-quality finding (separate issue)
- [x] Rollback rehearsal proves targeted re-backfill path works
- [ ] CI integration tests (auto-run by GitHub Actions against disposable Jellyfin)
- [ ] Branch 2 (router/filter SQL — #238 part 2/3) makes `production_countries` actually queryable
- [ ] Branch 3 (chat hardening — #238 part 3/3) gives the LLM unambiguous IDs

## Related

- #238 — Spec 25 (this is part 1/3)
- #239 — Spec 26 (LLM tool-calling — sequenced after Spec 25 lands)
- Builds on #228 (Spec 24 — query router foundation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)