### PR TITLE
refactor(search): expose home_countries property (#261)

### DIFF
--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -81,6 +81,15 @@ class SearchService:
         """
         return self._person_index
 
+    @property
+    def home_countries(self) -> list[str]:
+        """Read-only copy of configured foreign-film home-country ISO codes.
+
+        Mirrors ``person_index``: exposed for tests and eval harnesses
+        without reaching into private state.
+        """
+        return list(self._home_countries)
+
     async def search(
         self,
         query: str,

--- a/backend/tests/pipeline/test_query_router_eval.py
+++ b/backend/tests/pipeline/test_query_router_eval.py
@@ -72,7 +72,7 @@ async def test_query_router_case(
     detected = _detect_path(
         case.query,
         person_index,
-        home_countries=list(eval_search_service._home_countries),
+        home_countries=eval_search_service.home_countries,
     )
     if case.expected_path != "rating":
         # Rating cases will detect as 'rating' even when the column is

--- a/backend/tests/pipeline/test_retrieval_eval.py
+++ b/backend/tests/pipeline/test_retrieval_eval.py
@@ -63,7 +63,7 @@ async def test_retrieval_eval(
 
     person_index = eval_search_service.person_index
     assert person_index is not None
-    home_countries = list(eval_search_service._home_countries)
+    home_countries = eval_search_service.home_countries
 
     outcome = evaluate(cases, ranked, title_index, person_index, home_countries, ks=_KS)
 

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -63,6 +63,21 @@ def _make_service(
     )
 
 
+class TestHomeCountriesProperty:
+    def test_exposes_configured_codes(self) -> None:
+        service = _make_service(foreign_film_home_countries=["US", "GB"])
+        assert service.home_countries == ["US", "GB"]
+
+    def test_defaults_to_empty_list(self) -> None:
+        service = _make_service()
+        assert service.home_countries == []
+
+    def test_returns_a_copy(self) -> None:
+        service = _make_service(foreign_film_home_countries=["US"])
+        service.home_countries.append("FR")
+        assert service.home_countries == ["US"]
+
+
 class TestSearchPrependsQueryPrefix:
     async def test_embed_called_with_search_query_prefix(self) -> None:
         ollama = AsyncMock()

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -111,7 +111,7 @@ async def _amain(args: argparse.Namespace) -> int:
                 ranked,
                 title_index,
                 person_index,
-                list(service._home_countries),
+                service.home_countries,
                 ks=tuple(args.ks),
             )
             current = VecMeta(


### PR DESCRIPTION
## Summary

Adds a public `home_countries` property on `SearchService` (a read-only defensive copy, mirroring the existing `person_index` property) and migrates every caller that reached into the private `_home_countries`.

Closes #261.

## Context — relationship to #264

External contributor @shantoshdurai opened #264 with the property idea. That PR branched from `main` *before* #258 landed, so it could only touch the one call site that existed on `main` at the time (and that line was simultaneously refactored by #258, so #264 now conflicts). With #258 merged, **all** the real call sites — the eval harness, the router eval, and the standalone script — now exist on `main` and can be fixed in one pass.

This PR uses @shantoshdurai's property verbatim and credits them via `Co-authored-by`. #264 can be closed as superseded.

## Changes

- `backend/app/search/service.py` — new `home_countries` property
- `scripts/eval_retrieval.py` — use the property
- `backend/tests/pipeline/test_retrieval_eval.py` — use the property
- `backend/tests/pipeline/test_query_router_eval.py` — use the property
- `backend/tests/test_search_service.py` — 3 new tests (values, empty default, returns-a-copy)

## Verification

- `ruff check .` / `ruff format --check` — clean
- `pyright` — 0 errors
- `pytest -m "not integration and not ollama_integration"` — 1075 passed, 28 skipped
- `grep -rn "_home_countries" backend/tests/pipeline scripts` — no private access remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)