### PR TITLE
feat(search): country/language filter dimension (Spec 25, 2/3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -202,6 +202,12 @@ JELLYFIN_TIMEOUT=10.0
 # Cache entry TTL in hours (1–168, default: 24)
 # REWRITE_CACHE_TTL_HOURS=24
 
+# --- Spec 25 — Country Filter ---
+# Comma-separated ISO 3166-1 alpha-2 codes for your home country or countries.
+# Used to resolve "foreign film" queries: results must NOT be from these countries.
+# Example: US,GB  (if you consider both American and British films "domestic")
+# FOREIGN_FILM_HOME_COUNTRIES=US
+
 # --- Local Development ---
 # For local HTTP development only, uncomment the line below.
 # WARNING: This MUST remain commented out (or set to true) for any

--- a/.env.example
+++ b/.env.example
@@ -205,7 +205,10 @@ JELLYFIN_TIMEOUT=10.0
 # --- Spec 25 — Country Filter ---
 # Comma-separated ISO 3166-1 alpha-2 codes for your home country or countries.
 # Used to resolve "foreign film" queries: results must NOT be from these countries.
-# Example: US,GB  (if you consider both American and British films "domestic")
+# Example: US,GB  (if you consider both American and British films "domestic").
+# Codes are validated at startup against ISO 3166-1; "USA" / "United States"
+# / unknown codes will refuse to start. Set to empty (FOREIGN_FILM_HOME_COUNTRIES=)
+# to disable the foreign-film route entirely. Defaults to US when unset.
 # FOREIGN_FILM_HOME_COUNTRIES=US
 
 # --- Local Development ---

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import logging
 from typing import Annotated, Literal
 
-from pydantic import AnyHttpUrl, Field, SecretStr, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import AnyHttpUrl, Field, SecretStr, field_validator, model_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 _logger = logging.getLogger(__name__)
 _RATE_LIMIT_RE = r"^\d+/(second|minute|hour|day)$"
@@ -104,6 +104,27 @@ class Settings(BaseSettings):
     intent_filter_person_enabled: bool = True
     intent_filter_year_enabled: bool = True
     intent_filter_rating_enabled: bool = True
+
+    # Spec 25 — country/origin filter dimension. Operator's home country
+    # or countries (ISO 3166-1 alpha-2 codes), used to resolve "foreign
+    # film" queries to a NOT-IN predicate. Comma-separated env var
+    # (``US,GB``) is parsed into a list and uppercased for safe matching
+    # against normalised ISO codes stored in ``library_items``.
+    foreign_film_home_countries: Annotated[list[str], NoDecode] = Field(
+        default_factory=lambda: ["US"]
+    )
+
+    @field_validator("foreign_film_home_countries", mode="before")
+    @classmethod
+    def _parse_foreign_film_home_countries(cls, v: object) -> list[str]:
+        """Accept comma-separated env var string or list; normalise to uppercase ISO."""
+        if isinstance(v, str):
+            items = [s.strip() for s in v.split(",") if s.strip()]
+        elif isinstance(v, list):
+            items = [str(s).strip() for s in v if str(s).strip()]
+        else:
+            return v  # type: ignore[return-value]
+        return [s.upper() for s in items]
 
     # Spec 24 — paraphrastic LLM rewriter + cache.
     rewrite_timeout_seconds: Annotated[float, Field(ge=0.1, le=10.0)] = 2.0

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -117,14 +117,42 @@ class Settings(BaseSettings):
     @field_validator("foreign_film_home_countries", mode="before")
     @classmethod
     def _parse_foreign_film_home_countries(cls, v: object) -> list[str]:
-        """Accept comma-separated env var string or list; normalise to uppercase ISO."""
+        """Parse + validate the operator-configured home set.
+
+        Accepts a comma-separated env-var string or an explicit list,
+        normalises to uppercase, and rejects anything that isn't a real
+        ISO 3166-1 alpha-2 code. Without the validation step ``USA``,
+        ``UK``, ``Narnia`` would all pass silently and the foreign-film
+        route would NOT-EXISTS-against-nothing — operator sees their
+        whole library returned, no error, no log. Council review
+        (PR #244) closed this hole at the boundary.
+        """
+        import pycountry  # noqa: PLC0415
+
         if isinstance(v, str):
             items = [s.strip() for s in v.split(",") if s.strip()]
         elif isinstance(v, list):
             items = [str(s).strip() for s in v if str(s).strip()]
         else:
-            return v  # type: ignore[return-value]
-        return [s.upper() for s in items]
+            msg = (
+                "FOREIGN_FILM_HOME_COUNTRIES must be a comma-separated string "
+                f"or list of ISO 3166-1 alpha-2 codes, got {type(v).__name__}"
+            )
+            raise ValueError(msg)
+        normalised = [s.upper() for s in items]
+        invalid = [
+            code
+            for code in normalised
+            if len(code) != 2 or pycountry.countries.get(alpha_2=code) is None
+        ]
+        if invalid:
+            msg = (
+                "FOREIGN_FILM_HOME_COUNTRIES contains values that are not "
+                f"ISO 3166-1 alpha-2 codes: {invalid}. Use 2-letter codes "
+                "like 'US', 'GB', 'JP' (not 'USA', 'United States', etc.)."
+            )
+            raise ValueError(msg)
+        return normalised
 
     # Spec 24 — paraphrastic LLM rewriter + cache.
     rewrite_timeout_seconds: Annotated[float, Field(ge=0.1, le=10.0)] = 2.0

--- a/backend/app/library/store.py
+++ b/backend/app/library/store.py
@@ -436,6 +436,8 @@ class LibraryStore:
         people: list[str] | None,
         year_range: tuple[int, int] | None,
         ratings: list[str] | None,
+        countries: list[str] | None = None,
+        countries_negate: bool = False,
     ) -> set[str] | None:
         """Return the AND-intersected set of jellyfin_ids matching every filter.
 
@@ -445,9 +447,17 @@ class LibraryStore:
         no exception" contract for over-constrained intents.
 
         Person matching uses LIKE because the JSON columns store names as
-        a JSON array; year matching uses BETWEEN; rating matching uses IN.
+        a JSON array; year matching uses BETWEEN; rating matching uses IN;
+        country matching uses ``json_each`` over the JSON-array
+        ``production_countries`` column so substrings inside other JSON
+        columns (e.g. ``tags='["Japanese garden"]'``) cannot leak in. When
+        ``countries_negate`` is True the predicate flips to ``NOT EXISTS``
+        — used by the foreign-film route. Rows with empty
+        ``production_countries`` survive the negation case (json_each over
+        an empty array yields no rows, so ``NOT EXISTS`` is trivially
+        true) — the router treats unknown-as-not-excluded.
         """
-        if not people and year_range is None and not ratings:
+        if not people and year_range is None and not ratings and not countries:
             return None
 
         clauses: list[str] = ["deleted_at IS NULL"]
@@ -473,6 +483,15 @@ class LibraryStore:
             placeholders = ",".join("?" * len(ratings))
             clauses.append(f"official_rating IN ({placeholders})")
             params.extend(ratings)
+
+        if countries:
+            placeholders = ",".join("?" * len(countries))
+            keyword = "NOT EXISTS" if countries_negate else "EXISTS"
+            clauses.append(
+                f"{keyword} (SELECT 1 FROM json_each(production_countries) "
+                f"WHERE value IN ({placeholders}))"
+            )
+            params.extend(countries)
 
         sql = "SELECT jellyfin_id FROM library_items WHERE " + " AND ".join(clauses)
         cursor = await self._conn.execute(sql, params)

--- a/backend/app/library/store.py
+++ b/backend/app/library/store.py
@@ -446,16 +446,14 @@ class LibraryStore:
         set on AND-empty so the caller can honour the Q3-D "empty results,
         no exception" contract for over-constrained intents.
 
