### PR TITLE
chore(eval): align retrieval eval flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ eval-router: ## Run query-router eval cases against live stack (Spec 24)
 
 eval-retrieval: ## Run retrieval eval (golden set -> IR metrics + regression gate) against live stack (Spec 26)
 	@curl -sf http://localhost:11434/ > /dev/null 2>&1 || { echo "ERROR: Ollama not reachable at http://localhost:11434/"; echo "Start Ollama first, or run: make pipeline-up"; exit 1; }
-	@$(MAKE) jellyfin-up && JELLYFIN_TEST_URL=http://localhost:8096 uv run --directory backend pytest -m pipeline -s -v tests/pipeline/test_retrieval_eval.py ; ret=$$?; $(MAKE) jellyfin-down; exit $$ret
+	@$(MAKE) jellyfin-up && JELLYFIN_TEST_URL=http://localhost:8096 uv run --directory backend pytest -m pipeline -v tests/pipeline/test_retrieval_eval.py ; ret=$$?; $(MAKE) jellyfin-down; exit $$ret
 
 # ---------------------------------------------------------------------------
 # Adversarial injection test harness


### PR DESCRIPTION
## Summary
- remove the redundant `-s` flag from `eval-retrieval`
- keep the target aligned with `eval-router` while still running the same retrieval eval pytest file

Fixes #263

## Validation
- `uv run python -m pytest -m pipeline -v tests/pipeline/test_retrieval_eval.py` *(collected the retrieval eval and skipped because the live pipeline prerequisites are unavailable locally)*
- `git diff --check`

## Notes
- I could not run `make eval-retrieval` end-to-end in this Windows environment because `make` and `ollama` are not installed here.