### PR TITLE
feat(chat-ui): structured chat output — frontend (Spec 27, PR 2/2)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,13 +60,33 @@ sequenceDiagram
     B->>L: get_many() for top permitted matches
     L-->>B: Full metadata from local SQLite
     Note over B: If candidates are empty, emit graceful<br/>text + done and skip Ollama (Spec 25)
-    B->>O: Chat completion (llama3.1:8b) via SSE<br/>System prompt + conversation history +<br/>matched movie context (with [ID:&lt;jellyfin_id&gt;]<br/>prefixes) + user query
+    B-->>F: SSE: metadata event (version 2, candidates + status)
+    B-->>F: SSE: status event (generating)
+    B->>O: Structured chat (llama3.1:8b) — Ollama `format` JSON schema,<br/>temperature 0, non-streaming (Spec 27).<br/>System prompt (+ schema) + history + [ID:] candidate context + query
     Note over B: Cooperative GPU pause: embedding worker<br/>yields GPU while chat is active
-    O-->>B: Streaming token chunks
-    B-->>F: SSE stream: metadata event → text chunks → done
-    B->>C: Store assistant turn (under lock)
-    F-->>U: Chat response + movie cards (streamed)
+    O-->>B: Grammar-constrained JSON payload<br/>{introductory_message, recommendations[{jellyfin_id, reasoning}]}
+    Note over B: Validate each jellyfin_id against the candidate set;<br/>drop hallucinated ids. Zero valid / parse error / timeout<br/>→ canned fallback (text + done, no picks event)
+    B-->>F: SSE: picks event (validated, 1-based order)
+    B-->>F: SSE: text (prose synthesized from picks) → done
+    B->>C: Store assistant turn + structured sidecar (under lock)
+    F-->>U: Cards + prose from one validated payload (cannot diverge)
 ```
+
+### Chat SSE event contract (Spec 27, version 2)
+
+The `metadata` event carries `version: 2`. Events are additive over the v1
+contract, so a v1 frontend ignores unknown event types and still works:
+
+- `metadata` — `{version: 2, recommendations: SearchResultItem[], search_status, turn_count}` (all candidates; instant)
+- `status` — `{phase: "generating"}` (staged wait state; emitted when generation begins)
+- `picks` — `{version: 2, picks: [{jellyfin_id, reasoning, pick_order}]}` (validated recommendations, LLM order; **absent on the fallback path**)
+- `text` — `{content}` (prose synthesized deterministically from the picks; one event, not token-streamed)
+- `done` — stream complete
+- `error` — only for pre-search failures (`search_unavailable`); generation failures degrade to the canned-text fallback, never an error event
+
+Generation is non-streaming (grammar-constrained decoding produces the whole
+payload at once), so the 120s chat timeout now bounds a single blocking call;
+the `status` event is the user-facing mitigation.
 
 ## Data Flow: Library Sync & Embedding
 
@@ -146,7 +166,7 @@ Rationale: Different access patterns (sessions are small/frequent; library is la
 ### Ollama
 - **Embedding model**: `nomic-embed-text` for library indexing (uses asymmetric `search_document:` / `search_query:` prefixes)
 - **Chat model**: `llama3.1:8b` for conversational recommendations
-- **Split clients**: `OllamaEmbeddingClient` (120s timeout, batch support) and `OllamaChatClient` (300s timeout, SSE streaming) — separate classes due to different I/O contracts
+- **Split clients**: `OllamaEmbeddingClient` (120s timeout, batch support) and `OllamaChatClient` (300s timeout; `chat_stream` for legacy streaming + `chat_structured` for grammar-constrained JSON via `format`, Spec 27) — separate classes due to different I/O contracts
 - **Deployment**: Either bundled sidecar or user's existing instance
 - **Constraint**: Single-model-at-a-time on consumer GPUs; cooperative GPU pause yields to chat when both are active
 
@@ -160,7 +180,7 @@ Rationale: Different access patterns (sessions are small/frequent; library is la
 - **Network**: Docker Compose maps backend port to `127.0.0.1:8000`. External access via existing reverse proxy (Caddy).
 - **Privacy**: All AI inference is local. Conversation history is in-memory only — never persisted to disk (PII constraint). No outbound calls to third-party metadata services — movie metadata comes from Jellyfin only.
 - **API hardening**: CORS restricted to frontend origin. `/docs` disabled in production. Rate limiting on login (5/min), chat (10/min), and search (10/min) endpoints. Security headers via middleware. Request validation errors return HTTP 422 (FastAPI/Pydantic convention), not 400.
-- **Prompt injection**: Soft mitigation via system prompt instructions plus structural separation — every candidate line carries a `[ID:<jellyfin_id>]` prefix and the framing constrains the model to "ONLY recommend movies from the following list of candidates." No hard sandboxing — Spec 25 (#238) shipped the soft-mitigation hardening (IDs in candidate context + strengthened system prompt + empty-result graceful path); Spec 27 (#239) tracks the structural fix via tool-calling / structured output.
+- **Prompt injection**: Structural mitigation via grammar-constrained output plus prompt separation. Spec 25 (#238) shipped the soft hardening (IDs in candidate context + strengthened system prompt + empty-result graceful path). **Spec 27 (#239) shipped the structural fix**: the LLM emits a JSON-schema-constrained payload (Ollama `format`), and the backend validates every `jellyfin_id` against the permission-filtered candidate set — the model can no longer fabricate a recommendation or smuggle one in via metadata, because card identity comes only from validated ids, not free text. Residual surface: the `reasoning`/`introductory_message` free-text fields remain attacker-influenceable (via crafted metadata) and are rendered through the sanitized markdown path — a severity reduction, not elimination. The fallback path is a canned message (never free-prose), so a forced structured-output failure cannot downgrade to the soft-prompt-only surface.
 - **Service worker**: Cache-first for static shell only. No API response or image caching — cross-user data leakage risk on shared household devices.
 - **Credential distinction**: Two types of Jellyfin credentials are used, with different handling:
   - **User tokens** (per-session): Encrypted at rest in `sessions.db` using Fernet with HKDF-derived keys. Never persisted to objects, never logged. Request-scoped — passed as parameters, not stored on instances.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,7 +60,7 @@ sequenceDiagram
     B->>L: get_many() for top permitted matches
     L-->>B: Full metadata from local SQLite
     Note over B: If candidates are empty, emit graceful<br/>text + done and skip Ollama (Spec 25)
-    B-->>F: SSE: metadata event (version 2, candidates + status)
+    B-->>F: SSE: metadata event (version 2, candidates + search_status)
     B-->>F: SSE: status event (generating)
     B->>O: Structured chat (llama3.1:8b) — Ollama `format` JSON schema,<br/>temperature 0, non-streaming (Spec 27).<br/>System prompt (+ schema) + history + [ID:] candidate context + query
     Note over B: Cooperative GPU pause: embedding worker<br/>yields GPU while chat is active

--- a/frontend/src/components/chat/__tests__/recommendation-sections.test.tsx
+++ b/frontend/src/components/chat/__tests__/recommendation-sections.test.tsx
@@ -78,6 +78,21 @@ describe("RecommendationSections", () => {
     expect(screen.getByLabelText("View details for Predator")).toBeTruthy();
   });
 
+  it("exposes pick status to screen readers via the accessible name", () => {
+    render(
+      <RecommendationSections
+        recommendations={RECS}
+        picks={PICKS}
+        onCardClick={vi.fn()}
+      />
+    );
+    // Picked cards announce "Recommended pick"; unpicked cards do not.
+    expect(
+      screen.getByLabelText("Recommended pick: View details for Galaxy Quest")
+    ).toBeTruthy();
+    expect(screen.getByLabelText("View details for The Thing")).toBeTruthy();
+  });
+
   it("falls back to a single plain carousel when no picks resolve", () => {
     render(
       <RecommendationSections

--- a/frontend/src/components/chat/__tests__/recommendation-sections.test.tsx
+++ b/frontend/src/components/chat/__tests__/recommendation-sections.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { RecommendationSections } from "../recommendation-sections";
+import type { PickItem, SearchResultItem } from "@/lib/api/types";
+
+afterEach(() => cleanup());
+
+function rec(jellyfin_id: string, title: string): SearchResultItem {
+  return {
+    jellyfin_id,
+    title,
+    overview: null,
+    genres: [],
+    year: null,
+    score: 0.8,
+    poster_url: `/p/${jellyfin_id}`,
+    community_rating: null,
+    runtime_minutes: null,
+    jellyfin_web_url: null,
+  };
+}
+
+const RECS = [
+  rec("a1", "Alien"),
+  rec("g1", "Galaxy Quest"),
+  rec("t1", "The Thing"),
+  rec("p1", "Predator"),
+];
+
+const PICKS: PickItem[] = [
+  { jellyfin_id: "g1", reasoning: "funny", pick_order: 1 },
+  { jellyfin_id: "a1", reasoning: "scary", pick_order: 2 },
+];
+
+describe("RecommendationSections", () => {
+  it("renders a Recommended section and a collapsed More matches disclosure", () => {
+    render(
+      <RecommendationSections
+        recommendations={RECS}
+        picks={PICKS}
+        onCardClick={vi.fn()}
+      />
+    );
+
+    // Recommended label present, with aria-live scoped to the label only.
+    const label = screen.getByText("Recommended");
+    expect(label).toHaveAttribute("aria-live", "polite");
+
+    // The "More matches" disclosure is collapsed by default and counts the rest.
+    const summary = screen.getByText(/More matches \(2\)/);
+    const details = summary.closest("details");
+    expect(details).not.toBeNull();
+    expect(details).not.toHaveAttribute("open");
+  });
+
+  it("shows picks in LLM order and the unpicked rest under the disclosure", () => {
+    render(
+      <RecommendationSections
+        recommendations={RECS}
+        picks={PICKS}
+        onCardClick={vi.fn()}
+      />
+    );
+
+    // Pick badges appear for the recommended cards (one ★ Pick per pick).
+    expect(screen.getAllByText("★ Pick")).toHaveLength(2);
+
+    // Recommended cards are Galaxy Quest (order 1) then Alien (order 2).
+    const recButtons = screen.getAllByLabelText(/View details for/);
+    const recommendedTitles = recButtons
+      .map((b) => b.getAttribute("aria-label"))
+      .filter((l) => l?.includes("Galaxy Quest") || l?.includes("Alien"));
+    expect(recommendedTitles[0]).toContain("Galaxy Quest");
+    expect(recommendedTitles[1]).toContain("Alien");
+
+    // The rest (The Thing, Predator) are present (inside the disclosure).
+    expect(screen.getByLabelText("View details for The Thing")).toBeTruthy();
+    expect(screen.getByLabelText("View details for Predator")).toBeTruthy();
+  });
+
+  it("falls back to a single plain carousel when no picks resolve", () => {
+    render(
+      <RecommendationSections
+        recommendations={RECS}
+        picks={[{ jellyfin_id: "UNKNOWN", reasoning: "x", pick_order: 1 }]}
+        onCardClick={vi.fn()}
+      />
+    );
+    // No Recommended label, no badges — just the plain candidate cards.
+    expect(screen.queryByText("Recommended")).toBeNull();
+    expect(screen.queryByText("★ Pick")).toBeNull();
+    expect(screen.getAllByLabelText(/View details for/)).toHaveLength(4);
+  });
+});

--- a/frontend/src/components/chat/card-carousel.tsx
+++ b/frontend/src/components/chat/card-carousel.tsx
@@ -7,9 +7,15 @@ import type { SearchResultItem } from "@/lib/api/types";
 interface CardCarouselProps {
   items: SearchResultItem[];
   onCardClick: (item: SearchResultItem) => void;
+  /** Spec 27 — mark every card in this carousel as a validated pick. */
+  isPick?: boolean;
 }
 
-export function CardCarousel({ items, onCardClick }: CardCarouselProps) {
+export function CardCarousel({
+  items,
+  onCardClick,
+  isPick = false,
+}: CardCarouselProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [activeIndex, setActiveIndex] = useState(0);
 
@@ -46,7 +52,11 @@ export function CardCarousel({ items, onCardClick }: CardCarouselProps) {
             key={item.jellyfin_id}
             className="w-[80vw] flex-shrink-0 snap-start md:w-auto"
           >
-            <MovieCard item={item} onClick={() => onCardClick(item)} />
+            <MovieCard
+              item={item}
+              onClick={() => onCardClick(item)}
+              isPick={isPick}
+            />
           </div>
         ))}
       </div>

--- a/frontend/src/components/chat/message-list.tsx
+++ b/frontend/src/components/chat/message-list.tsx
@@ -10,6 +10,7 @@ import type {
   SearchResultItem,
 } from "@/lib/api/types";
 import { CardCarousel } from "./card-carousel";
+import { RecommendationSections } from "./recommendation-sections";
 import { CardDetail } from "./card-detail";
 
 interface MessageListProps {
@@ -18,16 +19,31 @@ interface MessageListProps {
   onRetry?: (messageId: string) => void;
 }
 
-/** Dots animation for streaming loading state */
-function LoadingIndicator() {
+/** Dots animation + staged status text for the streaming loading state.
+ *
+ * Spec 27 — generation no longer streams tokens, so a tens-of-seconds wait can
+ * look frozen. A changing status line ("Searching…" → "Thinking about your
+ * picks…") keeps the app reading as alive (Adorabelle ruling). */
+function LoadingIndicator({
+  statusPhase,
+}: {
+  statusPhase?: "searching" | "generating";
+}) {
+  const label =
+    statusPhase === "generating"
+      ? "Thinking about your picks…"
+      : "Searching your library…";
   return (
     <div
-      className="flex items-center gap-1 px-4 py-2"
+      className="flex items-center gap-2 px-4 py-2"
       aria-label="Loading response"
     >
-      <span className="h-2 w-2 rounded-full bg-muted-foreground animate-bounce [animation-delay:0ms]" />
-      <span className="h-2 w-2 rounded-full bg-muted-foreground animate-bounce [animation-delay:150ms]" />
-      <span className="h-2 w-2 rounded-full bg-muted-foreground animate-bounce [animation-delay:300ms]" />
+      <span className="flex items-center gap-1" aria-hidden="true">
+        <span className="h-2 w-2 rounded-full bg-muted-foreground animate-bounce [animation-delay:0ms]" />
+        <span className="h-2 w-2 rounded-full bg-muted-foreground animate-bounce [animation-delay:150ms]" />
+        <span className="h-2 w-2 rounded-full bg-muted-foreground animate-bounce [animation-delay:300ms]" />
+      </span>
+      <span className="text-sm text-muted-foreground">{label}</span>
     </div>
   );
 }
@@ -171,7 +187,7 @@ export function MessageList({
               {msg.role === "assistant" ? (
                 <>
                   {msg.isStreaming && !msg.content ? (
-                    <LoadingIndicator />
+                    <LoadingIndicator statusPhase={msg.statusPhase} />
                   ) : (
                     <div className="prose prose-sm dark:prose-invert max-w-none break-words">
                       <ReactMarkdown
@@ -182,12 +198,22 @@ export function MessageList({
                       </ReactMarkdown>
                     </div>
                   )}
-                  {msg.recommendations && msg.recommendations.length > 0 && (
-                    <CardCarousel
-                      items={msg.recommendations}
-                      onCardClick={setSelectedMovie}
-                    />
-                  )}
+                  {msg.recommendations &&
+                    msg.recommendations.length > 0 &&
+                    (msg.picks && msg.picks.length > 0 ? (
+                      // Spec 27 v2 — two-section layout when the LLM picked.
+                      <RecommendationSections
+                        recommendations={msg.recommendations}
+                        picks={msg.picks}
+                        onCardClick={setSelectedMovie}
+                      />
+                    ) : (
+                      // No picks (legacy v1 backend or fallback) — plain carousel.
+                      <CardCarousel
+                        items={msg.recommendations}
+                        onCardClick={setSelectedMovie}
+                      />
+                    ))}
                   {msg.error && (
                     <MessageError
                       error={msg.error}

--- a/frontend/src/components/chat/message-list.tsx
+++ b/frontend/src/components/chat/message-list.tsx
@@ -34,10 +34,12 @@ function LoadingIndicator({
       ? "Thinking about your picks…"
       : "Searching your library…";
   return (
-    <div
-      className="flex items-center gap-2 px-4 py-2"
-      aria-label="Loading response"
-    >
+    // No container aria-label: it would override the visible staged text as the
+    // accessible name, hiding the "Searching…" → "Thinking…" phase change from
+    // screen readers (the whole point of the staged status). The decorative dots
+    // are aria-hidden, so the accessible name is the phase label, announced via
+    // the surrounding role="log" region.
+    <div className="flex items-center gap-2 px-4 py-2">
       <span className="flex items-center gap-1" aria-hidden="true">
         <span className="h-2 w-2 rounded-full bg-muted-foreground animate-bounce [animation-delay:0ms]" />
         <span className="h-2 w-2 rounded-full bg-muted-foreground animate-bounce [animation-delay:150ms]" />

--- a/frontend/src/components/chat/movie-card.tsx
+++ b/frontend/src/components/chat/movie-card.tsx
@@ -8,9 +8,11 @@ import type { SearchResultItem } from "@/lib/api/types";
 interface MovieCardProps {
   item: SearchResultItem;
   onClick: () => void;
+  /** Spec 27 — mark a card as one of the assistant's validated recommendations. */
+  isPick?: boolean;
 }
 
-export function MovieCard({ item, onClick }: MovieCardProps) {
+export function MovieCard({ item, onClick, isPick = false }: MovieCardProps) {
   const [posterError, setPosterError] = useState(false);
 
   const altText = item.year ? `${item.title} (${item.year})` : item.title;
@@ -26,7 +28,12 @@ export function MovieCard({ item, onClick }: MovieCardProps) {
         className="w-full text-left min-h-[44px]"
         aria-label={`View details for ${item.title}`}
       >
-        <div className="aspect-[2/3] overflow-hidden rounded-t-xl">
+        <div className="relative aspect-[2/3] overflow-hidden rounded-t-xl">
+          {isPick && (
+            <span className="absolute left-2 top-2 z-10 rounded-full bg-primary px-2 py-0.5 text-[10px] font-semibold text-primary-foreground shadow">
+              ★ Pick
+            </span>
+          )}
           {posterError || !item.poster_url ? (
             <PosterPlaceholder title={item.title} />
           ) : (

--- a/frontend/src/components/chat/movie-card.tsx
+++ b/frontend/src/components/chat/movie-card.tsx
@@ -26,7 +26,11 @@ export function MovieCard({ item, onClick, isPick = false }: MovieCardProps) {
         type="button"
         onClick={onClick}
         className="w-full text-left min-h-[44px]"
-        aria-label={`View details for ${item.title}`}
+        aria-label={
+          isPick
+            ? `Recommended pick: View details for ${item.title}`
+            : `View details for ${item.title}`
+        }
       >
         <div className="relative aspect-[2/3] overflow-hidden rounded-t-xl">
           {isPick && (

--- a/frontend/src/components/chat/recommendation-sections.tsx
+++ b/frontend/src/components/chat/recommendation-sections.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
 import { CardCarousel } from "./card-carousel";
 import type { PickItem, SearchResultItem } from "@/lib/api/types";
 
@@ -26,8 +26,14 @@ export function RecommendationSections({
   picks,
   onCardClick,
 }: RecommendationSectionsProps) {
-  const byId = new Map(recommendations.map((r) => [r.jellyfin_id, r]));
-  const pickIds = new Set(picks.map((p) => p.jellyfin_id));
+  const byId = useMemo(
+    () => new Map(recommendations.map((r) => [r.jellyfin_id, r])),
+    [recommendations]
+  );
+  const pickIds = useMemo(
+    () => new Set(picks.map((p) => p.jellyfin_id)),
+    [picks]
+  );
 
   // Recommended: picks in LLM order, resolved against the candidate set.
   const recommended = picks

--- a/frontend/src/components/chat/recommendation-sections.tsx
+++ b/frontend/src/components/chat/recommendation-sections.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React from "react";
+import { CardCarousel } from "./card-carousel";
+import type { PickItem, SearchResultItem } from "@/lib/api/types";
+
+interface RecommendationSectionsProps {
+  recommendations: SearchResultItem[];
+  picks: PickItem[];
+  onCardClick: (item: SearchResultItem) => void;
+}
+
+/**
+ * Spec 27 — two-section card layout (Adorabelle ruling).
+ *
+ * The validated picks render first as a labelled "Recommended" carousel (in the
+ * LLM's order, badged); the remaining candidates sit behind a collapsed
+ * "More matches" disclosure. Two DISTINCT carousels — not an in-place mutation
+ * of one scroll container — so a phone user mid-swipe is never stranded.
+ *
+ * `aria-live="polite"` is scoped to the section LABEL only (a single
+ * announcement), never the cards, so screen readers aren't flooded per card.
+ */
+export function RecommendationSections({
+  recommendations,
+  picks,
+  onCardClick,
+}: RecommendationSectionsProps) {
+  const byId = new Map(recommendations.map((r) => [r.jellyfin_id, r]));
+  const pickIds = new Set(picks.map((p) => p.jellyfin_id));
+
+  // Recommended: picks in LLM order, resolved against the candidate set.
+  const recommended = picks
+    .map((p) => byId.get(p.jellyfin_id))
+    .filter((r): r is SearchResultItem => r !== undefined);
+
+  // More matches: candidates the model didn't pick.
+  const rest = recommendations.filter((r) => !pickIds.has(r.jellyfin_id));
+
+  if (recommended.length === 0) {
+    // Defensive: no resolvable picks — fall back to a single plain carousel.
+    return <CardCarousel items={recommendations} onCardClick={onCardClick} />;
+  }
+
+  return (
+    <div className="mt-1">
+      <p
+        aria-live="polite"
+        className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+      >
+        Recommended
+      </p>
+      <CardCarousel items={recommended} onCardClick={onCardClick} isPick />
+
+      {rest.length > 0 && (
+        <details className="mt-3 group">
+          <summary className="inline-flex min-h-11 cursor-pointer items-center text-sm font-medium text-muted-foreground hover:text-foreground">
+            More matches ({rest.length})
+          </summary>
+          <CardCarousel items={rest} onCardClick={onCardClick} />
+        </details>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/__tests__/use-chat-structured.test.ts
+++ b/frontend/src/hooks/__tests__/use-chat-structured.test.ts
@@ -1,0 +1,131 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useChat } from "../use-chat";
+import type { SSEEvent } from "@/lib/api/types";
+
+vi.mock("@/lib/api/chat-stream", () => ({
+  sendChatMessage: vi.fn(),
+  parseSSEStream: vi.fn(),
+}));
+vi.mock("@/lib/api/client", () => ({
+  apiDelete: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { sendChatMessage, parseSSEStream } from "@/lib/api/chat-stream";
+
+async function* gen(events: SSEEvent[]): AsyncGenerator<SSEEvent> {
+  for (const e of events) yield e;
+}
+
+function mockStream(events: SSEEvent[]) {
+  vi.mocked(sendChatMessage).mockResolvedValue(
+    {} as ReadableStream<Uint8Array>
+  );
+  vi.mocked(parseSSEStream).mockReturnValue(gen(events));
+}
+
+const META = (recs: { jellyfin_id: string; title: string }[]): SSEEvent => ({
+  type: "metadata",
+  version: 2,
+  recommendations: recs.map((r) => ({
+    jellyfin_id: r.jellyfin_id,
+    title: r.title,
+    overview: null,
+    genres: [],
+    year: null,
+    score: 0.8,
+    poster_url: `/p/${r.jellyfin_id}`,
+    community_rating: null,
+    runtime_minutes: null,
+    jellyfin_web_url: null,
+  })),
+  search_status: "ok",
+  turn_count: 1,
+});
+
+describe("useChat — Spec 27 structured output", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      "crypto",
+      Object.assign({}, globalThis.crypto, {
+        randomUUID: vi
+          .fn()
+          .mockReturnValueOnce("user-1")
+          .mockReturnValueOnce("assistant-1"),
+      })
+    );
+  });
+
+  it("stores picks and clears status on the assistant message", async () => {
+    mockStream([
+      META([
+        { jellyfin_id: "a1", title: "Alien" },
+        { jellyfin_id: "g1", title: "Galaxy Quest" },
+      ]),
+      { type: "status", phase: "generating" },
+      {
+        type: "picks",
+        version: 2,
+        picks: [{ jellyfin_id: "g1", reasoning: "funny", pick_order: 1 }],
+      },
+      { type: "text", content: "1. **Galaxy Quest** — funny" },
+      { type: "done" },
+    ]);
+
+    const { result } = renderHook(() => useChat());
+    act(() => result.current.sendMessage("like alien but funny"));
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    const assistant = result.current.messages.find(
+      (m) => m.role === "assistant"
+    );
+    expect(assistant?.picks).toEqual([
+      { jellyfin_id: "g1", reasoning: "funny", pick_order: 1 },
+    ]);
+    expect(assistant?.statusPhase).toBeUndefined();
+    expect(assistant?.recommendations).toHaveLength(2);
+    expect(assistant?.content).toContain("Galaxy Quest");
+  });
+
+  it("ignores unknown event types without crashing (backward-compat)", async () => {
+    mockStream([
+      META([{ jellyfin_id: "a1", title: "Alien" }]),
+      // An event type this client version doesn't know about.
+      { type: "future_event", surprise: true } as unknown as SSEEvent,
+      { type: "text", content: "hi" },
+      { type: "done" },
+    ]);
+
+    const { result } = renderHook(() => useChat());
+    act(() => result.current.sendMessage("hello"));
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+    const assistant = result.current.messages.find(
+      (m) => m.role === "assistant"
+    );
+    expect(assistant?.content).toBe("hi");
+    expect(assistant?.error).toBeUndefined();
+  });
+
+  it("leaves picks undefined when no picks event arrives (v1 / fallback)", async () => {
+    mockStream([
+      META([{ jellyfin_id: "a1", title: "Alien" }]),
+      { type: "status", phase: "generating" },
+      { type: "text", content: "couldn't put together a recommendation" },
+      { type: "done" },
+    ]);
+
+    const { result } = renderHook(() => useChat());
+    act(() => result.current.sendMessage("hi"));
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+    const assistant = result.current.messages.find(
+      (m) => m.role === "assistant"
+    );
+    expect(assistant?.picks).toBeUndefined();
+    expect(assistant?.recommendations).toHaveLength(1);
+  });
+});

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -6,6 +6,7 @@ import { apiDelete } from "@/lib/api/client";
 import { TRIGGERED_KEY } from "@/hooks/use-install-prompt";
 import type {
   ChatMessage,
+  PickItem,
   SearchResultItem,
   SearchStatus,
   ChatErrorCode,
@@ -34,6 +35,8 @@ type ChatAction =
         searchStatus: SearchStatus;
       };
     }
+  | { type: "SET_STATUS"; payload: { id: string; phase: "generating" } }
+  | { type: "SET_PICKS"; payload: { id: string; picks: PickItem[] } }
   | { type: "SET_STREAMING_DONE"; payload: { id: string; content: string } }
   | {
       type: "SET_ERROR";
@@ -72,7 +75,11 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
     case "ADD_ASSISTANT_PLACEHOLDER":
       return {
         ...state,
-        messages: [...state.messages, action.payload],
+        // Spec 27 — staged wait state: searching until generation begins.
+        messages: [
+          ...state.messages,
+          { ...action.payload, statusPhase: "searching" },
+        ],
       };
     case "UPDATE_ASSISTANT_CONTENT":
       return {
@@ -96,6 +103,22 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
             : m
         ),
       };
+    case "SET_STATUS":
+      return {
+        ...state,
+        messages: state.messages.map((m) =>
+          m.id === action.payload.id
+            ? { ...m, statusPhase: action.payload.phase }
+            : m
+        ),
+      };
+    case "SET_PICKS":
+      return {
+        ...state,
+        messages: state.messages.map((m) =>
+          m.id === action.payload.id ? { ...m, picks: action.payload.picks } : m
+        ),
+      };
     case "SET_STREAMING_DONE":
       return {
         ...state,
@@ -105,6 +128,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
             ? {
                 ...m,
                 isStreaming: false,
+                statusPhase: undefined,
                 content: action.payload.content,
               }
             : m
@@ -252,6 +276,18 @@ export function useChat(): UseChatReturn {
                   recommendations: event.recommendations,
                   searchStatus: event.search_status,
                 },
+              });
+              break;
+            case "status":
+              dispatch({
+                type: "SET_STATUS",
+                payload: { id: assistantMessageId, phase: event.phase },
+              });
+              break;
+            case "picks":
+              dispatch({
+                type: "SET_PICKS",
+                payload: { id: assistantMessageId, picks: event.picks },
               });
               break;
             case "text":

--- a/frontend/src/lib/api/__tests__/chat-stream.test.ts
+++ b/frontend/src/lib/api/__tests__/chat-stream.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { parseSSEStream } from "../chat-stream";
+import type { SSEEvent } from "../types";
+
+/** Build a ReadableStream<Uint8Array> from an SSE wire string. */
+function streamFrom(text: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+async function collect(text: string): Promise<SSEEvent[]> {
+  const out: SSEEvent[] = [];
+  for await (const ev of parseSSEStream(streamFrom(text))) {
+    out.push(ev);
+  }
+  return out;
+}
+
+describe("parseSSEStream — Spec 27 v2 events", () => {
+  it("parses the full v2 success sequence", async () => {
+    const wire = [
+      `data: ${JSON.stringify({ type: "metadata", version: 2, recommendations: [], search_status: "ok", turn_count: 1 })}`,
+      `data: ${JSON.stringify({ type: "status", phase: "generating" })}`,
+      `data: ${JSON.stringify({ type: "picks", version: 2, picks: [{ jellyfin_id: "a1", reasoning: "scary", pick_order: 1 }] })}`,
+      `data: ${JSON.stringify({ type: "text", content: "1. **Alien**" })}`,
+      `data: ${JSON.stringify({ type: "done" })}`,
+    ]
+      .map((l) => `${l}\n\n`)
+      .join("");
+
+    const events = await collect(wire);
+    expect(events.map((e) => e.type)).toEqual([
+      "metadata",
+      "status",
+      "picks",
+      "text",
+      "done",
+    ]);
+  });
+
+  it("parses a picks event payload", async () => {
+    const events = await collect(
+      `data: ${JSON.stringify({ type: "picks", version: 2, picks: [{ jellyfin_id: "g1", reasoning: "funny", pick_order: 2 }] })}\n\n`
+    );
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.type).toBe("picks");
+    if (ev.type === "picks") {
+      expect(ev.picks[0]).toEqual({
+        jellyfin_id: "g1",
+        reasoning: "funny",
+        pick_order: 2,
+      });
+    }
+  });
+
+  it("silently skips malformed JSON frames", async () => {
+    const wire =
+      "data: not valid json {\n\n" +
+      `data: ${JSON.stringify({ type: "done" })}\n\n`;
+    const events = await collect(wire);
+    expect(events.map((e) => e.type)).toEqual(["done"]);
+  });
+});

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -122,7 +122,13 @@ export type ChatErrorCode =
 
 export interface MetadataEvent {
   type: "metadata";
-  /** 1 = legacy free-prose contract; 2 = Spec 27 structured output (adds status/picks). */
+  /**
+   * 1 = legacy free-prose contract; 2 = Spec 27 structured output (adds status/picks).
+   * Wire documentation only: the client does NOT branch on this value. v1/v2
+   * compatibility is governed by event PRESENCE — a `picks` event triggers the
+   * two-section layout; its absence falls back to the plain carousel. A future
+   * contract change should keep that presence-based dispatch in mind.
+   */
   version: 1 | 2;
   recommendations: SearchResultItem[];
   search_status: SearchStatus;
@@ -138,6 +144,13 @@ export interface StatusEvent {
 /** Spec 27 — a single validated recommendation in the LLM's order. */
 export interface PickItem {
   jellyfin_id: string;
+  /**
+   * LLM-authored, attacker-influenceable free text. MUST NOT be rendered as
+   * raw HTML. If ever displayed, route it through the sanitized markdown path
+   * (ReactMarkdown + rehypeSanitize), never `dangerouslySetInnerHTML`. Not
+   * rendered anywhere as of Spec 27 — card identity/metadata come from the
+   * validated SearchResultItem resolved by jellyfin_id, not from this field.
+   */
   reasoning: string;
   /** 1-based position in the model's recommendation list. */
   pick_order: number;

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -122,10 +122,32 @@ export type ChatErrorCode =
 
 export interface MetadataEvent {
   type: "metadata";
+  /** 1 = legacy free-prose contract; 2 = Spec 27 structured output (adds status/picks). */
   version: number;
   recommendations: SearchResultItem[];
   search_status: SearchStatus;
   turn_count: number;
+}
+
+/** Spec 27 — staged wait state emitted when LLM generation begins. */
+export interface StatusEvent {
+  type: "status";
+  phase: "generating";
+}
+
+/** Spec 27 — a single validated recommendation in the LLM's order. */
+export interface PickItem {
+  jellyfin_id: string;
+  reasoning: string;
+  /** 1-based position in the model's recommendation list. */
+  pick_order: number;
+}
+
+/** Spec 27 — terminal set of validated picks (version 2 contract). */
+export interface PicksEvent {
+  type: "picks";
+  version: number;
+  picks: PickItem[];
 }
 
 export interface TextEvent {
@@ -144,7 +166,13 @@ export interface ErrorEvent {
 }
 
 /** Discriminated union of all SSE event types from POST /api/chat */
-export type SSEEvent = MetadataEvent | TextEvent | DoneEvent | ErrorEvent;
+export type SSEEvent =
+  | MetadataEvent
+  | StatusEvent
+  | PicksEvent
+  | TextEvent
+  | DoneEvent
+  | ErrorEvent;
 
 // --- Chat message for client state ---
 
@@ -153,7 +181,11 @@ export interface ChatMessage {
   role: "user" | "assistant";
   content: string;
   recommendations?: SearchResultItem[];
+  /** Spec 27 — validated LLM picks (subset of recommendations, in LLM order). */
+  picks?: PickItem[];
   searchStatus?: SearchStatus;
+  /** Spec 27 — staged wait state while the response is being produced. */
+  statusPhase?: "searching" | "generating";
   error?: { code: ChatErrorCode; message: string };
   isStreaming?: boolean;
 }

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -123,7 +123,7 @@ export type ChatErrorCode =
 export interface MetadataEvent {
   type: "metadata";
   /** 1 = legacy free-prose contract; 2 = Spec 27 structured output (adds status/picks). */
-  version: number;
+  version: 1 | 2;
   recommendations: SearchResultItem[];
   search_status: SearchStatus;
   turn_count: number;
@@ -146,7 +146,7 @@ export interface PickItem {
 /** Spec 27 — terminal set of validated picks (version 2 contract). */
 export interface PicksEvent {
   type: "picks";
-  version: number;
+  version: 2;
   picks: PickItem[];
 }
 

--- a/frontend/tests/components/chat/message-list.test.tsx
+++ b/frontend/tests/components/chat/message-list.test.tsx
@@ -71,7 +71,7 @@ describe("MessageList", () => {
       <MessageList messages={[userMessage, streamingMsg]} isStreaming={true} />
     );
 
-    expect(screen.getByLabelText("Loading response")).toBeInTheDocument();
+    expect(screen.getByText("Searching your library…")).toBeInTheDocument();
   });
 
   it("does not show loading indicator when content has arrived", () => {
@@ -89,7 +89,9 @@ describe("MessageList", () => {
       />
     );
 
-    expect(screen.queryByLabelText("Loading response")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Searching your library…")
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/tests/e2e/chat/chat-structured-output.spec.ts
+++ b/frontend/tests/e2e/chat/chat-structured-output.spec.ts
@@ -36,8 +36,8 @@ import type { SSEEvent, SearchResultItem } from "../../../src/lib/api/types";
 interface MockStep {
   /** Delay (ms) added to the running clock before this frame is enqueued. */
   delayMs: number;
-  /** SSE event to emit; null = a pure delay (advance the clock, emit nothing). */
-  event: SSEEvent | null;
+  /** SSE event to emit at this point in the schedule. */
+  event: SSEEvent;
 }
 
 interface MockScenario {
@@ -179,7 +179,6 @@ function installChatStreamMock(scenario: MockScenario): void {
         for (const step of scenario.steps) {
           clock += step.delayMs;
           const frame = step.event;
-          if (frame === null) continue;
           setTimeout(() => {
             controller.enqueue(
               encoder.encode(`data: ${JSON.stringify(frame)}\n\n`)
@@ -228,8 +227,12 @@ test.describe("Structured chat output (v2 SSE)", () => {
     const searching = page.getByText("Searching your library…");
     const thinking = page.getByText("Thinking about your picks…");
 
-    // 1) Staged status — IN ORDER. "Searching…" first…
+    // 1) Staged status — IN ORDER. "Searching…" is visible while
+    //    "Thinking…" has NOT yet appeared — this proves the ORDER, not just
+    //    that both labels eventually rendered (toBeHidden resolves the instant
+    //    the element is absent, so it asserts the current frame, not a wait).
     await expect(searching).toBeVisible();
+    await expect(thinking).toBeHidden();
 
     // 2) …then transitions to "Thinking about your picks…" (and "Searching…"
     //    is gone — proving a real transition, not two overlapping labels).

--- a/frontend/tests/e2e/chat/chat-structured-output.spec.ts
+++ b/frontend/tests/e2e/chat/chat-structured-output.spec.ts
@@ -1,0 +1,299 @@
+/**
+ * Structured chat output E2E (Spec 27, version-2 SSE contract).
+ *
+ * Asserts the FRONTEND consumption of the v2 stream through a real browser:
+ *   - the staged status sequence renders IN ORDER
+ *     (loading → "Searching your library…" → "Thinking about your picks…"
+ *      → response with picks + prose together),
+ *   - the two-section layout ("Recommended" + collapsed "More matches"),
+ *   - the "Show more" disclosure reveals the remaining candidates,
+ *   - the canned fallback path (no picks) renders without a "Recommended" section.
+ *
+ * Design decision (recorded in the task file per the audit FLAG on 5.1):
+ * the /api/chat SSE response is mocked client-side via an injected window.fetch
+ * override that emits frames on a TIMED schedule. This is deliberate:
+ *   1. It makes the staged status sequence deterministic and observable —
+ *      Playwright cannot reliably catch a sub-millisecond "generating" flash if
+ *      the whole SSE body is delivered at once (route.fulfill has no streaming).
+ *   2. It lets us force the fallback (zero-valid-picks) path the live harness
+ *      cannot otherwise force — the audit's preferred remediation.
+ * Backend behaviour (search → structured generation → ID validation → fallback)
+ * is covered by the backend suite + the 2.6 router test; this spec owns the
+ * browser-level v2 contract consumption only.
+ *
+ * The auth/session and app shell are real (storageState from globalSetup);
+ * only the POST /api/chat stream is synthesized.
+ */
+
+import type { Page } from "@playwright/test";
+import { test, expect } from "../fixtures/auth.fixture";
+import type { SSEEvent, SearchResultItem } from "../../../src/lib/api/types";
+
+// ---------------------------------------------------------------------------
+// Mock scenario shape — plain serialisable data passed into addInitScript.
+// ---------------------------------------------------------------------------
+
+interface MockStep {
+  /** Delay (ms) added to the running clock before this frame is enqueued. */
+  delayMs: number;
+  /** SSE event to emit; null = a pure delay (advance the clock, emit nothing). */
+  event: SSEEvent | null;
+}
+
+interface MockScenario {
+  steps: MockStep[];
+}
+
+// ---------------------------------------------------------------------------
+// Fixture data
+// ---------------------------------------------------------------------------
+
+function makeCandidate(index: number): SearchResultItem {
+  return {
+    jellyfin_id: `mock-${index}`,
+    title: `Mock Movie ${index}`,
+    overview: `Overview for mock movie ${index}.`,
+    genres: ["Drama"],
+    year: 2000 + index,
+    score: 1 - index * 0.05,
+    poster_url: "",
+    community_rating: null,
+    runtime_minutes: 100 + index,
+    jellyfin_web_url: null,
+  };
+}
+
+const CANDIDATES: SearchResultItem[] = Array.from({ length: 5 }, (_, i) =>
+  makeCandidate(i + 1)
+);
+
+const SUCCESS_PROSE =
+  "Based on your taste, these two should land well together.";
+const CANNED_FALLBACK =
+  "I could not find a confident match in your library for that. Try rephrasing?";
+
+/**
+ * Success scenario: metadata → status(generating) → picks → text → done.
+ * The model "picks" the first two candidates, leaving three under "More matches".
+ * Timing is spaced so each staged status phase is comfortably observable.
+ */
+const SUCCESS_SCENARIO: MockScenario = {
+  steps: [
+    // ~900ms of "Searching your library…" before search results land.
+    {
+      delayMs: 900,
+      event: {
+        type: "metadata",
+        version: 2,
+        recommendations: CANDIDATES,
+        search_status: "ok",
+        turn_count: 1,
+      },
+    },
+    // Same tick: generation begins → "Thinking about your picks…".
+    { delayMs: 0, event: { type: "status", phase: "generating" } },
+    // ~900ms of "Thinking…" before the structured result is validated.
+    {
+      delayMs: 900,
+      event: {
+        type: "picks",
+        version: 2,
+        picks: [
+          {
+            jellyfin_id: "mock-1",
+            reasoning: "Tense and character-driven.",
+            pick_order: 1,
+          },
+          {
+            jellyfin_id: "mock-2",
+            reasoning: "A funnier companion piece.",
+            pick_order: 2,
+          },
+        ],
+      },
+    },
+    { delayMs: 30, event: { type: "text", content: SUCCESS_PROSE } },
+    { delayMs: 30, event: { type: "done" } },
+  ],
+};
+
+/**
+ * Fallback scenario: all model picks were hallucinated IDs, so the backend
+ * drops them and emits a canned message with NO picks event.
+ */
+const FALLBACK_SCENARIO: MockScenario = {
+  steps: [
+    {
+      delayMs: 900,
+      event: {
+        type: "metadata",
+        version: 2,
+        recommendations: CANDIDATES,
+        search_status: "ok",
+        turn_count: 1,
+      },
+    },
+    { delayMs: 0, event: { type: "status", phase: "generating" } },
+    { delayMs: 900, event: { type: "text", content: CANNED_FALLBACK } },
+    { delayMs: 30, event: { type: "done" } },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Client-side fetch override (runs in the browser before app scripts).
+// ---------------------------------------------------------------------------
+
+/**
+ * Installed via addInitScript. Replaces window.fetch so that a POST to
+ * /api/chat returns a synthetic text/event-stream Response whose body is
+ * enqueued frame-by-frame on the scenario's timed schedule. All other
+ * requests (auth, history) fall through to the real fetch.
+ */
+function installChatStreamMock(scenario: MockScenario): void {
+  const originalFetch = window.fetch.bind(window);
+  const encoder = new TextEncoder();
+
+  window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    const method = (
+      init?.method ?? (input instanceof Request ? input.method : "GET")
+    ).toUpperCase();
+
+    const isChatPost =
+      method === "POST" &&
+      url.includes("/api/chat") &&
+      !url.includes("/history");
+
+    if (!isChatPost) {
+      return originalFetch(input, init);
+    }
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        let clock = 0;
+        for (const step of scenario.steps) {
+          clock += step.delayMs;
+          const frame = step.event;
+          if (frame === null) continue;
+          setTimeout(() => {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(frame)}\n\n`)
+            );
+          }, clock);
+        }
+        setTimeout(() => controller.close(), clock + 20);
+      },
+    });
+
+    return Promise.resolve(
+      new Response(stream, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function sendChat(page: Page, scenario: MockScenario): Promise<void> {
+  await page.addInitScript(installChatStreamMock, scenario);
+  // Mobile-first viewport — the layout this PR targets (and the 4.7 screenshots).
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+
+  const input = page.getByLabel("Chat message");
+  await expect(input).toBeVisible();
+  await input.fill("Something like Alien but funny");
+  await page.getByRole("button", { name: "Send message" }).click();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Structured chat output (v2 SSE)", () => {
+  test("renders the staged status sequence in order, then picks + prose together, then 'Show more'", async ({
+    authenticatedPage: page,
+  }) => {
+    await sendChat(page, SUCCESS_SCENARIO);
+
+    const searching = page.getByText("Searching your library…");
+    const thinking = page.getByText("Thinking about your picks…");
+
+    // 1) Staged status — IN ORDER. "Searching…" first…
+    await expect(searching).toBeVisible();
+
+    // 2) …then transitions to "Thinking about your picks…" (and "Searching…"
+    //    is gone — proving a real transition, not two overlapping labels).
+    await expect(thinking).toBeVisible();
+    await expect(searching).toBeHidden();
+
+    // 3) Final response — prose AND the "Recommended" picks section arrive
+    //    together (the core v2 behaviour). Status labels are gone.
+    await expect(page.getByText(SUCCESS_PROSE)).toBeVisible();
+    await expect(thinking).toBeHidden();
+
+    const recommendedLabel = page.getByText("Recommended", { exact: true });
+    await expect(recommendedLabel).toBeVisible();
+
+    // Picks render in LLM order, badged.
+    await expect(
+      page.getByRole("button", {
+        name: /Recommended pick: View details for Mock Movie 1/,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: /Recommended pick: View details for Mock Movie 2/,
+      })
+    ).toBeVisible();
+
+    // 4) "More matches" disclosure — collapsed by default, holds the remaining
+    //    3 candidates (5 total − 2 picks).
+    const moreMatches = page.getByText(/More matches \(3\)/);
+    await expect(moreMatches).toBeVisible();
+
+    // Screenshot (Task 4.7): mobile, two-section layout, disclosure collapsed.
+    await page.screenshot({
+      path: "test-results/spec27-mobile-recommended-collapsed.png",
+      fullPage: true,
+    });
+
+    // Reveal the remaining candidates and confirm one becomes visible.
+    await moreMatches.click();
+    await expect(
+      page.getByRole("button", { name: /View details for Mock Movie 5/ })
+    ).toBeVisible();
+
+    // Screenshot (Task 4.7): mobile, "More matches" expanded.
+    await page.screenshot({
+      path: "test-results/spec27-mobile-more-matches-expanded.png",
+      fullPage: true,
+    });
+  });
+
+  test("fallback path: canned message renders with no 'Recommended' section", async ({
+    authenticatedPage: page,
+  }) => {
+    await sendChat(page, FALLBACK_SCENARIO);
+
+    // Staged status still runs.
+    await expect(page.getByText("Searching your library…")).toBeVisible();
+    await expect(page.getByText("Thinking about your picks…")).toBeVisible();
+
+    // Canned message renders…
+    await expect(page.getByText(CANNED_FALLBACK)).toBeVisible();
+
+    // …and there is NO picks section (no "Recommended" label, no disclosure).
+    await expect(page.getByText("Recommended", { exact: true })).toHaveCount(0);
+    await expect(page.getByText(/More matches/)).toHaveCount(0);
+  });
+});

--- a/frontend/tests/e2e/chat/chat-structured-output.spec.ts
+++ b/frontend/tests/e2e/chat/chat-structured-output.spec.ts
@@ -221,7 +221,7 @@ async function sendChat(page: Page, scenario: MockScenario): Promise<void> {
 test.describe("Structured chat output (v2 SSE)", () => {
   test("renders the staged status sequence in order, then picks + prose together, then 'Show more'", async ({
     authenticatedPage: page,
-  }) => {
+  }, testInfo) => {
     await sendChat(page, SUCCESS_SCENARIO);
 
     const searching = page.getByText("Searching your library…");
@@ -265,8 +265,10 @@ test.describe("Structured chat output (v2 SSE)", () => {
     await expect(moreMatches).toBeVisible();
 
     // Screenshot (Task 4.7): mobile, two-section layout, disclosure collapsed.
+    // testInfo.outputPath namespaces by project (chromium/firefox) + retry, so
+    // parallel projects never collide on a shared filename.
     await page.screenshot({
-      path: "test-results/spec27-mobile-recommended-collapsed.png",
+      path: testInfo.outputPath("spec27-mobile-recommended-collapsed.png"),
       fullPage: true,
     });
 
@@ -278,7 +280,7 @@ test.describe("Structured chat output (v2 SSE)", () => {
 
     // Screenshot (Task 4.7): mobile, "More matches" expanded.
     await page.screenshot({
-      path: "test-results/spec27-mobile-more-matches-expanded.png",
+      path: testInfo.outputPath("spec27-mobile-more-matches-expanded.png"),
       fullPage: true,
     });
   });


### PR DESCRIPTION
## What & why

PR 2 of 2 for #239. Consumes the v2 SSE contract from [PR #270](https://github.com/PCritchfield/ai-movie-suggester/pull/270) so the chat UI renders cards and prose from one validated payload.

> **Stacked on PR #270.** Base is `feat/239-structured-chat-output`, so this diff is frontend + docs only. Retarget to `main` once PR #270 merges.

## Changes (Task 4 + 5.2)

- **Types** (`lib/api/types.ts`): `StatusEvent`, `PicksEvent`, `PickItem`; `ChatMessage` gains `picks` + `statusPhase`; `MetadataEvent.version` documented (1 legacy / 2 structured).
- **Hook** (`hooks/use-chat.ts`): `SET_STATUS` / `SET_PICKS` reducer actions; staged wait state (`searching` → `generating`); unknown event types ignored (backward-compat).
- **Two-section layout** (`components/chat/recommendation-sections.tsx`, new): badged "Recommended" carousel in LLM order + collapsed "More matches (N)" disclosure — two distinct carousels per Adorabelle's ruling (no in-place mutation that strands a mid-swipe phone user). `aria-live="polite"` scoped to the section label only; disclosure trigger ≥44px.
- **`MovieCard`** gains an `isPick` ★ badge; **`MessageList`** shows staged status text and renders the two-section layout when `picks` are present, falling back to the plain carousel for a v1/fallback stream.
- **`ARCHITECTURE.md`**: updated sequence diagram, documented v2 SSE contract, prompt-injection section marked shipped.

## Verification

- 9 new tests (SSE parse, reducer transitions incl. unknown-event skip + v1 compat, two-section layout); full frontend suite **213 passed**; `tsc` + `eslint` + `prettier` clean.

## Remaining before ready-for-review (why this is a draft)

- [ ] **Task 5.1 — Playwright e2e** asserting the staged status sequence + picks/prose + "Show more" disclosure (needs the running frontend+backend stack).
- [ ] **Task 4.7 — mobile-viewport screenshots** (captured during the e2e run; RTL tests already prove the layout structure).
- [ ] **Task 5.3 — `make test && make lint`** in Docker (local equivalents are green: backend 1119, frontend 213, ruff/eslint/prettier/tsc clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)