-        Person matching uses LIKE because the JSON columns store names as
-        a JSON array; year matching uses BETWEEN; rating matching uses IN;
-        country matching uses ``json_each`` over the JSON-array
-        ``production_countries`` column so substrings inside other JSON
-        columns (e.g. ``tags='["Japanese garden"]'``) cannot leak in. When
-        ``countries_negate`` is True the predicate flips to ``NOT EXISTS``
-        — used by the foreign-film route. Rows with empty
-        ``production_countries`` survive the negation case (json_each over
-        an empty array yields no rows, so ``NOT EXISTS`` is trivially
-        true) — the router treats unknown-as-not-excluded.
+        Country matching uses ``json_each`` over the JSON-array
+        ``production_countries`` column so substrings inside sibling JSON
+        columns (e.g. ``tags='["Japanese garden"]'``) cannot leak in.
+        When ``countries_negate`` is True the predicate flips to
+        ``NOT EXISTS`` — used by the foreign-film route. Rows with empty
+        ``production_countries`` survive the negation case (json_each
+        over an empty array yields no rows, so ``NOT EXISTS`` is
+        trivially true) — the router treats unknown-as-not-excluded.
         """
         if not people and year_range is None and not ratings and not countries:
             return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -308,6 +308,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             intent_filter_year_enabled=settings.intent_filter_year_enabled,
             intent_filter_rating_enabled=settings.intent_filter_rating_enabled,
             rewriter=query_rewriter,
+            foreign_film_home_countries=settings.foreign_film_home_countries,
         )
         app.state.search_service = search_service
         search_router = create_search_router(

--- a/backend/app/search/intent.py
+++ b/backend/app/search/intent.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.library.country_codes import name_to_iso
 from app.search.genre_keywords import detect_query_genres
 
 if TYPE_CHECKING:
@@ -58,8 +59,92 @@ _RATING_NOUN_SUFFIX_RES: dict[str, re.Pattern[str]] = {
 _PARAPHRASTIC_MIN_WORDS = 4
 
 
+# Spec 25 — country/demonym → ISO 3166-1 alpha-2 lookup. The full English
+# names are mapped via ``country_codes.name_to_iso``; demonyms (adjectival
+# forms) need a hand-curated mapping because pycountry's
+# ``official_name``/``common_name`` fields don't carry the adjective form
+# universally. Start with the 20 most common; expandable. Keys are
+# lowercase tokens — matching is case-insensitive on the query side.
+_DEMONYM_TO_ISO: dict[str, str] = {
+    "japanese": "JP",
+    "korean": "KR",
+    "french": "FR",
+    "british": "GB",
+    "english": "GB",
+    "scottish": "GB",
+    "german": "DE",
+    "italian": "IT",
+    "spanish": "ES",
+    "mexican": "MX",
+    "brazilian": "BR",
+    "russian": "RU",
+    "chinese": "CN",
+    "indian": "IN",
+    "australian": "AU",
+    "canadian": "CA",
+    "american": "US",
+    "swedish": "SE",
+    "danish": "DK",
+    "norwegian": "NO",
+    "polish": "PL",
+    "iranian": "IR",
+    "thai": "TH",
+}
+
+# Country names that pycountry handles directly, but we want to recognise
+# in queries even when typed as a single token (no demonym needed).
+_COUNTRY_NAME_TOKENS: tuple[str, ...] = (
+    "japan",
+    "korea",
+    "france",
+    "britain",
+    "germany",
+    "italy",
+    "spain",
+    "mexico",
+    "brazil",
+    "russia",
+    "china",
+    "india",
+    "australia",
+    "canada",
+    "sweden",
+    "denmark",
+    "norway",
+    "poland",
+    "iran",
+    "thailand",
+)
+
+# Plot-setting markers — when one appears within ~5 tokens before a
+# country mention, the country is a setting (``set in Japan``,
+# ``during the Cold War``, ``about France``), not a production-country
+# signal. Tokenisation is whitespace + punctuation strip; window size of 5
+# tokens covers ``set in / during / about <country>`` plus 1–2
+# determiners or prepositions.
+_PLOT_SETTING_MARKERS: frozenset[str] = frozenset(
+    {"set", "in", "during", "about", "takes", "place"}
+)
+_PLOT_SETTING_WINDOW = 5
+
+_FOREIGN_FILM_RE = re.compile(
+    r"\bforeign\s+(film|films|movie|movies|cinema)\b", re.IGNORECASE
+)
+
+
 class QueryIntent(BaseModel):
-    """Structured signals extracted from a free-text search query."""
+    """Structured signals extracted from a free-text search query.
+
+    Spec 25 adds two country-related fields:
+
+    - ``countries``: the list of ISO 3166-1 alpha-2 codes the user named
+      (positive matches OR the home set when ``countries_negate`` fires).
+      Always a concrete list — never ``None`` — so callers can pass it
+      straight through to ``LibraryStore.search_filtered_ids``.
+    - ``countries_negate``: ``True`` only for ``foreign film`` /
+      ``foreign cinema`` queries, signalling the SQL layer to use the
+      ``NOT EXISTS`` predicate against the home set.
+    """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -67,11 +152,19 @@ class QueryIntent(BaseModel):
     people: list[str] = Field(default_factory=list)
     year_range: tuple[int, int] | None = None
     ratings: list[str] = Field(default_factory=list)
+    countries: list[str] = Field(default_factory=list)
+    countries_negate: bool = False
     is_paraphrastic: bool = False
 
     def has_signals(self) -> bool:
         """True when at least one structured filter signal fired."""
-        return bool(self.genres or self.people or self.year_range or self.ratings)
+        return bool(
+            self.genres
+            or self.people
+            or self.year_range
+            or self.ratings
+            or self.countries
+        )
 
 
 def _detect_year_range(query: str) -> tuple[int, int] | None:
@@ -157,13 +250,70 @@ def _detect_ratings(query: str) -> list[str]:
     return [r for r in canonical_order if r in found]
 
 
-def detect_intent(query: str, library_index: PersonIndex) -> QueryIntent:
+def _tokenise(query: str) -> list[str]:
+    """Lowercase whitespace-split tokens with punctuation stripped."""
+    return [re.sub(r"[^\w-]", "", t).lower() for t in query.split() if t]
+
+
+def _has_plot_setting_marker(tokens: list[str], match_index: int) -> bool:
+    """Return True iff a plot-setting marker sits within ``_PLOT_SETTING_WINDOW``
+    tokens *before* ``match_index``.
+
+    Window scans backwards because plot markers always precede the country
+    they govern in English (``set in Japan``, never ``Japan set in``).
+    """
+    start = max(0, match_index - _PLOT_SETTING_WINDOW)
+    return any(tok in _PLOT_SETTING_MARKERS for tok in tokens[start:match_index])
+
+
+def _detect_countries(query: str) -> list[str]:
+    """Return ISO codes for country names + demonyms in ``query``.
+
+    Suppresses extraction when a plot-setting marker (``set in``,
+    ``during``, ``about``, ``takes place in``) sits within five tokens
+    before the match. Output preserves first-occurrence order and dedupes.
+    """
+    tokens = _tokenise(query)
+    found: list[str] = []
+    seen: set[str] = set()
+
+    for i, tok in enumerate(tokens):
+        iso: str | None = None
+        if tok in _DEMONYM_TO_ISO:
+            iso = _DEMONYM_TO_ISO[tok]
+        elif tok in _COUNTRY_NAME_TOKENS:
+            iso = name_to_iso(tok)
+        else:
+            continue
+
+        if iso is None or iso in seen:
+            continue
+        if _has_plot_setting_marker(tokens, i):
+            continue
+        seen.add(iso)
+        found.append(iso)
+
+    return found
+
+
+def detect_intent(
+    query: str,
+    library_index: PersonIndex,
+    *,
+    home_countries: list[str] | None = None,
+) -> QueryIntent:
     """Extract structured search signals from a free-text query.
 
     Args:
         query: The raw user query.
         library_index: Precomputed ``PersonIndex`` (built at startup,
             rebuilt on sync). Pass an empty index to skip person matching.
+        home_countries: Operator-configured ISO codes for the
+            foreign-film negation route. When ``foreign film`` (or a
+            recognised variant) appears in the query, the returned
+            ``countries`` list is set to this set and ``countries_negate``
+            is ``True``. Pass ``None`` or an empty list to disable the
+            foreign-film route — the query then falls through unchanged.
 
     Returns:
         A ``QueryIntent`` with whichever signals fired. ``is_paraphrastic``
@@ -175,7 +325,15 @@ def detect_intent(query: str, library_index: PersonIndex) -> QueryIntent:
     ratings = _detect_ratings(query)
     people = library_index.match(query)
 
-    has_signals = bool(genres or people or year_range or ratings)
+    countries: list[str] = []
+    countries_negate = False
+    if home_countries and _FOREIGN_FILM_RE.search(query):
+        countries = list(home_countries)
+        countries_negate = True
+    else:
+        countries = _detect_countries(query)
+
+    has_signals = bool(genres or people or year_range or ratings or countries)
     word_count = len(query.split())
     is_paraphrastic = (not has_signals) and word_count >= _PARAPHRASTIC_MIN_WORDS
 
@@ -184,5 +342,7 @@ def detect_intent(query: str, library_index: PersonIndex) -> QueryIntent:
         people=people,
         year_range=year_range,
         ratings=ratings,
+        countries=countries,
+        countries_negate=countries_negate,
         is_paraphrastic=is_paraphrastic,
     )

--- a/backend/app/search/intent.py
+++ b/backend/app/search/intent.py
@@ -65,6 +65,10 @@ _PARAPHRASTIC_MIN_WORDS = 4
 # ``official_name``/``common_name`` fields don't carry the adjective form
 # universally. Start with the 20 most common; expandable. Keys are
 # lowercase tokens — matching is case-insensitive on the query side.
+#
+# British/English/Scottish all collapse to GB: ISO 3166-1 has no codes
+# for the constituent UK nations, so the demonym layer pre-resolves them
+# to the country code the SQL filter actually stores.
 _DEMONYM_TO_ISO: dict[str, str] = {
     "japanese": "JP",
     "korean": "KR",
@@ -91,8 +95,12 @@ _DEMONYM_TO_ISO: dict[str, str] = {
     "thai": "TH",
 }
 
-# Country names that pycountry handles directly, but we want to recognise
-# in queries even when typed as a single token (no demonym needed).
+# Gating allow-list of country-name tokens. We could call ``name_to_iso``
+# on every token in the query, but that would route arbitrary words
+# (``the``, ``movie``, …) into pycountry's ``search_fuzzy`` path, which
+# the ``country_codes`` module documents as the heavy branch. Limiting
+# the ``name_to_iso`` invocation to known canonical names keeps the
+# query-router hot path effectively a pair of dict lookups per token.
 _COUNTRY_NAME_TOKENS: tuple[str, ...] = (
     "japan",
     "korea",
@@ -130,6 +138,11 @@ _PLOT_SETTING_WINDOW = 5
 _FOREIGN_FILM_RE = re.compile(
     r"\bforeign\s+(film|films|movie|movies|cinema)\b", re.IGNORECASE
 )
+
+# Token-punctuation strip used by ``_tokenise``. Hoisted to module scope
+# so the regex isn't even hashed against the per-call cache for every
+# token in every query.
+_TOKEN_PUNCT_RE = re.compile(r"[^\w-]")
 
 
 class QueryIntent(BaseModel):
@@ -252,7 +265,7 @@ def _detect_ratings(query: str) -> list[str]:
 
 def _tokenise(query: str) -> list[str]:
     """Lowercase whitespace-split tokens with punctuation stripped."""
-    return [re.sub(r"[^\w-]", "", t).lower() for t in query.split() if t]
+    return [_TOKEN_PUNCT_RE.sub("", t).lower() for t in query.split() if t]
 
 
 def _has_plot_setting_marker(tokens: list[str], match_index: int) -> bool:
@@ -328,6 +341,10 @@ def detect_intent(
     countries: list[str] = []
     countries_negate = False
     if home_countries and _FOREIGN_FILM_RE.search(query):
+        # Foreign-film route is exclusive: explicit country mentions in
+        # the same query are ignored. Spec 25 scoped negation to the
+        # ``foreign`` keyword family; widening to ``non-American`` etc.
+        # is tracked as a documented follow-up in the live router cases.
         countries = list(home_countries)
         countries_negate = True
     else:

--- a/backend/app/search/intent.py
+++ b/backend/app/search/intent.py
@@ -135,14 +135,22 @@ _COUNTRY_NAME_TOKENS: tuple[str, ...] = (
 # ``during the Cold War``, ``about France``), not a production-country
 # signal. Tokenisation is whitespace + punctuation strip; window size of 5
 # tokens covers ``set in / during / about <country>`` plus 1–2
-# determiners or prepositions. ``'in'`` is deliberately excluded — it's
-# the most common English preposition and over-suppresses production-
-# location queries (``filmed in France``, ``movies made in Japan``,
-# ``interested in Japanese cinema``). Every documented plot-setting
-# phrasing carries a stronger marker (``set`` / ``during`` / ``about``
-# / ``takes`` / ``place``); council review (PR #244) confirmed.
-_PLOT_SETTING_MARKERS: frozenset[str] = frozenset(
-    {"set", "during", "about", "takes", "place"}
+# determiners or prepositions.
+#
+# Single-token markers must be unambiguous in this context. Common
+# tokens like ``in`` and ``set`` are intentionally NOT in this set —
+# they over-suppress production queries (``filmed in France``,
+# ``movies made in Japan``, ``a set of Japanese films``). Their plot-
+# setting force comes from specific 2-token phrases, captured below.
+_PLOT_SETTING_SINGLE: frozenset[str] = frozenset({"during", "about"})
+
+# Phrase markers — consecutive token pairs that disambiguate a noun
+# from a plot-setting verb. ``set in`` vs. bare ``set`` is the
+# canonical case; ``takes place`` similarly. Council + Copilot
+# review (PR #244) drove the move from single-token to phrase-level
+# detection here.
+_PLOT_SETTING_PHRASES: frozenset[tuple[str, str]] = frozenset(
+    {("set", "in"), ("takes", "place")}
 )
 _PLOT_SETTING_WINDOW = 5
 
@@ -285,9 +293,20 @@ def _has_plot_setting_marker(tokens: list[str], match_index: int) -> bool:
 
     Window scans backwards because plot markers always precede the country
     they govern in English (``set in Japan``, never ``Japan set in``).
+
+    Single-token markers (``during`` / ``about``) trigger anywhere in
+    the window. Phrase markers (``set in`` / ``takes place``) trigger
+    only on consecutive tokens — that's how ``a set of Japanese films``
+    avoids the suppression that ``a film set in Japan`` correctly fires.
     """
     start = max(0, match_index - _PLOT_SETTING_WINDOW)
-    return any(tok in _PLOT_SETTING_MARKERS for tok in tokens[start:match_index])
+    window = tokens[start:match_index]
+    if any(tok in _PLOT_SETTING_SINGLE for tok in window):
+        return True
+    return any(
+        (window[i], window[i + 1]) in _PLOT_SETTING_PHRASES
+        for i in range(len(window) - 1)
+    )
 
 
 def _detect_countries(query: str) -> list[str]:
@@ -306,7 +325,10 @@ def _detect_countries(query: str) -> list[str]:
         if tok in _DEMONYM_TO_ISO:
             iso = _DEMONYM_TO_ISO[tok]
         elif tok in _COUNTRY_NAME_TOKENS:
-            iso = name_to_iso(tok)
+            # Title-case so pycountry's case-sensitive ``get(name=...)``
+            # fast path hits — otherwise the first lookup per process
+            # falls through to ``search_fuzzy`` (Copilot review, PR #244).
+            iso = name_to_iso(tok.title())
         else:
             continue
 

--- a/backend/app/search/intent.py
+++ b/backend/app/search/intent.py
@@ -71,6 +71,11 @@ _PARAPHRASTIC_MIN_WORDS = 4
 # to the country code the SQL filter actually stores.
 _DEMONYM_TO_ISO: dict[str, str] = {
     "japanese": "JP",
+    # ``korea`` (the bare name) is also routed here rather than via
+    # ``name_to_iso`` because pycountry's ``search_fuzzy`` could surface
+    # KP (DPRK) before KR (ROK) depending on version ordering. Pinning
+    # the contemporary South Korea is what users mean for film queries.
+    "korea": "KR",
     "korean": "KR",
     "french": "FR",
     "british": "GB",
@@ -103,7 +108,8 @@ _DEMONYM_TO_ISO: dict[str, str] = {
 # query-router hot path effectively a pair of dict lookups per token.
 _COUNTRY_NAME_TOKENS: tuple[str, ...] = (
     "japan",
-    "korea",
+    # ``korea`` deliberately omitted — handled via _DEMONYM_TO_ISO above
+    # to avoid pycountry's ambiguous fuzzy match between KP and KR.
     "france",
     "britain",
     "germany",
@@ -129,9 +135,14 @@ _COUNTRY_NAME_TOKENS: tuple[str, ...] = (
 # ``during the Cold War``, ``about France``), not a production-country
 # signal. Tokenisation is whitespace + punctuation strip; window size of 5
 # tokens covers ``set in / during / about <country>`` plus 1–2
-# determiners or prepositions.
+# determiners or prepositions. ``'in'`` is deliberately excluded — it's
+# the most common English preposition and over-suppresses production-
+# location queries (``filmed in France``, ``movies made in Japan``,
+# ``interested in Japanese cinema``). Every documented plot-setting
+# phrasing carries a stronger marker (``set`` / ``during`` / ``about``
+# / ``takes`` / ``place``); council review (PR #244) confirmed.
 _PLOT_SETTING_MARKERS: frozenset[str] = frozenset(
-    {"set", "in", "during", "about", "takes", "place"}
+    {"set", "during", "about", "takes", "place"}
 )
 _PLOT_SETTING_WINDOW = 5
 

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -81,15 +81,6 @@ class SearchService:
         """
         return self._person_index
 
-    @property
-    def foreign_film_home_countries(self) -> list[str]:
-        """Read-only copy of the home-country set for the foreign-film route.
-
-        The eval harness reads this so curated cases route through the
-        same negation set the live deploy does.
-        """
-        return list(self._home_countries)
-
     async def search(
         self,
         query: str,
@@ -328,6 +319,9 @@ class SearchService:
             else None
         )
         ratings = intent.ratings if (self._filter_rating and intent.ratings) else None
+        # No `intent_filter_country_enabled` switch by design — Spec 25
+        # ships the country dimension as always-on alongside genre. If a
+        # noisy filter ever needs muting, add the flag at that point.
         countries = intent.countries if intent.countries else None
 
         if not people and year_range is None and not ratings and not countries:
@@ -340,16 +334,14 @@ class SearchService:
             countries=countries,
             countries_negate=intent.countries_negate,
         )
+        country_label = "country_negate" if intent.countries_negate else "country"
         signals = [
             label
             for label, present in (
                 ("person", bool(people)),
                 ("year", year_range is not None),
                 ("rating", bool(ratings)),
-                (
-                    "country_negate" if intent.countries_negate else "country",
-                    bool(countries),
-                ),
+                (country_label, bool(countries)),
             )
             if present
         ]

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -52,6 +52,7 @@ class SearchService:
         intent_filter_year_enabled: bool = True,
         intent_filter_rating_enabled: bool = True,
         rewriter: QueryRewriter | None = None,
+        foreign_film_home_countries: list[str] | None = None,
     ) -> None:
         self._ollama = ollama_client
         self._vec_repo = vec_repo
@@ -66,6 +67,7 @@ class SearchService:
         self._filter_year = intent_filter_year_enabled
         self._filter_rating = intent_filter_rating_enabled
         self._rewriter = rewriter
+        self._home_countries: list[str] = list(foreign_film_home_countries or [])
         self._status_cache: SearchStatus | None = None
         self._status_cache_time: float = 0.0
         self._status_cache_ttl: float = 30.0  # seconds
@@ -78,6 +80,15 @@ class SearchService:
         configuration without reaching into private state.
         """
         return self._person_index
+
+    @property
+    def foreign_film_home_countries(self) -> list[str]:
+        """Read-only copy of the home-country set for the foreign-film route.
+
+        The eval harness reads this so curated cases route through the
+        same negation set the live deploy does.
+        """
+        return list(self._home_countries)
 
     async def search(
         self,
@@ -281,7 +292,9 @@ class SearchService:
         if self._person_index is None:
             return query, None, None
 
-        intent = detect_intent(query, self._person_index)
+        intent = detect_intent(
+            query, self._person_index, home_countries=self._home_countries
+        )
         if intent.has_signals():
             return query, await self._apply_filter(intent), intent
 
@@ -289,7 +302,11 @@ class SearchService:
         if intent.is_paraphrastic and self._rewriter is not None:
             rewritten = await self._rewriter.rewrite(query)
             if rewritten != query:
-                rewritten_intent = detect_intent(rewritten, self._person_index)
+                rewritten_intent = detect_intent(
+                    rewritten,
+                    self._person_index,
+                    home_countries=self._home_countries,
+                )
                 self._log_chain(intent, rewritten_intent)
                 if rewritten_intent.has_signals():
                     return (
@@ -311,12 +328,17 @@ class SearchService:
             else None
         )
         ratings = intent.ratings if (self._filter_rating and intent.ratings) else None
+        countries = intent.countries if intent.countries else None
 
-        if not people and year_range is None and not ratings:
+        if not people and year_range is None and not ratings and not countries:
             return None
 
         filter_ids = await self._library.search_filtered_ids(
-            people=people, year_range=year_range, ratings=ratings
+            people=people,
+            year_range=year_range,
+            ratings=ratings,
+            countries=countries,
+            countries_negate=intent.countries_negate,
         )
         signals = [
             label
@@ -324,6 +346,10 @@ class SearchService:
                 ("person", bool(people)),
                 ("year", year_range is not None),
                 ("rating", bool(ratings)),
+                (
+                    "country_negate" if intent.countries_negate else "country",
+                    bool(countries),
+                ),
             )
             if present
         ]

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -364,6 +364,8 @@ class SearchService:
             gained.append("year_filter")
         if rewritten.ratings and not original.ratings:
             gained.append("rating_filter")
+        if rewritten.countries and not original.countries:
+            gained.append("country_filter")
         if rewritten.genres and not original.genres:
             gained.append("genre_rerank")
         for kind in gained:

--- a/backend/tests/fixtures/query_router_cases.json
+++ b/backend/tests/fixtures/query_router_cases.json
@@ -121,5 +121,34 @@
     "expected_genres": ["Action"],
     "must_include_titles": ["Die Hard"],
     "notes": "Person + year + genre — the rare three-signal intent. AND-intersect should keep Die Hard as the survivor."
+  },
+  {
+    "query": "movies from Japan",
+    "expected_path": "country",
+    "expected_genres": [],
+    "must_include_titles": ["Spirited Away"],
+    "must_exclude_titles": ["Alien", "Die Hard"],
+    "notes": "Spec 25 — pure country signal, no genre. Filter SQL must keep only rows whose production_countries contains JP; substring leak via tags must not occur."
+  },
+  {
+    "query": "Japanese animation",
+    "expected_path": "country",
+    "expected_genres": ["Animation"],
+    "must_include_titles": ["Spirited Away"],
+    "notes": "Spec 25 — country + genre intersection. Country path wins precedence over keyword; the genre rerank still surfaces Animation."
+  },
+  {
+    "query": "British horror comedy",
+    "expected_path": "country",
+    "expected_genres": ["Horror", "Comedy"],
+    "must_include_titles": ["Shaun of the Dead"],
+    "notes": "Spec 25 — demonym + multi-genre. GB country filter narrows to UK films; horror+comedy genre rerank surfaces Shaun of the Dead."
+  },
+  {
+    "query": "movies set in Japan during WWII",
+    "expected_path": "rewrite",
+    "expected_genres": [],
+    "must_include_titles": [],
+    "notes": "Spec 25 — plot-setting boundary. ``set in Japan`` must NOT trigger the country filter; with no other structured signals the query falls through to the rewriter (paraphrastic, 6 words)."
   }
 ]

--- a/backend/tests/fixtures/query_router_cases.live.example.json
+++ b/backend/tests/fixtures/query_router_cases.live.example.json
@@ -161,5 +161,54 @@
     "expected_genres": ["Action"],
     "must_include_titles": ["Die Hard"],
     "notes": "Three-signal AND-intersect (person+year+genre). Library has McTiernan directing Die Hard, Die Hard 3, Medicine Man — only Die Hard fits 80s + action."
+  },
+  {
+    "query": "Something weird and adult from Japan",
+    "expected_path": "country",
+    "expected_genres": [],
+    "must_include_titles": [],
+    "notes": "Spec 25 motivating query #1. Country (JP) filter narrows the candidate set; cosine within picks weird/adult Japanese cinema (RoboGeisha, Tokyo Gore Police, etc.)."
+  },
+  {
+    "query": "Korean horror",
+    "expected_path": "country",
+    "expected_genres": ["Horror"],
+    "must_include_titles": [],
+    "notes": "Spec 25 motivating query #2. Demonym (KR) + horror genre — both signals fire; country wins path precedence, genre still informs rerank."
+  },
+  {
+    "query": "French comedy",
+    "expected_path": "country",
+    "expected_genres": ["Comedy"],
+    "must_include_titles": [],
+    "notes": "Spec 25 motivating query #3. Demonym (FR) + comedy genre."
+  },
+  {
+    "query": "foreign film",
+    "expected_path": "country",
+    "expected_genres": [],
+    "must_include_titles": [],
+    "notes": "Spec 25 motivating query #4. Resolves to NOT-IN against FOREIGN_FILM_HOME_COUNTRIES (default US). countries_negate=True; SQL flips to NOT EXISTS."
+  },
+  {
+    "query": "Japanese animation",
+    "expected_path": "country",
+    "expected_genres": ["Animation"],
+    "must_include_titles": [],
+    "notes": "Spec 25 motivating query #5. Mirrors the curated case — exercises country+genre intersection on the live 1.8k-item library."
+  },
+  {
+    "query": "British thriller",
+    "expected_path": "country",
+    "expected_genres": ["Thriller"],
+    "must_include_titles": [],
+    "notes": "Spec 25 motivating query #6. Demonym (GB) + thriller genre."
+  },
+  {
+    "query": "non-American sci-fi",
+    "expected_path": "keyword",
+    "expected_genres": ["Science Fiction"],
+    "must_include_titles": [],
+    "notes": "Spec 25 motivating query #7. ``non-American`` is not yet a recognised negation phrasing — Spec 25 scoped extraction to ``foreign``; the genre signal still fires and the query routes to keyword (sci-fi rerank), but the country signal falls through. Documented limitation; widening the negation phrasing is tracked for a follow-up."
   }
 ]

--- a/backend/tests/integration/test_nfo_validation.py
+++ b/backend/tests/integration/test_nfo_validation.py
@@ -115,6 +115,35 @@ def test_movie_nfo_has_required_fields(nfo_path: Path) -> None:
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize(
+    ("movie_dir", "expected_country"),
+    [
+        ("Spirited Away (2001)", "Japan"),
+        ("Shaun of the Dead (2004)", "United Kingdom"),
+    ],
+)
+def test_country_fixture_has_country_element(
+    movie_dir: str, expected_country: str
+) -> None:
+    """Spec 25 — the two curated country fixtures carry full English country names.
+
+    Jellyfin's NFO parser expects the full English name; our backend then
+    converts to ISO via ``country_codes.name_to_iso`` at sync time. Pinning
+    the fixture content in this test guards against accidental edits that
+    would silently break ``query_router_cases.json`` country assertions.
+    """
+    nfo_path = _MEDIA_ROOT / "movies" / movie_dir / "movie.nfo"
+    tree = ET.parse(nfo_path)  # noqa: S314
+    countries = [
+        elem.text.strip() for elem in tree.getroot().findall("country") if elem.text
+    ]
+    assert expected_country in countries, (
+        f"{movie_dir} should declare <country>{expected_country}</country>; "
+        f"found {countries}"
+    )
+
+
+@pytest.mark.integration
 @pytest.mark.parametrize("nfo_path", _SHOW_NFOS, ids=_nfo_id)
 def test_show_nfo_has_required_fields(nfo_path: Path) -> None:
     """Each tvshow.nfo parses as valid XML with all required fields."""

--- a/backend/tests/pipeline/_router_eval_loader.py
+++ b/backend/tests/pipeline/_router_eval_loader.py
@@ -16,9 +16,9 @@ _FIXTURE_PATH = (
 )
 
 # Recognised values for ``expected_path``. Keep aligned with the spec's
-# six router strategies.
+# router strategies — Spec 24 introduced six, Spec 25 added ``country``.
 ALLOWED_PATHS = frozenset(
-    {"keyword", "person", "year", "rating", "rewrite", "semantic"}
+    {"keyword", "person", "year", "rating", "country", "rewrite", "semantic"}
 )
 
 

--- a/backend/tests/pipeline/test_query_router_eval.py
+++ b/backend/tests/pipeline/test_query_router_eval.py
@@ -127,7 +127,7 @@ async def test_query_router_case(
     detected = _detect_path(
         case.query,
         person_index,
-        home_countries=query_router_service.foreign_film_home_countries,
+        home_countries=list(query_router_service._home_countries),
     )
     if case.expected_path != "rating":
         # Rating cases will detect as 'rating' even when the column is

--- a/backend/tests/pipeline/test_query_router_eval.py
+++ b/backend/tests/pipeline/test_query_router_eval.py
@@ -84,15 +84,26 @@ async def query_router_service(
         yield service
 
 
-def _detect_path(query: str, person_index: PersonIndex) -> str:
-    """Map a query to one of the six expected_path values."""
-    intent = detect_intent(query, person_index)
+def _detect_path(
+    query: str,
+    person_index: PersonIndex,
+    home_countries: list[str] | None = None,
+) -> str:
+    """Map a query to one of the seven expected_path values.
+
+    Spec 25 adds the ``country`` path, sequenced after rating and before
+    keyword so a query like ``Japanese animation`` (country + genre) resolves
+    to country, while a pure-genre query still resolves to keyword.
+    """
+    intent = detect_intent(query, person_index, home_countries=home_countries)
     if intent.people:
         return "person"
     if intent.year_range is not None:
         return "year"
     if intent.ratings:
         return "rating"
+    if intent.countries:
+        return "country"
     if intent.genres:
         return "keyword"
     if intent.is_paraphrastic:
@@ -113,7 +124,11 @@ async def test_query_router_case(
 ) -> None:
     person_index = query_router_service.person_index
     assert person_index is not None
-    detected = _detect_path(case.query, person_index)
+    detected = _detect_path(
+        case.query,
+        person_index,
+        home_countries=query_router_service.foreign_film_home_countries,
+    )
     if case.expected_path != "rating":
         # Rating cases will detect as 'rating' even when the column is
         # NULL; we still record it but the title checks may not pass

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -435,6 +435,50 @@ def test_intent_filter_settings_validate_boolean() -> None:
         Settings()  # type: ignore[call-arg]
 
 
+# --- Spec 25 — country filter settings ---
+
+
+def test_foreign_film_home_countries_default_us() -> None:
+    """``FOREIGN_FILM_HOME_COUNTRIES`` defaults to ``["US"]``.
+
+    Used by the query router to resolve "foreign film" → NOT-IN
+    predicate against the operator's configured home country/countries.
+    """
+    env = _REQUIRED_ENV.copy()
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.foreign_film_home_countries == ["US"]
+
+
+def test_foreign_film_home_countries_comma_separated() -> None:
+    """Comma-separated env var produces a list (e.g., ``US,GB``).
+
+    Operators expect the documented commented-default form in
+    ``.env.example`` to round-trip — JSON-only parsing would silently
+    treat ``US,GB`` as a single string and break the foreign-film route.
+    """
+    env = {**_REQUIRED_ENV, "FOREIGN_FILM_HOME_COUNTRIES": "US,GB"}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.foreign_film_home_countries == ["US", "GB"]
+
+
+def test_foreign_film_home_countries_strips_whitespace() -> None:
+    """Whitespace around items in ``US, GB ,FR`` is trimmed."""
+    env = {**_REQUIRED_ENV, "FOREIGN_FILM_HOME_COUNTRIES": " US , GB ,FR "}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.foreign_film_home_countries == ["US", "GB", "FR"]
+
+
+def test_foreign_film_home_countries_uppercases_iso() -> None:
+    """ISO codes are normalised to upper-case for safe comparison."""
+    env = {**_REQUIRED_ENV, "FOREIGN_FILM_HOME_COUNTRIES": "us,gb"}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.foreign_film_home_countries == ["US", "GB"]
+
+
 # --- Spec 24 — rewriter / rewrite cache settings ---
 
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -479,6 +479,32 @@ def test_foreign_film_home_countries_uppercases_iso() -> None:
     assert s.foreign_film_home_countries == ["US", "GB"]
 
 
+def test_foreign_film_home_countries_rejects_full_name() -> None:
+    """Council review (PR #244) — ``USA`` / ``United States`` are typos
+    that previously passed silently; the foreign-film route then
+    NOT-EXISTS-against-nothing and returns the entire library with no
+    error. Operator gets a debugging nightmare. Validator now rejects
+    anything that isn't a 2-letter ISO 3166-1 alpha-2 code."""
+    env = {**_REQUIRED_ENV, "FOREIGN_FILM_HOME_COUNTRIES": "USA"}
+    with patch.dict(os.environ, env, clear=True), pytest.raises(ValidationError):
+        Settings()  # type: ignore[call-arg]
+
+
+def test_foreign_film_home_countries_rejects_unknown_code() -> None:
+    """Even a 2-letter input that isn't a real ISO code is rejected."""
+    env = {**_REQUIRED_ENV, "FOREIGN_FILM_HOME_COUNTRIES": "XX"}
+    with patch.dict(os.environ, env, clear=True), pytest.raises(ValidationError):
+        Settings()  # type: ignore[call-arg]
+
+
+def test_foreign_film_home_countries_accepts_empty_string() -> None:
+    """Setting the env var to empty string disables the foreign-film route."""
+    env = {**_REQUIRED_ENV, "FOREIGN_FILM_HOME_COUNTRIES": ""}
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.foreign_film_home_countries == []
+
+
 # --- Spec 24 — rewriter / rewrite cache settings ---
 
 

--- a/backend/tests/test_intent.py
+++ b/backend/tests/test_intent.py
@@ -163,6 +163,105 @@ class TestDetectIntentCombinations:
         assert frozenset({"Action"}) in intent.genres
 
 
+class TestDetectIntentCountries:
+    """Spec 25 — country/origin signal extraction.
+
+    Country phrases (full names + demonyms) map to ISO 3166-1 alpha-2 codes
+    and land on ``QueryIntent.countries``. Plot-setting phrasings
+    (``"set in"``, ``"during"``, ``"about"``, ``"takes place in"``)
+    suppress extraction so the router doesn't filter on what is
+    semantically a setting.
+    """
+
+    def test_country_name_maps_to_iso(self) -> None:
+        intent = detect_intent("movies from Japan", _EMPTY_INDEX)
+        assert intent.countries == ["JP"]
+
+    def test_demonym_maps_to_iso(self) -> None:
+        intent = detect_intent("Korean horror", _EMPTY_INDEX)
+        assert intent.countries == ["KR"]
+
+    def test_french_demonym(self) -> None:
+        intent = detect_intent("a French comedy", _EMPTY_INDEX)
+        assert intent.countries == ["FR"]
+
+    def test_british_demonym(self) -> None:
+        intent = detect_intent("British thriller", _EMPTY_INDEX)
+        assert intent.countries == ["GB"]
+
+    def test_country_intersects_with_genre(self) -> None:
+        intent = detect_intent("Japanese animation", _EMPTY_INDEX)
+        assert intent.countries == ["JP"]
+        assert frozenset({"Animation"}) in intent.genres
+
+    def test_plot_setting_phrase_does_not_trigger(self) -> None:
+        """``set in Japan`` is a plot setting, not a production-country signal."""
+        intent = detect_intent("movies set in Japan during WWII", _EMPTY_INDEX)
+        assert intent.countries == []
+
+    def test_takes_place_in_does_not_trigger(self) -> None:
+        intent = detect_intent("a film that takes place in France", _EMPTY_INDEX)
+        assert intent.countries == []
+
+    def test_about_japan_does_not_trigger(self) -> None:
+        intent = detect_intent("a documentary about Japan", _EMPTY_INDEX)
+        assert intent.countries == []
+
+    def test_signal_present_disables_paraphrastic(self) -> None:
+        """A country signal counts as a structured signal.
+
+        ``is_paraphrastic`` must therefore be False even when the query
+        is wordy enough to satisfy the paraphrastic threshold.
+        """
+        intent = detect_intent("movies from Japan with a quiet mood", _EMPTY_INDEX)
+        assert intent.countries == ["JP"]
+        assert intent.is_paraphrastic is False
+        assert intent.has_signals() is True
+
+
+class TestDetectIntentForeignFilm:
+    """Spec 25 — ``foreign film`` resolves to a NOT-IN intent.
+
+    The router carries ``countries`` + ``countries_negate=True`` so
+    ``LibraryStore.search_filtered_ids`` flips to ``NOT EXISTS`` against
+    the home set. The home set comes from
+    ``settings.foreign_film_home_countries`` and is injected by the
+    caller; the intent layer reads a ``home_countries`` keyword for tests.
+    """
+
+    def test_foreign_film_resolves_to_negate(self) -> None:
+        intent = detect_intent("foreign film", _EMPTY_INDEX, home_countries=["US"])
+        assert intent.countries == ["US"]
+        assert intent.countries_negate is True
+
+    def test_foreign_movie_variant(self) -> None:
+        intent = detect_intent(
+            "looking for a foreign movie", _EMPTY_INDEX, home_countries=["US"]
+        )
+        assert intent.countries_negate is True
+
+    def test_foreign_cinema_variant(self) -> None:
+        intent = detect_intent(
+            "good foreign cinema", _EMPTY_INDEX, home_countries=["US"]
+        )
+        assert intent.countries_negate is True
+
+    def test_foreign_film_uses_multi_home_set(self) -> None:
+        """Multiple home countries (e.g. ``[US, GB]``) all flow through."""
+        intent = detect_intent(
+            "foreign film", _EMPTY_INDEX, home_countries=["US", "GB"]
+        )
+        assert intent.countries == ["US", "GB"]
+        assert intent.countries_negate is True
+
+    def test_foreign_film_no_home_set_skips(self) -> None:
+        """When ``home_countries`` is empty the router can't honour the negation
+        — ``countries`` stays empty and the query falls through unchanged."""
+        intent = detect_intent("foreign film", _EMPTY_INDEX, home_countries=[])
+        assert intent.countries == []
+        assert intent.countries_negate is False
+
+
 class TestDetectIntentWordBoundary:
     """Word-boundary edge cases — false positives must not fire."""
 

--- a/backend/tests/test_intent.py
+++ b/backend/tests/test_intent.py
@@ -36,6 +36,7 @@ class TestQueryIntentModel:
         assert QueryIntent(people=["eddie murphy"]).has_signals() is True
         assert QueryIntent(year_range=(1980, 1989)).has_signals() is True
         assert QueryIntent(ratings=["R"]).has_signals() is True
+        assert QueryIntent(countries=["JP"]).has_signals() is True
 
     def test_has_signals_false_when_paraphrastic_only(self) -> None:
         assert QueryIntent(is_paraphrastic=True).has_signals() is False
@@ -206,6 +207,28 @@ class TestDetectIntentCountries:
     def test_about_japan_does_not_trigger(self) -> None:
         intent = detect_intent("a documentary about Japan", _EMPTY_INDEX)
         assert intent.countries == []
+
+    def test_filmed_in_country_does_trigger(self) -> None:
+        """Council review (PR #244) — ``'in'`` was previously a plot-setting
+        marker, but ``filmed in France`` is a production-location query, not
+        a plot-setting. Removing ``'in'`` from ``_PLOT_SETTING_MARKERS`` is
+        safe because every documented plot-setting case has a stronger
+        marker (`set` / `during` / `about` / `takes` / `place`)."""
+        intent = detect_intent("filmed in France", _EMPTY_INDEX)
+        assert intent.countries == ["FR"]
+
+    def test_made_in_country_does_trigger(self) -> None:
+        intent = detect_intent("movies made in Japan", _EMPTY_INDEX)
+        assert intent.countries == ["JP"]
+
+    def test_korea_disambiguates_to_south_korea(self) -> None:
+        """``'korea'`` is a name pycountry's ``search_fuzzy`` could resolve
+        ambiguously between KP (DPRK) and KR (ROK) depending on version
+        ordering. The router must always resolve bare ``korea`` to the
+        contemporary South Korea (KR) — that's overwhelmingly what users
+        mean for movie/TV cinema queries. Council review pinned this."""
+        intent = detect_intent("movies from Korea", _EMPTY_INDEX)
+        assert intent.countries == ["KR"]
 
     def test_signal_present_disables_paraphrastic(self) -> None:
         """A country signal counts as a structured signal.

--- a/backend/tests/test_intent.py
+++ b/backend/tests/test_intent.py
@@ -230,6 +230,30 @@ class TestDetectIntentCountries:
         intent = detect_intent("movies from Korea", _EMPTY_INDEX)
         assert intent.countries == ["KR"]
 
+    def test_set_as_noun_does_not_suppress(self) -> None:
+        """Copilot review (PR #244) — ``'set'`` was a single-token marker,
+        but ``a set of Japanese films`` (set as a noun) tokenises with
+        ``set`` inside the suppression window before ``japanese`` and
+        suppressed extraction. The disambiguator is the phrase ``set in``
+        (verb + preposition), not the bare token. Multi-token check now
+        prevents the false negative while keeping ``set in Japan``
+        suppression intact."""
+        intent = detect_intent("a set of Japanese films", _EMPTY_INDEX)
+        assert intent.countries == ["JP"]
+
+    def test_set_in_phrase_still_suppresses(self) -> None:
+        """Regression guard for the multi-token plot-setting check —
+        ``set in`` (consecutive tokens) must still suppress."""
+        intent = detect_intent("movies set in Japan", _EMPTY_INDEX)
+        assert intent.countries == []
+
+    def test_movies_in_country_does_trigger(self) -> None:
+        """``'movies in Japan'`` is a production-location query, not a
+        plot-setting. With ``in`` and ``set`` correctly out of the
+        single-token marker set, this routes to country."""
+        intent = detect_intent("movies in Japan", _EMPTY_INDEX)
+        assert intent.countries == ["JP"]
+
     def test_signal_present_disables_paraphrastic(self) -> None:
         """A country signal counts as a structured signal.
 

--- a/backend/tests/test_library_store.py
+++ b/backend/tests/test_library_store.py
@@ -38,6 +38,8 @@ def _make_item(
     writers: list[str] | None = None,
     composers: list[str] | None = None,
     official_rating: str | None = None,
+    production_countries: list[str] | None = None,
+    country_synced_at: int | None = None,
 ) -> LibraryItemRow:
     """Helper to build LibraryItemRow with sensible defaults."""
     return LibraryItemRow(
@@ -57,6 +59,10 @@ def _make_item(
         writers=writers if writers is not None else ["Dan O'Bannon"],
         composers=composers if composers is not None else ["Jerry Goldsmith"],
         official_rating=official_rating,
+        production_countries=(
+            production_countries if production_countries is not None else []
+        ),
+        country_synced_at=country_synced_at,
     )
 
 
@@ -691,6 +697,172 @@ class TestSearchFilteredIds:
         )
         # AND-empty: empty set, not None and not exception (Q3-D)
         assert ids == set()
+
+
+class TestSearchFilteredIdsCountries:
+    """Spec 25 — country/origin dimension on ``search_filtered_ids``.
+
+    ``json_each(production_countries) WHERE value IN (...)`` predicate (not
+    ``LIKE``) so a row whose ``tags`` happen to contain a country-shaped
+    substring (e.g. ``"Japanese garden"``) does not leak into the filter
+    when ``countries=["JP"]``.
+    """
+
+    async def test_country_filter_matches_iso_codes(self, store: LibraryStore) -> None:
+        await store.upsert_many(
+            [
+                _make_item(
+                    jellyfin_id="jf-jp",
+                    title="Spirited Away",
+                    production_countries=["JP"],
+                    content_hash="h-jp",
+                ),
+                _make_item(
+                    jellyfin_id="jf-us",
+                    title="Die Hard",
+                    production_countries=["US"],
+                    content_hash="h-us",
+                ),
+            ]
+        )
+        ids = await store.search_filtered_ids(
+            people=None, year_range=None, ratings=None, countries=["JP"]
+        )
+        assert ids == {"jf-jp"}
+
+    async def test_country_filter_handles_co_production(
+        self, store: LibraryStore
+    ) -> None:
+        await store.upsert_many(
+            [
+                _make_item(
+                    jellyfin_id="jf-deus",
+                    title="Cloud Atlas",
+                    production_countries=["DE", "US"],
+                    content_hash="h-deus",
+                ),
+                _make_item(
+                    jellyfin_id="jf-fr",
+                    title="Amélie",
+                    production_countries=["FR"],
+                    content_hash="h-fr",
+                ),
+            ]
+        )
+        # Either DE or US should hit the co-production row.
+        ids_de = await store.search_filtered_ids(
+            people=None, year_range=None, ratings=None, countries=["DE"]
+        )
+        assert ids_de == {"jf-deus"}
+        ids_us = await store.search_filtered_ids(
+            people=None, year_range=None, ratings=None, countries=["US"]
+        )
+        assert ids_us == {"jf-deus"}
+
+    async def test_country_filter_no_substring_leak_via_tags(
+        self, store: LibraryStore
+    ) -> None:
+        """The new filter must use json_each on production_countries — not LIKE.
+
+        A row whose ``tags`` JSON contains the string ``"Japanese garden"``
+        must NOT match ``countries=["JP"]`` when its actual
+        ``production_countries`` is empty.
+        """
+        await store.upsert_many(
+            [
+                _make_item(
+                    jellyfin_id="jf-leak",
+                    title="The Garden",
+                    tags=["Japanese garden", "calm"],
+                    production_countries=[],
+                    content_hash="h-leak",
+                ),
+                _make_item(
+                    jellyfin_id="jf-real-jp",
+                    title="Tokyo Story",
+                    production_countries=["JP"],
+                    content_hash="h-real-jp",
+                ),
+            ]
+        )
+        ids = await store.search_filtered_ids(
+            people=None, year_range=None, ratings=None, countries=["JP"]
+        )
+        assert ids == {"jf-real-jp"}
+
+    async def test_country_filter_intersects_with_year(
+        self, store: LibraryStore
+    ) -> None:
+        await store.upsert_many(
+            [
+                _make_item(
+                    jellyfin_id="jf-jp-old",
+                    production_year=1985,
+                    production_countries=["JP"],
+                    content_hash="h-jp-old",
+                ),
+                _make_item(
+                    jellyfin_id="jf-jp-new",
+                    production_year=2015,
+                    production_countries=["JP"],
+                    content_hash="h-jp-new",
+                ),
+                _make_item(
+                    jellyfin_id="jf-us-old",
+                    production_year=1985,
+                    production_countries=["US"],
+                    content_hash="h-us-old",
+                ),
+            ]
+        )
+        ids = await store.search_filtered_ids(
+            people=None,
+            year_range=(1980, 1989),
+            ratings=None,
+            countries=["JP"],
+        )
+        assert ids == {"jf-jp-old"}
+
+    async def test_country_filter_negate_excludes_home_country(
+        self, store: LibraryStore
+    ) -> None:
+        """``countries_negate=True`` ⇒ NOT-EXISTS predicate.
+
+        Used by the foreign-film route — every row whose
+        ``production_countries`` does NOT include any ISO from the negate
+        set should match. Rows with no country data (``[]``) survive too;
+        ``json_each`` over an empty array produces no rows so the
+        ``NOT EXISTS`` is trivially true. The query router treats this
+        permissively — better to surface a maybe-foreign film than to
+        silently exclude it.
+        """
+        await store.upsert_many(
+            [
+                _make_item(
+                    jellyfin_id="jf-us",
+                    production_countries=["US"],
+                    content_hash="h-us",
+                ),
+                _make_item(
+                    jellyfin_id="jf-jp",
+                    production_countries=["JP"],
+                    content_hash="h-jp",
+                ),
+                _make_item(
+                    jellyfin_id="jf-empty",
+                    production_countries=[],
+                    content_hash="h-empty",
+                ),
+            ]
+        )
+        ids = await store.search_filtered_ids(
+            people=None,
+            year_range=None,
+            ratings=None,
+            countries=["US"],
+            countries_negate=True,
+        )
+        assert ids == {"jf-jp", "jf-empty"}
 
 
 class TestOfficialRating:

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -21,6 +21,7 @@ def _make_service(
     intent_filter_year_enabled: bool = True,
     intent_filter_rating_enabled: bool = True,
     rewriter: AsyncMock | None = None,
+    foreign_film_home_countries: list[str] | None = None,
 ) -> SearchService:
     """Build a SearchService with mocked dependencies.
 
@@ -58,6 +59,7 @@ def _make_service(
         intent_filter_year_enabled=intent_filter_year_enabled,
         intent_filter_rating_enabled=intent_filter_rating_enabled,
         rewriter=rewriter,
+        foreign_film_home_countries=foreign_film_home_countries,
     )
 
 
@@ -847,6 +849,178 @@ class TestSearchPipelineWithIntent:
             assert kwargs.get("people") in (None, [])
         # Cosine still ran (we're falling through to raw cosine)
         vec_repo.search.assert_awaited_once()
+
+
+class TestSearchPipelineCountryFilter:
+    """Spec 25 — country dimension wiring through the search pipeline.
+
+    Pins three invariants:
+    1. ``intent.countries`` reaches ``search_filtered_ids`` with the right
+       shape (4.11).
+    2. Country filter active → fetch window expands to the full library
+       size, mirroring the Spec 24 person-filter recall fix (4.15).
+    3. Rewriter-derived country signals survive end-to-end so a
+       paraphrastic query that the LLM rewrote to a country phrase still
+       routes through the structured country filter (4.16).
+    """
+
+    async def test_country_intent_passes_country_to_filter(self) -> None:
+        ollama = AsyncMock()
+        ollama.embed.return_value = make_embedding_result()
+        vec_repo = AsyncMock()
+        vec_repo.count.return_value = 100
+        vec_repo.search.return_value = [make_search_result("m-jp", 0.9)]
+        permissions = AsyncMock()
+        permissions.filter_permitted.side_effect = lambda *a, **k: a[2]
+        library = AsyncMock()
+        library.get_many.return_value = [make_library_item("m-jp", "Spirited Away")]
+        library.get_queue_counts.return_value = {
+            "pending": 0,
+            "processing": 0,
+            "failed": 0,
+        }
+        library.search_filtered_ids = AsyncMock(return_value={"m-jp"})
+
+        service = _make_service(
+            ollama=ollama,
+            vec_repo=vec_repo,
+            permissions=permissions,
+            library=library,
+            person_index=PersonIndex(names=frozenset()),
+        )
+        await service.search("movies from Japan", limit=10, user_id="u1", token="tok")
+
+        library.search_filtered_ids.assert_awaited_once()
+        kwargs = library.search_filtered_ids.call_args.kwargs
+        assert kwargs.get("countries") == ["JP"]
+        assert kwargs.get("countries_negate") is False
+
+    async def test_foreign_film_passes_negation_to_filter(self) -> None:
+        ollama = AsyncMock()
+        ollama.embed.return_value = make_embedding_result()
+        vec_repo = AsyncMock()
+        vec_repo.count.return_value = 100
+        vec_repo.search.return_value = []
+        permissions = AsyncMock()
+        permissions.filter_permitted.return_value = []
+        library = AsyncMock()
+        library.get_many.return_value = []
+        library.get_queue_counts.return_value = {
+            "pending": 0,
+            "processing": 0,
+            "failed": 0,
+        }
+        library.search_filtered_ids = AsyncMock(return_value=set())
+
+        service = _make_service(
+            library=library,
+            ollama=ollama,
+            vec_repo=vec_repo,
+            permissions=permissions,
+            person_index=PersonIndex(names=frozenset()),
+            foreign_film_home_countries=["US", "GB"],
+        )
+        await service.search("foreign film", limit=10, user_id="u1", token="tok")
+
+        library.search_filtered_ids.assert_awaited_once()
+        kwargs = library.search_filtered_ids.call_args.kwargs
+        assert kwargs.get("countries") == ["US", "GB"]
+        assert kwargs.get("countries_negate") is True
+
+    async def test_country_filter_expands_fetch_limit_to_library_size(self) -> None:
+        """Spec 25 — country dimension inherits the Spec 24 filter-aware-fetch
+        recall fix.
+
+        With a country filter narrowing to a small subset of a 1805-item
+        library, the cosine fetch window must widen to the full library
+        size so all country-matched items have a chance to surface in the
+        top-N. Without this, country-narrowed queries would silently lose
+        recall when the filter set sat below the default cosine top-N.
+        """
+        ollama = AsyncMock()
+        ollama.embed.return_value = make_embedding_result()
+        vec_repo = AsyncMock()
+        vec_repo.count.return_value = 1805  # full live library size
+        vec_repo.search.return_value = []
+        permissions = AsyncMock()
+        permissions.filter_permitted.return_value = []
+        library = AsyncMock()
+        library.get_many.return_value = []
+        library.get_queue_counts.return_value = {
+            "pending": 0,
+            "processing": 0,
+            "failed": 0,
+        }
+        library.search_filtered_ids = AsyncMock(return_value={"jf-jp-1"})
+
+        service = _make_service(
+            ollama=ollama,
+            vec_repo=vec_repo,
+            permissions=permissions,
+            library=library,
+            person_index=PersonIndex(names=frozenset()),
+            overfetch=5,
+        )
+        await service.search("movies from Japan", limit=10, user_id="u1", token="tok")
+
+        vec_repo.search.assert_awaited_once()
+        # Country filter active ⇒ fetch_limit reaches full library size,
+        # NOT the default limit×overfetch=50.
+        assert vec_repo.search.call_args.kwargs["limit"] == 1805
+
+    async def test_rewriter_country_signal_survives_to_filter(self) -> None:
+        """Spec 25 — rewriter pass-through.
+
+        Original query is paraphrastic with no signals; the rewriter
+        produces a country-bearing rewrite (e.g. ``"a Japanese
+        animation"``); the SearchService re-detects intent on the
+        rewrite, surfaces a country signal, and passes it into
+        ``search_filtered_ids``. Pins that the structurally-extracted
+        country signal isn't dropped on the rewrite branch — the country
+        dimension must work end-to-end whether the signal arrived in the
+        raw query or via the LLM rewrite.
+        """
+        ollama = AsyncMock()
+        ollama.embed.return_value = make_embedding_result()
+        vec_repo = AsyncMock()
+        vec_repo.count.return_value = 1805
+        vec_repo.search.return_value = []
+        permissions = AsyncMock()
+        permissions.filter_permitted.return_value = []
+        library = AsyncMock()
+        library.get_many.return_value = []
+        library.get_queue_counts.return_value = {
+            "pending": 0,
+            "processing": 0,
+            "failed": 0,
+        }
+        library.search_filtered_ids = AsyncMock(return_value={"jf-jp-1"})
+
+        rewriter = AsyncMock()
+        rewriter.rewrite = AsyncMock(return_value="Japanese animation")
+
+        service = _make_service(
+            ollama=ollama,
+            vec_repo=vec_repo,
+            permissions=permissions,
+            library=library,
+            person_index=PersonIndex(names=frozenset()),
+            rewriter=rewriter,
+        )
+        # 4-word paraphrastic query with no structural signals
+        await service.search(
+            "an evocative dreamlike film",
+            limit=10,
+            user_id="u1",
+            token="tok",
+        )
+
+        rewriter.rewrite.assert_awaited_once()
+        # The rewritten "Japanese animation" must trigger the country
+        # filter — not get dropped because the signal arrived after rewrite.
+        library.search_filtered_ids.assert_awaited_once()
+        kwargs = library.search_filtered_ids.call_args.kwargs
+        assert kwargs.get("countries") == ["JP"]
 
 
 class TestSearchPipelineRewriterGating:

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -1022,6 +1022,57 @@ class TestSearchPipelineCountryFilter:
         kwargs = library.search_filtered_ids.call_args.kwargs
         assert kwargs.get("countries") == ["JP"]
 
+    async def test_rewriter_country_gain_emits_log_chain(self, caplog: object) -> None:
+        """Council review (PR #244) — observability gap.
+
+        ``_log_chain`` previously emitted ``rewrite_chained_to_*`` log
+        lines for person/year/rating/genre but not country. Without this
+        line, an operator monitoring rewrite efficacy cannot tell when
+        the LLM is surfacing country signals from paraphrastic queries.
+        Log line shape mirrors the four existing dimensions.
+        """
+        import logging  # noqa: PLC0415
+
+        ollama = AsyncMock()
+        ollama.embed.return_value = make_embedding_result()
+        vec_repo = AsyncMock()
+        vec_repo.count.return_value = 1805
+        vec_repo.search.return_value = []
+        permissions = AsyncMock()
+        permissions.filter_permitted.return_value = []
+        library = AsyncMock()
+        library.get_many.return_value = []
+        library.get_queue_counts.return_value = {
+            "pending": 0,
+            "processing": 0,
+            "failed": 0,
+        }
+        library.search_filtered_ids = AsyncMock(return_value=set())
+
+        rewriter = AsyncMock()
+        rewriter.rewrite = AsyncMock(return_value="Japanese animation")
+
+        service = _make_service(
+            ollama=ollama,
+            vec_repo=vec_repo,
+            permissions=permissions,
+            library=library,
+            person_index=PersonIndex(names=frozenset()),
+            rewriter=rewriter,
+        )
+        with caplog.at_level(logging.INFO, logger="app.search.service"):  # type: ignore[attr-defined]
+            await service.search(
+                "an evocative dreamlike film",
+                limit=10,
+                user_id="u1",
+                token="tok",
+            )
+
+        messages = [r.getMessage() for r in caplog.records]  # type: ignore[attr-defined]
+        assert any("rewrite_chained_to_country_filter" in m for m in messages), (
+            f"expected country log_chain line, got: {messages}"
+        )
+
 
 class TestSearchPipelineRewriterGating:
     """Spec 24 Unit 5 — paraphrastic rewriter is invoked ONLY when intent

--- a/tests/fixtures/media/movies/Shaun of the Dead (2004)/movie.nfo
+++ b/tests/fixtures/media/movies/Shaun of the Dead (2004)/movie.nfo
@@ -19,6 +19,7 @@
     <role>Liz</role>
   </actor>
   <studio>Universal Pictures</studio>
+  <country>United Kingdom</country>
   <rating>7.9</rating>
   <runtime>99</runtime>
 </movie>

--- a/tests/fixtures/media/movies/Spirited Away (2001)/movie.nfo
+++ b/tests/fixtures/media/movies/Spirited Away (2001)/movie.nfo
@@ -19,6 +19,7 @@
     <role>Yubaba</role>
   </actor>
   <studio>Studio Ghibli</studio>
+  <country>Japan</country>
   <rating>8.6</rating>
   <runtime>125</runtime>
 </movie>


### PR DESCRIPTION
## Summary

Branch 2/3 of [Spec 25](docs/specs/25-spec-country-language-filter/) — adds the **read path** that makes the `production_countries` data persisted by Branch 1 (#240) actually steer recommendations. Country/origin becomes a structured filter dimension alongside person, year, and rating.

- New router signal: country names (Japan, Korea, France, …) + 23 demonyms (Japanese, Korean, French, …) → ISO 3166-1 alpha-2 codes; plot-setting markers (`set in`, `during`, `about`, `takes place`) suppress extraction in a 5-token backwards window so `movies set in Japan during WWII` doesn't trip the filter.
- New SQL predicate on `LibraryStore.search_filtered_ids`: `EXISTS (SELECT 1 FROM json_each(production_countries) WHERE value IN (...))` (or `NOT EXISTS` for the foreign-film route). Substring-leak guard pinned: a row with `tags='["Japanese garden"]'` and `production_countries='[]'` does NOT match `countries=["JP"]`.
- New negation route: `foreign film` / `foreign cinema` / `foreign movie` → `countries=settings.foreign_film_home_countries`, `countries_negate=True`, SQL flips to `NOT EXISTS`.
- New setting: `FOREIGN_FILM_HOME_COUNTRIES: list[str]` (default `["US"]`, comma-separated env var, normalised to upper-case ISO).
- Pinned regression invariants: filter-aware-fetch expansion (Spec 24's recall fix carries over to country) and rewriter pass-through (a country signal extracted from a paraphrastic rewrite still reaches the filter).
- Curated fixtures: 4 new cases on `query_router_cases.json` (now 21/21), 7 new motivating-query cases on `query_router_cases.live.example.json`, plus `<country>` elements on the Spirited Away and Shaun of the Dead NFOs.

## Test plan

- [x] `uv run pytest -m "not integration and not pipeline"` — 959 passed, 0 failed
- [x] `uv run ruff check . && uv run ruff format --check .` — clean across 157 files
- [x] `uv run pyright` — 0 errors, 0 warnings on touched files
- [ ] `make test-integration` — CI-driven; will exercise the new `<country>` NFO assertions
- [ ] `make validate-pipeline` — CI-driven; will exercise the 4 new curated router cases against live Ollama
- [ ] Live deploy + manual replay against `/srv/stacks/jellyfin` for "Something weird and adult from Japan", "Korean horror", "foreign film" — deferred to SDD-4 evidence capture, post-merge

## Branch sequencing

| Branch | Status |
|---|---|
| 1/3 — schema + sync + backfill | merged (#240, commit 62647a7) |
| **2/3 — router + filter SQL** | **this PR** |
| 3/3 — chat hardening (IDs in candidates + strengthened prompt + empty-result graceful path) | next branch |

🤖 Generated with [Claude Code](https://claude.com/claude-code)