### PR TITLE
feat: bounded cross-encoder reranking, default-OFF (Spec 29, #276)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,22 @@ SEARCH_RATE_LIMIT=10
 # How many extra candidates to fetch from vector search to compensate for permission filtering (1–10)
 # SEARCH_OVERFETCH_MULTIPLIER=3
 
+# --- Cross-encoder reranking (Spec 29 / #276) ---
+# Re-scores the top candidates with a local cross-encoder for sharply better
+# ranking. OFF by default: the quality win is proven but CPU-only latency is
+# not yet measured (Spec 30). Requires the optional `rerank` dependency extra
+# (pulls torch): install with `uv sync --extra rerank`. Leave OFF unless you
+# have opted in.
+# SEARCH_RERANK_ENABLED=false
+# How many top cosine candidates the cross-encoder re-scores (1–1000). Higher =
+# better tail recall but more latency; lower if a CPU-only box is slow. Distinct
+# from SEARCH_OVERFETCH_MULTIPLIER (which governs the cosine fetch window).
+# SEARCH_RERANK_POOL_SIZE=100
+# Per-query rerank deadline in milliseconds. On timeout (or any reranker error)
+# the search falls back to the genre-heuristic ordering — worse results, never a
+# hung request. Provisional default; tune to your hardware.
+# SEARCH_RERANK_TIMEOUT_MS=5000
+
 # Timeout for Jellyfin API requests in seconds (default: 10)
 JELLYFIN_TIMEOUT=10.0
 

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ eval-retrieval: ## Run retrieval eval (golden set -> IR metrics + regression gat
 spike-rerank: ## Spec 28 (#253) cross-encoder rerank spike — three-way + latency, Ollama-only, NO Jellyfin/Docker
 	@curl -sf http://localhost:11434/ > /dev/null 2>&1 || { echo "ERROR: Ollama not reachable at http://localhost:11434/"; echo "Start Ollama first: ollama serve"; exit 1; }
 	@echo "Runs offline by default. First run only (fetch cross-encoder weights once): HF_HUB_OFFLINE=0 TRANSFORMERS_OFFLINE=0 make spike-rerank"
-	@uv run --directory backend --extra spike pytest -m pipeline -s -v tests/pipeline/test_rerank_spike.py
+	@uv run --directory backend --extra rerank pytest -m pipeline -s -v tests/pipeline/test_rerank_spike.py
 
 # ---------------------------------------------------------------------------
 # Adversarial injection test harness

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -109,7 +109,9 @@ class Settings(BaseSettings):
     # real-hardware numbers).
     search_rerank_enabled: bool = False
     search_rerank_pool_size: Annotated[int, Field(ge=1, le=1000)] = 100
-    search_rerank_timeout_ms: Annotated[int, Field(ge=1)] = 5000
+    # Upper bound guards operator misconfiguration: a multi-minute timeout would
+    # tie up a request slot on a hung reranker before wait_for cancels it.
+    search_rerank_timeout_ms: Annotated[int, Field(ge=1, le=60000)] = 5000
 
     # Spec 24 — query router per-filter disable switches. All default to
     # True (router on); flip individually to demonstrate regression at

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -98,6 +98,19 @@ class Settings(BaseSettings):
     search_overfetch_multiplier: Annotated[int, Field(ge=1, le=10)] = 3
     search_rate_limit: Annotated[str, Field(pattern=_RATE_LIMIT_RE)] = "10/minute"
 
+    # Spec 29 — cross-encoder reranking. Defaults OFF: the quality win is
+    # proven (NDCG@10 0.338 -> 0.591) but its CPU-only latency is unmeasured
+    # until Spec 30, so the live path must not engage without an explicit
+    # opt-in. ``pool_size`` caps how many top cosine candidates the
+    # cross-encoder re-scores (latency/quality knob, distinct from
+    # ``search_overfetch_multiplier`` which governs the cosine fetch window).
+    # ``timeout_ms`` is provisional (revised in Spec 29 task 5.x from an
+    # observed fixture wall-time; authoritative tuning waits on Spec 30
+    # real-hardware numbers).
+    search_rerank_enabled: bool = False
+    search_rerank_pool_size: Annotated[int, Field(ge=1, le=1000)] = 100
+    search_rerank_timeout_ms: Annotated[int, Field(ge=1)] = 5000
+
     # Spec 24 — query router per-filter disable switches. All default to
     # True (router on); flip individually to demonstrate regression at
     # eval time or to mute a noisy filter without redeploying code.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -293,6 +293,21 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
         app.state.query_rewriter = query_rewriter
 
+        # Spec 29 (#276) — cross-encoder reranker. Opt-in, default OFF: built
+        # only when enabled (the model imports/loads lazily on first query, so
+        # construction here is cheap and the default boot path never touches
+        # torch). Requires the `rerank` dependency extra.
+        reranker = None
+        if settings.search_rerank_enabled:
+            from app.search.reranker import CrossEncoderReranker
+
+            reranker = CrossEncoderReranker()
+            _logger.info(
+                "cross-encoder reranking ENABLED (pool=%d, timeout=%dms)",
+                settings.search_rerank_pool_size,
+                settings.search_rerank_timeout_ms,
+            )
+
         # Create search service and mount router
         from app.search.service import SearchService
 
@@ -309,6 +324,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             intent_filter_rating_enabled=settings.intent_filter_rating_enabled,
             rewriter=query_rewriter,
             foreign_film_home_countries=settings.foreign_film_home_countries,
+            reranker=reranker,
         )
         app.state.search_service = search_service
         search_router = create_search_router(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -299,14 +299,26 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # torch). Requires the `rerank` dependency extra.
         reranker = None
         if settings.search_rerank_enabled:
-            from app.search.reranker import CrossEncoderReranker
+            import importlib.util
 
-            reranker = CrossEncoderReranker()
-            _logger.info(
-                "cross-encoder reranking ENABLED (pool=%d, timeout=%dms)",
-                settings.search_rerank_pool_size,
-                settings.search_rerank_timeout_ms,
-            )
+            if importlib.util.find_spec("sentence_transformers") is None:
+                # Flag on but the opt-in extra absent: fail soft with a clear,
+                # actionable message rather than letting every query hit an
+                # ImportError and silently fall back to the heuristic.
+                _logger.warning(
+                    "SEARCH_RERANK_ENABLED=true but the optional 'rerank' extra "
+                    "is not installed; reranking is DISABLED (genre heuristic). "
+                    "Install it with: uv sync --extra rerank"
+                )
+            else:
+                from app.search.reranker import CrossEncoderReranker
+
+                reranker = CrossEncoderReranker()
+                _logger.info(
+                    "cross-encoder reranking ENABLED (pool=%d, timeout=%dms)",
+                    settings.search_rerank_pool_size,
+                    settings.search_rerank_timeout_ms,
+                )
 
         # Create search service and mount router
         from app.search.service import SearchService

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -325,6 +325,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             rewriter=query_rewriter,
             foreign_film_home_countries=settings.foreign_film_home_countries,
             reranker=reranker,
+            rerank_pool_size=settings.search_rerank_pool_size,
+            rerank_timeout_ms=settings.search_rerank_timeout_ms,
         )
         app.state.search_service = search_service
         search_router = create_search_router(

--- a/backend/app/search/reranker.py
+++ b/backend/app/search/reranker.py
@@ -1,0 +1,129 @@
+"""Cross-encoder reranker (Spec 29 / #276).
+
+Re-scores the top cosine candidates with a local cross-encoder
+(``cross-encoder/ms-marco-MiniLM-L-6-v2``) for sharply better ranking than the
+genre heuristic (spike #253: NDCG@10 0.338 -> 0.591). The heavy
+``sentence_transformers`` / ``torch`` dependency lives in the opt-in ``rerank``
+extra and is imported **lazily** inside :class:`CrossEncoderReranker` — so this
+module (and every other module under ``app/``) stays torch-free at import time,
+and the flag-OFF path never pays the import cost. ``test_no_heavy_imports_under_app``
+guards the boundary.
+
+Seam discipline: the public contract is :class:`RerankerProtocol` —
+``rerank(query, [(jellyfin_id, document_text)]) -> reordered ids``. The inference
+backend (torch now, ONNX in Spec 30) and the model **load timing** are internal
+details of :class:`CrossEncoderReranker`; they do not appear in the Protocol or in
+the way callers construct/inject the reranker, so Spec 30 can swap either without
+touching the seam.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Offline-by-default Hugging Face: these MUST be set before huggingface_hub is
+# imported. The CrossEncoder import is lazy (inside ``_ensure_scorer``), well
+# after this module loads, so setting them here guarantees they win.
+# ``setdefault`` for the offline flags so a deliberate ONE-TIME weight fetch can
+# override with HF_HUB_OFFLINE=0; every normal run inherits offline=1 and proves
+# local-only serving. Telemetry is disabled UNCONDITIONALLY (plain assignment,
+# not setdefault) — it must never be re-enabled by an outer environment.
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+os.environ["HF_HUB_DISABLE_TELEMETRY"] = "1"
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable  # noqa: E402
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    # A scorer maps ``(query, document)`` pairs to relevance scores. The real
+    # implementation is a CrossEncoder; unit tests inject a deterministic stub.
+    Scorer = Callable[[Sequence[tuple[str, str]]], Sequence[float]]
+
+# Pinned cross-encoder. ms-marco-MiniLM-L-6-v2 is the canonical small reranker
+# (~80MB, CPU-friendly). MODEL_REVISION pins the *weights* by Hub commit SHA —
+# the axis that fixes the scores — matching the merged spike (#253).
+MODEL_NAME = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+MODEL_REVISION = "c5ee24cb16019beea0893ab7796b1df96625c6b8"
+
+
+def reorder_by_scores(
+    query: str,
+    candidates: Sequence[tuple[str, str]],
+    scorer: Scorer,
+) -> list[str]:
+    """Reorder ``candidates`` by descending cross-encoder score.
+
+    ``candidates`` is a sequence of ``(jellyfin_id, document_text)``. Pure: all
+    model work is delegated to ``scorer`` (a real CrossEncoder in production, a
+    deterministic stub in unit tests). Stable on ties — equal scores keep their
+    input (cosine) order, matching ``SearchService._rerank_by_genre`` semantics.
+    Returns the reordered ``jellyfin_id``s only (never document text).
+    """
+    if not candidates:
+        return []
+    pairs = [(query, doc) for _id, doc in candidates]
+    scores = list(scorer(pairs))
+    order = sorted(range(len(candidates)), key=lambda i: scores[i], reverse=True)
+    return [candidates[i][0] for i in order]
+
+
+@runtime_checkable
+class RerankerProtocol(Protocol):
+    """Reorders ``(jellyfin_id, document_text)`` candidates by relevance.
+
+    The only contract callers (SearchService) depend on. Implementations own
+    their model/backend/load-timing internally.
+    """
+
+    def rerank(
+        self, query: str, candidates: Sequence[tuple[str, str]]
+    ) -> list[str]: ...
+
+
+class CrossEncoderReranker:
+    """A :class:`RerankerProtocol` backed by a local ``sentence_transformers``
+    CrossEncoder.
+
+    The model is imported and loaded **lazily** on first ``rerank`` call and
+    cached for reuse. Load timing is an internal detail (Spec 30 may move it to
+    eager-at-startup) and is intentionally not exposed through the Protocol.
+    """
+
+    def __init__(
+        self, model_name: str = MODEL_NAME, revision: str = MODEL_REVISION
+    ) -> None:
+        self._model_name = model_name
+        self._revision = revision
+        self._scorer: Scorer | None = None
+
+    def _ensure_scorer(self) -> Scorer:
+        """Build (once) and cache the CrossEncoder-backed scorer.
+
+        The ``sentence_transformers`` import is here — never at module load — so
+        importing this module stays torch-free. ``automodel_args`` forwards
+        ``use_safetensors=True`` to ``from_pretrained``: it forces the
+        safetensors weight file (no pickle deserialization surface) and fails
+        loud if the pinned revision has none — the desired behaviour, not a
+        silent fallback.
+        """
+        if self._scorer is None:
+            from sentence_transformers import CrossEncoder
+
+            model = CrossEncoder(
+                self._model_name,
+                revision=self._revision,
+                automodel_args={"use_safetensors": True},
+            )
+
+            def scorer(pairs: Sequence[tuple[str, str]]) -> list[float]:
+                return [float(s) for s in model.predict(list(pairs))]
+
+            self._scorer = scorer
+        return self._scorer
+
+    def rerank(self, query: str, candidates: Sequence[tuple[str, str]]) -> list[str]:
+        """Reorder candidates by cross-encoder relevance (loads the model on
+        first call)."""
+        return reorder_by_scores(query, candidates, self._ensure_scorer())

--- a/backend/app/search/reranker.py
+++ b/backend/app/search/reranker.py
@@ -20,6 +20,7 @@ touching the seam.
 from __future__ import annotations
 
 import os
+import threading
 
 # Offline-by-default Hugging Face: these MUST be set before huggingface_hub is
 # imported. The CrossEncoder import is lazy (inside ``_ensure_scorer``), well
@@ -97,6 +98,12 @@ class CrossEncoderReranker:
         self._model_name = model_name
         self._revision = revision
         self._scorer: Scorer | None = None
+        # Guards lazy init: ``_ensure_scorer`` runs inside ``asyncio.to_thread``
+        # workers, so concurrent first-use requests could otherwise each load a
+        # separate model. Double-checked locking loads exactly one. (Serialising
+        # ``model.predict`` itself — a throughput question under concurrency — is
+        # deferred to Spec 30 alongside the real-hardware latency measurement.)
+        self._lock = threading.Lock()
 
     def _ensure_scorer(self) -> Scorer:
         """Build (once) and cache the CrossEncoder-backed scorer.
@@ -109,18 +116,20 @@ class CrossEncoderReranker:
         silent fallback.
         """
         if self._scorer is None:
-            from sentence_transformers import CrossEncoder
+            with self._lock:
+                if self._scorer is None:  # double-checked under the lock
+                    from sentence_transformers import CrossEncoder
 
-            model = CrossEncoder(
-                self._model_name,
-                revision=self._revision,
-                automodel_args={"use_safetensors": True},
-            )
+                    model = CrossEncoder(
+                        self._model_name,
+                        revision=self._revision,
+                        automodel_args={"use_safetensors": True},
+                    )
 
-            def scorer(pairs: Sequence[tuple[str, str]]) -> list[float]:
-                return [float(s) for s in model.predict(list(pairs))]
+                    def scorer(pairs: Sequence[tuple[str, str]]) -> list[float]:
+                        return [float(s) for s in model.predict(list(pairs))]
 
-            self._scorer = scorer
+                    self._scorer = scorer
         return self._scorer
 
     def rerank(self, query: str, candidates: Sequence[tuple[str, str]]) -> list[str]:

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -96,8 +96,8 @@ class SearchService:
 
         Mirrors ``person_index``: exposed so tests and the eval harness can
         introspect rerank configuration without reaching into private state.
-        The reranker is stored here in this spec but not yet engaged by
-        ``search`` — the live bounded-rerank path lands in task 4.0.
+        When set, ``search`` engages it as the bounded rerank step (replacing
+        the genre heuristic), degrading to the heuristic on timeout/error.
         """
         return self._reranker
 
@@ -517,6 +517,19 @@ class SearchService:
                 "rerank failed (pool=%d), falling back to genre heuristic: %s",
                 len(candidates),
                 type(exc).__name__,
+            )
+            return self._rerank_by_genre(genre_groups, permitted_ids, item_map)
+
+        # Trust-but-verify the reranker output: it must be a permutation of the
+        # scored pool ids. A non-permutation (dropped/duplicate/foreign ids from
+        # a buggy or future implementation) would drop valid candidates or emit
+        # duplicate cards downstream — degrade to the heuristic instead.
+        pool_ids = [jid for jid, _doc in candidates]
+        if sorted(reordered_pool) != sorted(pool_ids):
+            logger.warning(
+                "rerank returned a non-permutation (pool=%d), "
+                "falling back to genre heuristic",
+                len(candidates),
             )
             return self._rerank_by_genre(genre_groups, permitted_ids, item_map)
 

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -75,7 +75,8 @@ class SearchService:
         self._rewriter = rewriter
         self._reranker = reranker
         self._rerank_pool_size = rerank_pool_size
-        self._rerank_timeout_ms = rerank_timeout_ms
+        # Stored in seconds (the ctor param is ms to match the config field).
+        self._rerank_timeout_s = rerank_timeout_ms / 1000
         self._home_countries: list[str] = list(foreign_film_home_countries or [])
         self._status_cache: SearchStatus | None = None
         self._status_cache_time: float = 0.0
@@ -509,7 +510,7 @@ class SearchService:
         try:
             reordered_pool = await asyncio.wait_for(
                 asyncio.to_thread(self._reranker.rerank, query, candidates),
-                timeout=self._rerank_timeout_ms / 1000,
+                timeout=self._rerank_timeout_s,
             )
         except Exception as exc:  # noqa: BLE001 — degrade safely on ANY failure
             # Count- and type-keyed only: no query/document text (PII).
@@ -524,8 +525,8 @@ class SearchService:
         # scored pool ids. A non-permutation (dropped/duplicate/foreign ids from
         # a buggy or future implementation) would drop valid candidates or emit
         # duplicate cards downstream — degrade to the heuristic instead.
-        pool_ids = [jid for jid, _doc in candidates]
-        if sorted(reordered_pool) != sorted(pool_ids):
+        scored_ids = [jid for jid, _doc in candidates]
+        if sorted(reordered_pool) != sorted(scored_ids):
             logger.warning(
                 "rerank returned a non-permutation (pool=%d), "
                 "falling back to genre heuristic",

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING
 
 from app.ollama.errors import OllamaConnectionError, OllamaError, OllamaTimeoutError
+from app.ollama.text_builder import build_sections
 from app.search.genre_keywords import detect_query_genres
 from app.search.intent import QueryIntent, detect_intent
 from app.search.models import (
@@ -55,6 +57,8 @@ class SearchService:
         rewriter: QueryRewriter | None = None,
         foreign_film_home_countries: list[str] | None = None,
         reranker: RerankerProtocol | None = None,
+        rerank_pool_size: int = 100,
+        rerank_timeout_ms: int = 5000,
     ) -> None:
         self._ollama = ollama_client
         self._vec_repo = vec_repo
@@ -70,6 +74,8 @@ class SearchService:
         self._filter_rating = intent_filter_rating_enabled
         self._rewriter = rewriter
         self._reranker = reranker
+        self._rerank_pool_size = rerank_pool_size
+        self._rerank_timeout_ms = rerank_timeout_ms
         self._home_countries: list[str] = list(foreign_film_home_countries or [])
         self._status_cache: SearchStatus | None = None
         self._status_cache_time: float = 0.0
@@ -229,16 +235,26 @@ class SearchService:
         items = await self._library.get_many(permitted_ids)
         item_map = {item.jellyfin_id: item for item in items}
 
-        # Soft genre rerank: bucket-sort by genre match while preserving
-        # cosine order (the input ``permitted_ids`` order) within each tier.
-        # Reuse the genre groups already computed by ``detect_intent`` if
-        # available — otherwise fall back to a fresh detection so callers
-        # bypassing the router (e.g. unit tests) still get the rerank.
+        # Genre groups are computed regardless: they drive the genre heuristic
+        # AND serve as the cross-encoder's safe-degradation fallback. Reuse the
+        # groups already computed by ``detect_intent`` if available — otherwise
+        # a fresh detection so callers bypassing the router (e.g. unit tests)
+        # still get a sensible ordering.
         if effective_intent is not None and effective_intent.genres:
             genre_groups = effective_intent.genres
         else:
             genre_groups = detect_query_genres(effective_query)
-        ordered_ids = self._rerank_by_genre(genre_groups, permitted_ids, item_map)
+
+        if self._reranker is not None:
+            # Spec 29: bounded cross-encoder rerank REPLACES the genre heuristic
+            # when enabled. Degrades to the heuristic on timeout/error.
+            ordered_ids = await self._rerank_cross_encoder(
+                effective_query, permitted_ids, item_map, genre_groups
+            )
+        else:
+            # Soft genre rerank: bucket-sort by genre match while preserving
+            # cosine order (the input ``permitted_ids`` order) within each tier.
+            ordered_ids = self._rerank_by_genre(genre_groups, permitted_ids, item_map)
         ordered_ids = ordered_ids[:limit]
 
         results: list[SearchResultItem] = []
@@ -433,6 +449,78 @@ class SearchService:
             else:
                 tier3.append(jid)
         return tier1 + tier2 + tier3
+
+    @staticmethod
+    def _rerank_document_text(item: LibraryItemRow) -> str:
+        """Cross-encoder document side: the SAME composite template used for
+        embeddings (``build_sections``), minus the nomic ``search_document:``
+        prefix (a bi-encoder asymmetric-retrieval artifact, meaningless to a
+        ms-marco cross-encoder). Same section content, just no prefix.
+        """
+        return build_sections(
+            title=item.title,
+            overview=item.overview,
+            genres=item.genres,
+            production_year=item.production_year,
+            runtime_minutes=item.runtime_minutes,
+            cast=item.people,
+            directors=item.directors,
+            writers=item.writers,
+            composers=item.composers,
+            studios=item.studios,
+            tags=item.tags,
+        )
+
+    async def _rerank_cross_encoder(
+        self,
+        query: str,
+        permitted_ids: list[str],
+        item_map: Mapping[str, LibraryItemRow],
+        genre_groups: list[frozenset[str]],
+    ) -> list[str]:
+        """Bounded cross-encoder rerank with safe degradation.
+
+        Caps the rerank input to the top ``rerank_pool_size`` cosine candidates,
+        scores them OFF the event loop (``asyncio.to_thread``) under a per-query
+        deadline (``asyncio.wait_for``), and reorders that pool; the un-reranked
+        tail keeps cosine order and is appended after. On timeout or ANY reranker
+        error, degrades to the genre-heuristic ordering so a slow/broken reranker
+        never hangs or fails the request. Logging is count-keyed only — never the
+        query or document text (PII).
+        """
+        assert self._reranker is not None  # guarded by caller
+        pool_ids = permitted_ids[: self._rerank_pool_size]
+        tail_ids = permitted_ids[self._rerank_pool_size :]
+
+        candidates: list[tuple[str, str]] = []
+        missing_pool: list[str] = []
+        for jid in pool_ids:
+            item = item_map.get(jid)
+            if item is None:
+                # Lost between permission filter and metadata fetch — keep it
+                # rather than drop it (matches ``_rerank_by_genre``).
+                missing_pool.append(jid)
+            else:
+                candidates.append((jid, self._rerank_document_text(item)))
+
+        if not candidates:
+            return permitted_ids
+
+        try:
+            reordered_pool = await asyncio.wait_for(
+                asyncio.to_thread(self._reranker.rerank, query, candidates),
+                timeout=self._rerank_timeout_ms / 1000,
+            )
+        except Exception as exc:  # noqa: BLE001 — degrade safely on ANY failure
+            # Count- and type-keyed only: no query/document text (PII).
+            logger.warning(
+                "rerank failed (pool=%d), falling back to genre heuristic: %s",
+                len(candidates),
+                type(exc).__name__,
+            )
+            return self._rerank_by_genre(genre_groups, permitted_ids, item_map)
+
+        return list(reordered_pool) + missing_pool + tail_ids
 
     async def _determine_status(self) -> SearchStatus:
         """Check embedding completeness and return status (cached 30s)."""

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from app.ollama.client import OllamaEmbeddingClient
     from app.permissions.service import PermissionService
     from app.search.person_index import PersonIndex
+    from app.search.reranker import RerankerProtocol
     from app.search.rewriter import QueryRewriter
     from app.vectors.repository import SqliteVecRepository
 
@@ -53,6 +54,7 @@ class SearchService:
         intent_filter_rating_enabled: bool = True,
         rewriter: QueryRewriter | None = None,
         foreign_film_home_countries: list[str] | None = None,
+        reranker: RerankerProtocol | None = None,
     ) -> None:
         self._ollama = ollama_client
         self._vec_repo = vec_repo
@@ -67,6 +69,7 @@ class SearchService:
         self._filter_year = intent_filter_year_enabled
         self._filter_rating = intent_filter_rating_enabled
         self._rewriter = rewriter
+        self._reranker = reranker
         self._home_countries: list[str] = list(foreign_film_home_countries or [])
         self._status_cache: SearchStatus | None = None
         self._status_cache_time: float = 0.0
@@ -80,6 +83,17 @@ class SearchService:
         configuration without reaching into private state.
         """
         return self._person_index
+
+    @property
+    def reranker(self) -> RerankerProtocol | None:
+        """Read-only handle to the injected reranker (or ``None``).
+
+        Mirrors ``person_index``: exposed so tests and the eval harness can
+        introspect rerank configuration without reaching into private state.
+        The reranker is stored here in this spec but not yet engaged by
+        ``search`` — the live bounded-rerank path lands in task 4.0.
+        """
+        return self._reranker
 
     @property
     def home_countries(self) -> list[str]:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,17 +32,22 @@ dev = [
     # implementation in tests/pipeline/_eval_scoring.py.
     "ranx>=0.3.0",
 ]
-# Spec 28 (#253) cross-encoder reranking spike. Heavy (pulls torch) and
-# experiment-only, so it lives in its OWN extra — NOT in `dev` — to keep the
-# default dev/CI install (and image builds) torch-free. Dev/test-only —
-# NEVER import under backend/app/ (an import-isolation guard in
-# tests/pipeline/test_rerank_spike.py enforces this).
+# Spec 29 (#276) cross-encoder reranking. Heavy (pulls torch), so it lives in
+# its OWN opt-in extra — NOT in `dev`, NOT in core `dependencies` — to keep the
+# default dev/CI install AND the default Docker image torch-free (Havelock veto;
+# the import-isolation guard `test_no_heavy_imports_under_app` enforces no
+# top-level import). `app/search/reranker.py` imports `sentence_transformers`
+# LAZILY (inside CrossEncoderReranker, never at module load), so the flag-OFF
+# path and CI never pay torch's import cost. Supersedes the former `spike` extra
+# (the merged #253 experiment runs against this same extra via `make spike-rerank`).
 #
-# Reproducibility: the spike pins the cross-encoder *model weights* by commit
-# SHA at load time (see tests/pipeline/rerank_spike.py:MODEL_REVISION =
-# c5ee24cb16019beea0893ab7796b1df96625c6b8), which is what actually determines
-# the scores; the library range below is the looser axis.
-spike = [
+# Reproducibility: the cross-encoder *model weights* are pinned by commit SHA at
+# load time (app/search/reranker.py:MODEL_REVISION =
+# c5ee24cb16019beea0893ab7796b1df96625c6b8), which is what determines the scores;
+# the library range below is the looser axis (uv.lock is the lockfile of record
+# for exact transitive versions, incl. torch). Spec 30 swaps this for a
+# torch-free onnxruntime path.
+rerank = [
     "sentence-transformers>=3.0,<4.0",
 ]
 

--- a/backend/tests/pipeline/conftest.py
+++ b/backend/tests/pipeline/conftest.py
@@ -288,6 +288,20 @@ async def eval_search_service(
         )
         permissions = AsyncMock()
         permissions.filter_permitted.side_effect = lambda *args, **_kw: args[2]
+        # Spec 29 — optionally engage the cross-encoder reranker. The flag and
+        # tuning come from Settings (env-driven SEARCH_RERANK_*), never raw
+        # os.environ. Default OFF, so router/retrieval evals are unchanged
+        # unless an operator opts in (then the eval measures the rerank path).
+        settings = Settings(
+            jellyfin_url="http://localhost:8096",
+            session_secret=TEST_SECRET,
+            ollama_host=OLLAMA_HOST,
+        )  # type: ignore[call-arg]
+        reranker = None
+        if settings.search_rerank_enabled:
+            from app.search.reranker import CrossEncoderReranker
+
+            reranker = CrossEncoderReranker()
         service = SearchService(
             ollama_client=embed_client,
             vec_repo=embedded_library,
@@ -295,5 +309,8 @@ async def eval_search_service(
             library_store=pipeline_library_store,
             person_index=person_index,
             rewriter=rewriter,
+            reranker=reranker,
+            rerank_pool_size=settings.search_rerank_pool_size,
+            rerank_timeout_ms=settings.search_rerank_timeout_ms,
         )
         yield service

--- a/backend/tests/pipeline/test_rerank_spike.py
+++ b/backend/tests/pipeline/test_rerank_spike.py
@@ -39,7 +39,6 @@ from tests.pipeline.seed_fixtures import build_seeded_stack, load_fixture_rows
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-_APP_DIR = Path(__file__).resolve().parents[2] / "app"
 # 64 hex chars: ≥32 long, >2 distinct chars, no blocklist word — passes the
 # SESSION_SECRET validator. Not a real secret (this stack faces no network).
 _SPIKE_SECRET = "0123456789abcdef" * 4
@@ -78,26 +77,14 @@ def test_rerank_empty_pool_returns_empty() -> None:
     assert rerank("q", [], _stub_scorer({})) == []
 
 
-def test_no_heavy_imports_under_app() -> None:
-    """Guard: torch / sentence_transformers must NEVER be imported under app/.
-
-    The spike's heavy deps live in the ``spike`` extra and load lazily inside
-    ``make_cross_encoder_scorer`` — production code stays torch-free.
-
-    Line-level check (no ``if TYPE_CHECKING:`` block tracking): a type-only torch
-    import under ``app/`` would register as a false positive. None exists today,
-    and the runtime-import-leak case this guards is the one that matters.
-    """
-    offenders: list[str] = []
-    for py in _APP_DIR.rglob("*.py"):
-        text = py.read_text(encoding="utf-8")
-        for line in text.splitlines():
-            stripped = line.strip()
-            if stripped.startswith(("import ", "from ")) and (
-                "sentence_transformers" in stripped or "torch" in stripped
-            ):
-                offenders.append(f"{py.relative_to(_APP_DIR.parent)}: {stripped}")
-    assert not offenders, "heavy-dep import leaked under app/:\n" + "\n".join(offenders)
+# NOTE: the import-isolation guard moved to ``tests/test_reranker.py``
+# (``test_no_heavy_imports_under_app``). That copy is AST-precise — it allows the
+# legitimate *lazy* ``sentence_transformers`` import inside
+# ``app/search/reranker.py:CrossEncoderReranker`` while still failing on any
+# module-load-time heavy import — and lives at the top level so it runs in CI
+# (this pipeline file is skipped when Ollama is absent). The old line-scan copy
+# here was removed (Spec 29 #276): it false-positived on the production lazy
+# import.
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -536,3 +536,50 @@ def test_rewriter_settings_bounds() -> None:
             pytest.raises(ValidationError),
         ):
             Settings()  # type: ignore[call-arg]
+
+
+# --- Spec 29 — cross-encoder reranking settings ---
+
+
+def test_rerank_settings_defaults() -> None:
+    """Reranking ships OFF by default with a 100-item pool and 5s timeout.
+
+    Default OFF is a hard requirement (Spec 29): the quality win is proven
+    but its CPU-only latency is unmeasured until Spec 30, so the live path
+    must not engage until an operator opts in.
+    """
+    env = _REQUIRED_ENV.copy()
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.search_rerank_enabled is False
+    assert s.search_rerank_pool_size == 100
+    assert s.search_rerank_timeout_ms == 5000
+
+
+def test_rerank_settings_env_override() -> None:
+    """All three rerank settings load from environment variables."""
+    env = {
+        **_REQUIRED_ENV,
+        "SEARCH_RERANK_ENABLED": "true",
+        "SEARCH_RERANK_POOL_SIZE": "75",
+        "SEARCH_RERANK_TIMEOUT_MS": "2000",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        s = Settings()  # type: ignore[call-arg]
+    assert s.search_rerank_enabled is True
+    assert s.search_rerank_pool_size == 75
+    assert s.search_rerank_timeout_ms == 2000
+
+
+def test_rerank_pool_size_rejects_zero() -> None:
+    """search_rerank_pool_size must be >= 1 (a zero pool reranks nothing)."""
+    env = {**_REQUIRED_ENV, "SEARCH_RERANK_POOL_SIZE": "0"}
+    with patch.dict(os.environ, env, clear=True), pytest.raises(ValidationError):
+        Settings()  # type: ignore[call-arg]
+
+
+def test_rerank_timeout_rejects_zero() -> None:
+    """search_rerank_timeout_ms must be >= 1 (a zero deadline is unusable)."""
+    env = {**_REQUIRED_ENV, "SEARCH_RERANK_TIMEOUT_MS": "0"}
+    with patch.dict(os.environ, env, clear=True), pytest.raises(ValidationError):
+        Settings()  # type: ignore[call-arg]

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -583,3 +583,11 @@ def test_rerank_timeout_rejects_zero() -> None:
     env = {**_REQUIRED_ENV, "SEARCH_RERANK_TIMEOUT_MS": "0"}
     with patch.dict(os.environ, env, clear=True), pytest.raises(ValidationError):
         Settings()  # type: ignore[call-arg]
+
+
+def test_rerank_timeout_rejects_over_max() -> None:
+    """search_rerank_timeout_ms is capped at 60000ms to catch misconfiguration
+    (a multi-minute deadline would tie up a request slot on a hung reranker)."""
+    env = {**_REQUIRED_ENV, "SEARCH_RERANK_TIMEOUT_MS": "60001"}
+    with patch.dict(os.environ, env, clear=True), pytest.raises(ValidationError):
+        Settings()  # type: ignore[call-arg]

--- a/backend/tests/test_reranker.py
+++ b/backend/tests/test_reranker.py
@@ -1,0 +1,137 @@
+"""Unit tests for the cross-encoder reranker module (Spec 29 / #276).
+
+All tests here run under plain ``pytest`` / ``make test`` with **no** ``rerank``
+extra installed (no torch): the pure reorder logic is exercised with a
+deterministic stub scorer, and an import-isolation guard asserts no heavy import
+leaks under ``backend/app/``. The heavy ``CrossEncoderReranker`` path is exercised
+by the pipeline eval (task 5.x), not here.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from app.search.reranker import RerankerProtocol, reorder_by_scores
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_APP_DIR = Path(__file__).resolve().parents[1] / "app"
+
+
+# --------------------------------------------------------------------------- #
+# Pure reorder logic — deterministic stub scorer, no heavy deps
+# --------------------------------------------------------------------------- #
+def _stub_scorer(score_by_doc: dict[str, float]):
+    def scorer(pairs: Sequence[tuple[str, str]]) -> list[float]:
+        return [score_by_doc[doc] for _q, doc in pairs]
+
+    return scorer
+
+
+def test_reorder_by_descending_score() -> None:
+    candidates = [("a", "docA"), ("b", "docB"), ("c", "docC")]
+    scorer = _stub_scorer({"docA": 0.1, "docB": 0.9, "docC": 0.5})
+    # Highest score first: B (0.9), C (0.5), A (0.1).
+    assert reorder_by_scores("q", candidates, scorer) == ["b", "c", "a"]
+
+
+def test_reorder_is_stable_on_ties() -> None:
+    candidates = [("a", "docA"), ("b", "docB"), ("c", "docC")]
+    scorer = _stub_scorer({"docA": 0.5, "docB": 0.5, "docC": 0.5})
+    # All equal — input (cosine) order preserved, matching _rerank_by_genre.
+    assert reorder_by_scores("q", candidates, scorer) == ["a", "b", "c"]
+
+
+def test_reorder_empty_pool_returns_empty() -> None:
+    assert reorder_by_scores("q", [], _stub_scorer({})) == []
+
+
+def test_reorder_preserves_ids_not_docs() -> None:
+    """The returned values are jellyfin_ids (tuple[0]), never document text."""
+    candidates = [("id-1", "doc one"), ("id-2", "doc two")]
+    scorer = _stub_scorer({"doc one": 0.2, "doc two": 0.8})
+    assert reorder_by_scores("q", candidates, scorer) == ["id-2", "id-1"]
+
+
+def test_cross_encoder_reranker_satisfies_protocol() -> None:
+    """CrossEncoderReranker is a structural RerankerProtocol (no torch needed
+    to import the class — only to call ``.rerank``)."""
+    from app.search.reranker import CrossEncoderReranker
+
+    reranker: RerankerProtocol = CrossEncoderReranker()
+    assert hasattr(reranker, "rerank")
+
+
+# --------------------------------------------------------------------------- #
+# Offline / telemetry env guards — set at module import, before any HF import
+# --------------------------------------------------------------------------- #
+def test_offline_and_telemetry_env_guards_set_on_import() -> None:
+    """Importing the reranker module sets the HF offline + telemetry-off env
+    vars in code, so a missing env var cannot silently re-enable outbound
+    fetches or telemetry (Angua)."""
+    import app.search.reranker  # noqa: F401 — import is the thing under test
+
+    assert os.environ["HF_HUB_OFFLINE"] == "1"
+    assert os.environ["TRANSFORMERS_OFFLINE"] == "1"
+    # Telemetry is disabled UNCONDITIONALLY (plain assignment, not setdefault).
+    assert os.environ["HF_HUB_DISABLE_TELEMETRY"] == "1"
+
+
+# --------------------------------------------------------------------------- #
+# Import-isolation guard — torch must NEVER load at module import under app/
+# --------------------------------------------------------------------------- #
+_HEAVY_MODULES = ("torch", "sentence_transformers")
+
+
+def _module_load_heavy_imports(tree: ast.Module) -> list[str]:
+    """Return heavy imports that execute at MODULE IMPORT time.
+
+    Walks module- and class-level statements but does NOT descend into function
+    or method bodies — a lazy ``import`` inside a function (e.g.
+    ``CrossEncoderReranker._ensure_scorer``) runs only when called, not at
+    import, so it is correctly *not* flagged. This is the precise version of the
+    "no torch at import" rule; the naive line-scan it replaces could not tell a
+    lazy import from a top-level one.
+    """
+    found: list[str] = []
+
+    def names(node: ast.Import | ast.ImportFrom) -> list[str]:
+        if isinstance(node, ast.Import):
+            return [a.name for a in node.names]
+        return [node.module] if node.module else []
+
+    def visit(node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue  # function body is lazy — not executed at import
+            if isinstance(child, ast.Import | ast.ImportFrom):
+                for name in names(child):
+                    root = name.split(".")[0]
+                    if root in _HEAVY_MODULES:
+                        found.append(name)
+            visit(child)
+
+    visit(tree)
+    return found
+
+
+def test_no_heavy_imports_under_app() -> None:
+    """Guard: ``torch`` / ``sentence_transformers`` must NEVER be imported at
+    module load under ``backend/app/``.
+
+    The reranker's heavy deps live in the opt-in ``rerank`` extra and load
+    lazily inside ``CrossEncoderReranker`` — production code (and CI, which
+    lacks the extra) stays torch-free. This is the CI-visible copy of the guard;
+    the spike's copy in ``tests/pipeline/test_rerank_spike.py`` remains and only
+    runs under ``make spike-rerank``.
+    """
+    offenders: list[str] = []
+    for py in _APP_DIR.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        for imp in _module_load_heavy_imports(tree):
+            offenders.append(f"{py.relative_to(_APP_DIR.parent)}: import {imp}")
+    assert not offenders, "heavy-dep import leaked under app/:\n" + "\n".join(offenders)

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -1521,6 +1521,18 @@ async def test_rerank_error_falls_back_to_genre_heuristic() -> None:
     assert [r.jellyfin_id for r in result.results] == ["m0", "m1", "m2", "m3", "m4"]
 
 
+async def test_rerank_non_permutation_falls_back_to_genre_heuristic() -> None:
+    """A reranker that returns ids outside the scored pool (or drops/dupes them)
+    is rejected — the search degrades to the genre-heuristic ordering rather than
+    silently dropping valid candidates or emitting duplicate cards."""
+    reranker = _CapturingReranker(reorder=lambda _cands: ["bogus-id"])
+    service = _ordering_service(reranker, pool_size=3, n=5)
+
+    result = await service.search("q", limit=5, user_id="u1", token="tok")
+
+    assert [r.jellyfin_id for r in result.results] == ["m0", "m1", "m2", "m3", "m4"]
+
+
 async def test_rerank_failure_logs_without_pii(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
 from app.search.person_index import PersonIndex
 from app.search.service import SearchService
 from tests.factories import make_embedding_result, make_library_item, make_search_result
+
+if TYPE_CHECKING:
+    from app.search.reranker import RerankerProtocol
 
 
 def _make_service(
@@ -22,6 +26,7 @@ def _make_service(
     intent_filter_rating_enabled: bool = True,
     rewriter: AsyncMock | None = None,
     foreign_film_home_countries: list[str] | None = None,
+    reranker: RerankerProtocol | None = None,
 ) -> SearchService:
     """Build a SearchService with mocked dependencies.
 
@@ -60,6 +65,7 @@ def _make_service(
         intent_filter_rating_enabled=intent_filter_rating_enabled,
         rewriter=rewriter,
         foreign_film_home_countries=foreign_film_home_countries,
+        reranker=reranker,
     )
 
 
@@ -1318,3 +1324,27 @@ class TestSearchResponseMetadata:
         assert result.filtered_count == 0
         # total_candidates still reports the raw vector-search count.
         assert result.total_candidates == 3
+
+
+# --- Spec 29 — reranker optional collaborator (inert wiring) ---
+
+
+class _StubReranker:
+    """Minimal RerankerProtocol impl for wiring tests (no torch)."""
+
+    def rerank(self, query: str, candidates: list[tuple[str, str]]) -> list[str]:
+        return [jid for jid, _doc in candidates]
+
+
+def test_reranker_defaults_to_none() -> None:
+    """SearchService constructs without a reranker; the property is None."""
+    service = _make_service()
+    assert service.reranker is None
+
+
+def test_reranker_is_exposed_when_injected() -> None:
+    """An injected reranker is exposed via the read-only property (mirrors
+    person_index), so the eval harness can introspect it."""
+    stub = _StubReranker()
+    service = _make_service(reranker=stub)
+    assert service.reranker is stub

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -1491,7 +1491,7 @@ async def test_rerank_timeout_falls_back_to_genre_heuristic() -> None:
     reranker = _CapturingReranker(reorder=_slow)
     service = _ordering_service(reranker, pool_size=3, n=5)
     # 50ms deadline << 500ms scorer sleep.
-    service._rerank_timeout_ms = 50  # type: ignore[attr-defined]
+    service._rerank_timeout_s = 0.05  # type: ignore[attr-defined]
 
     ticks = 0
 

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -10,6 +10,8 @@ from app.search.service import SearchService
 from tests.factories import make_embedding_result, make_library_item, make_search_result
 
 if TYPE_CHECKING:
+    import pytest
+
     from app.search.reranker import RerankerProtocol
 
 
@@ -27,6 +29,8 @@ def _make_service(
     rewriter: AsyncMock | None = None,
     foreign_film_home_countries: list[str] | None = None,
     reranker: RerankerProtocol | None = None,
+    rerank_pool_size: int = 100,
+    rerank_timeout_ms: int = 5000,
 ) -> SearchService:
     """Build a SearchService with mocked dependencies.
 
@@ -66,6 +70,8 @@ def _make_service(
         rewriter=rewriter,
         foreign_film_home_countries=foreign_film_home_countries,
         reranker=reranker,
+        rerank_pool_size=rerank_pool_size,
+        rerank_timeout_ms=rerank_timeout_ms,
     )
 
 
@@ -1348,3 +1354,190 @@ def test_reranker_is_exposed_when_injected() -> None:
     stub = _StubReranker()
     service = _make_service(reranker=stub)
     assert service.reranker is stub
+
+
+# --- Spec 29 — live bounded rerank + safe degradation (flag ON) ---
+
+
+class _CapturingReranker:
+    """A reranker stub that records the candidates it was given and reorders
+    them via an injectable rule (default: identity)."""
+
+    def __init__(self, reorder=None, *, raises: Exception | None = None) -> None:
+        self.calls: list[tuple[str, list[tuple[str, str]]]] = []
+        self._reorder = reorder
+        self._raises = raises
+
+    def rerank(self, query: str, candidates: list[tuple[str, str]]) -> list[str]:
+        self.calls.append((query, list(candidates)))
+        if self._raises is not None:
+            raise self._raises
+        if self._reorder is not None:
+            return self._reorder(list(candidates))
+        return [jid for jid, _doc in candidates]
+
+
+def _ordering_service(reranker, *, pool_size=100, n=5):
+    """Build a SearchService whose pipeline yields ``n`` cosine-ordered,
+    permitted candidates m0..m(n-1), wired to ``reranker``."""
+    ollama = AsyncMock()
+    ollama.embed.return_value = make_embedding_result()
+    vec_repo = AsyncMock()
+    vec_repo.count.return_value = 100
+    vec_repo.search.return_value = [
+        make_search_result(f"m{i}", 0.9 - i * 0.1) for i in range(n)
+    ]
+    permissions = AsyncMock()
+    permissions.filter_permitted.return_value = [f"m{i}" for i in range(n)]
+    library = AsyncMock()
+    library.get_many.return_value = [
+        make_library_item(f"m{i}", f"Title{i}") for i in range(n)
+    ]
+    library.get_queue_counts.return_value = {"pending": 0, "processing": 0, "failed": 0}
+    library.search_filtered_ids = AsyncMock(return_value=None)
+    return _make_service(
+        ollama=ollama,
+        vec_repo=vec_repo,
+        permissions=permissions,
+        library=library,
+        reranker=reranker,
+        rerank_pool_size=pool_size,
+    )
+
+
+async def test_live_rerank_bounds_pool_and_keeps_cosine_tail() -> None:
+    """With the flag ON: only the top-``pool_size`` cosine candidates are
+    reranked; the tail keeps cosine order and is appended after the reordered
+    pool; ``[:limit]`` applies last."""
+
+    def _reverse(cands: list[tuple[str, str]]) -> list[str]:
+        return [jid for jid, _doc in reversed(cands)]
+
+    reranker = _CapturingReranker(reorder=_reverse)
+    service = _ordering_service(reranker, pool_size=3, n=5)
+
+    result = await service.search("aliens", limit=5, user_id="u1", token="tok")
+
+    # pool = [m0,m1,m2] reversed -> [m2,m1,m0]; tail = [m3,m4] cosine-ordered.
+    assert [r.jellyfin_id for r in result.results] == ["m2", "m1", "m0", "m3", "m4"]
+    # Only the top-3 were handed to the reranker (bounded pool).
+    assert len(reranker.calls) == 1
+    passed_ids = [jid for jid, _doc in reranker.calls[0][1]]
+    assert passed_ids == ["m0", "m1", "m2"]
+
+
+async def test_live_rerank_document_text_uses_build_sections_without_prefix() -> None:
+    """The document side reuses the composite template (``build_sections``)
+    minus the nomic ``search_document:`` prefix."""
+    reranker = _CapturingReranker()
+    service = _ordering_service(reranker, pool_size=10, n=2)
+
+    await service.search("q", limit=10, user_id="u1", token="tok")
+
+    docs = [doc for _jid, doc in reranker.calls[0][1]]
+    assert docs, "reranker received no candidates"
+    for doc in docs:
+        assert not doc.startswith("search_document:")
+    # build_sections emits the title; confirm the real composite text flows through.
+    assert any("Title0" in doc for doc in docs)
+
+
+async def test_rerank_replaces_genre_heuristic_when_enabled() -> None:
+    """When the reranker is ON, ``_rerank_by_genre`` is NOT called (replace,
+    not layer)."""
+    from unittest.mock import patch
+
+    reranker = _CapturingReranker()
+    service = _ordering_service(reranker, n=4)
+
+    with patch.object(
+        SearchService, "_rerank_by_genre", wraps=SearchService._rerank_by_genre
+    ) as spy:
+        await service.search("q", limit=10, user_id="u1", token="tok")
+
+    spy.assert_not_called()
+
+
+async def test_genre_heuristic_used_when_reranker_absent() -> None:
+    """Sanity: with no reranker, ``_rerank_by_genre`` IS the ordering path."""
+    from unittest.mock import patch
+
+    service = _ordering_service(None, n=4)
+
+    with patch.object(
+        SearchService, "_rerank_by_genre", wraps=SearchService._rerank_by_genre
+    ) as spy:
+        await service.search("q", limit=10, user_id="u1", token="tok")
+
+    spy.assert_called_once()
+
+
+async def test_rerank_timeout_falls_back_to_genre_heuristic() -> None:
+    """A reranker slower than the deadline raises TimeoutError internally; the
+    search degrades to the genre-heuristic ordering and still returns results,
+    without blocking the event loop."""
+    import asyncio
+
+    def _slow(_cands: list[tuple[str, str]]) -> list[str]:
+        # Block the worker thread past the deadline. Runs in a thread (via
+        # asyncio.to_thread), so a concurrent event-loop probe must still tick.
+        import time
+
+        time.sleep(0.5)
+        return []
+
+    reranker = _CapturingReranker(reorder=_slow)
+    service = _ordering_service(reranker, pool_size=3, n=5)
+    # 50ms deadline << 500ms scorer sleep.
+    service._rerank_timeout_ms = 50  # type: ignore[attr-defined]
+
+    ticks = 0
+
+    async def _probe() -> None:
+        nonlocal ticks
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    probe = asyncio.create_task(_probe())
+    result = await service.search("q", limit=5, user_id="u1", token="tok")
+    await probe
+
+    # Fell back to cosine/genre ordering (all 5, original order — no rerank).
+    assert [r.jellyfin_id for r in result.results] == ["m0", "m1", "m2", "m3", "m4"]
+    # The event loop kept ticking while the rerank thread was blocked.
+    assert ticks >= 5
+
+
+async def test_rerank_error_falls_back_to_genre_heuristic() -> None:
+    """Any reranker exception degrades to the genre-heuristic ordering."""
+    reranker = _CapturingReranker(raises=RuntimeError("model exploded"))
+    service = _ordering_service(reranker, pool_size=3, n=5)
+
+    result = await service.search("q", limit=5, user_id="u1", token="tok")
+
+    assert [r.jellyfin_id for r in result.results] == ["m0", "m1", "m2", "m3", "m4"]
+
+
+async def test_rerank_failure_logs_without_pii(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The fallback warning is count/index-keyed and contains no query or
+    document text (PII constraint)."""
+    import logging
+
+    reranker = _CapturingReranker(raises=RuntimeError("boom: secret query leaked?"))
+    service = _ordering_service(reranker, pool_size=3, n=5)
+
+    with caplog.at_level(logging.WARNING):
+        await service.search(
+            "my private late-night query", limit=5, user_id="u1", token="tok"
+        )
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("rerank" in m.lower() for m in warnings), "expected a rerank warning"
+    blob = "\n".join(warnings)
+    assert "my private late-night query" not in blob
+    assert "Title0" not in blob
+    # The exception's own message must not be interpolated verbatim either.
+    assert "secret query leaked" not in blob

--- a/backend/tests/test_search_service.py
+++ b/backend/tests/test_search_service.py
@@ -10,6 +10,8 @@ from app.search.service import SearchService
 from tests.factories import make_embedding_result, make_library_item, make_search_result
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     import pytest
 
     from app.search.reranker import RerankerProtocol
@@ -1338,7 +1340,7 @@ class TestSearchResponseMetadata:
 class _StubReranker:
     """Minimal RerankerProtocol impl for wiring tests (no torch)."""
 
-    def rerank(self, query: str, candidates: list[tuple[str, str]]) -> list[str]:
+    def rerank(self, query: str, candidates: Sequence[tuple[str, str]]) -> list[str]:
         return [jid for jid, _doc in candidates]
 
 
@@ -1368,7 +1370,7 @@ class _CapturingReranker:
         self._reorder = reorder
         self._raises = raises
 
-    def rerank(self, query: str, candidates: list[tuple[str, str]]) -> list[str]:
+    def rerank(self, query: str, candidates: Sequence[tuple[str, str]]) -> list[str]:
         self.calls.append((query, list(candidates)))
         if self._raises is not None:
             raise self._raises

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -36,7 +36,7 @@ dev = [
     { name = "ranx" },
     { name = "ruff" },
 ]
-spike = [
+rerank = [
     { name = "sentence-transformers" },
 ]
 
@@ -55,12 +55,12 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "ranx", marker = "extra == 'dev'", specifier = ">=0.3.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
-    { name = "sentence-transformers", marker = "extra == 'spike'", specifier = ">=3.0,<4.0" },
+    { name = "sentence-transformers", marker = "extra == 'rerank'", specifier = ">=3.0,<4.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlite-vec", specifier = "==0.1.6" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
-provides-extras = ["dev", "spike"]
+provides-extras = ["dev", "rerank"]
 
 [[package]]
 name = "aiosqlite"

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -35,6 +35,7 @@ ROOT = Path(__file__).resolve().parents[1]
 BACKEND = ROOT / "backend"
 sys.path.insert(0, str(BACKEND))
 
+from app.config import Settings  # noqa: E402
 from app.library.store import LibraryStore  # noqa: E402
 from app.ollama.chat_client import OllamaChatClient  # noqa: E402
 from app.ollama.client import OllamaEmbeddingClient  # noqa: E402
@@ -219,17 +220,20 @@ def main() -> None:
         help="Engage the Spec 29 cross-encoder reranker (requires the 'rerank' "
         "extra). Off by default; matches the SEARCH_RERANK_ENABLED flag.",
     )
+    # Defaults sourced from the Settings field defaults so the script can't
+    # drift from config.py.
+    _fields = Settings.model_fields
     parser.add_argument(
         "--rerank-pool-size",
         type=int,
-        default=100,
-        help="Top-N cosine candidates the reranker re-scores (default: 100).",
+        default=_fields["search_rerank_pool_size"].default,
+        help="Top-N cosine candidates the reranker re-scores.",
     )
     parser.add_argument(
         "--rerank-timeout-ms",
         type=int,
-        default=5000,
-        help="Per-query rerank deadline in ms (default: 5000).",
+        default=_fields["search_rerank_timeout_ms"].default,
+        help="Per-query rerank deadline in ms.",
     )
     args = parser.parse_args()
     sys.exit(asyncio.run(_amain(args)))

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -89,6 +90,15 @@ async def _amain(args: argparse.Namespace) -> int:
             )
             permissions = AsyncMock()
             permissions.filter_permitted.side_effect = lambda *a, **_kw: a[2]
+            reranker = None
+            if args.rerank:
+                from app.search.reranker import CrossEncoderReranker
+
+                reranker = CrossEncoderReranker()
+                print(
+                    f"Cross-encoder reranking ON (pool={args.rerank_pool_size}, "
+                    f"timeout={args.rerank_timeout_ms}ms)\n"
+                )
             service = SearchService(
                 ollama_client=embed_client,
                 vec_repo=repo,
@@ -96,14 +106,33 @@ async def _amain(args: argparse.Namespace) -> int:
                 library_store=store,
                 person_index=person_index,
                 rewriter=rewriter,
+                reranker=reranker,
+                rerank_pool_size=args.rerank_pool_size,
+                rerank_timeout_ms=args.rerank_timeout_ms,
             )
 
             ranked: dict[str, list[str]] = {}
+            search_elapsed: list[float] = []
             for case in cases:
+                _t0 = time.perf_counter()
                 response = await service.search(
                     case.query, limit=max(args.ks), user_id="eval", token="eval-token"
                 )
+                search_elapsed.append(time.perf_counter() - _t0)
                 ranked[case.query] = [r.jellyfin_id for r in response.results]
+
+            if args.rerank and search_elapsed:
+                ordered = sorted(search_elapsed)
+                p50 = ordered[len(ordered) // 2]
+                p95 = ordered[min(len(ordered) - 1, int(len(ordered) * 0.95))]
+                # Informational only — NOT a gate. Whole-search wall-time
+                # (rerank-dominated for filtered queries); grounds the
+                # SEARCH_RERANK_TIMEOUT_MS default. Real-hardware p95 is Spec 30.
+                print(
+                    f"[informational] search wall-time incl. rerank over "
+                    f"{len(search_elapsed)} queries: p50={p50 * 1000:.0f}ms "
+                    f"p95={p95 * 1000:.0f}ms (not a gate)\n"
+                )
 
             title_index = await store.get_title_index()
             outcome = evaluate(
@@ -174,6 +203,24 @@ def main() -> None:
         "--update-baseline",
         action="store_true",
         help="Append the current gated scores as a new baseline record.",
+    )
+    parser.add_argument(
+        "--rerank",
+        action="store_true",
+        help="Engage the Spec 29 cross-encoder reranker (requires the 'rerank' "
+        "extra). Off by default; matches the SEARCH_RERANK_ENABLED flag.",
+    )
+    parser.add_argument(
+        "--rerank-pool-size",
+        type=int,
+        default=100,
+        help="Top-N cosine candidates the reranker re-scores (default: 100).",
+    )
+    parser.add_argument(
+        "--rerank-timeout-ms",
+        type=int,
+        default=5000,
+        help="Per-query rerank deadline in ms (default: 5000).",
     )
     args = parser.parse_args()
     sys.exit(asyncio.run(_amain(args)))

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import importlib.util
 import sys
 import time
 from datetime import UTC, datetime
@@ -61,6 +62,13 @@ _BASELINE_PATH = str(BACKEND / "tests" / "fixtures" / "eval_baseline.json")
 
 
 async def _amain(args: argparse.Namespace) -> int:
+    if args.rerank and importlib.util.find_spec("sentence_transformers") is None:
+        print(
+            "ERROR: --rerank requires the optional 'rerank' extra "
+            "(it is not installed). Install with: uv sync --extra rerank",
+            file=sys.stderr,
+        )
+        return 1
     cases = load_golden_set()
     print(f"Loaded {len(cases)} golden cases; scoring against {args.db}\n")
 

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -122,9 +122,18 @@ async def _amain(args: argparse.Namespace) -> int:
                 ranked[case.query] = [r.jellyfin_id for r in response.results]
 
             if args.rerank and search_elapsed:
-                ordered = sorted(search_elapsed)
-                p50 = ordered[len(ordered) // 2]
-                p95 = ordered[min(len(ordered) - 1, int(len(ordered) * 0.95))]
+
+                def _pct(values: list[float], p: float) -> float:
+                    # Linear interpolation between closest ranks (numpy-style),
+                    # so small samples don't snap p95 to the max.
+                    s = sorted(values)
+                    k = (len(s) - 1) * p
+                    lo = int(k)
+                    hi = min(lo + 1, len(s) - 1)
+                    return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+                p50 = _pct(search_elapsed, 0.50)
+                p95 = _pct(search_elapsed, 0.95)
                 # Informational only — NOT a gate. Whole-search wall-time
                 # (rerank-dominated for filtered queries); grounds the
                 # SEARCH_RERANK_TIMEOUT_MS default. Real-hardware p95 is Spec 30.


### PR DESCRIPTION
Implements bounded cross-encoder reranking behind a default-OFF flag — the ADOPT follow-up to the #253 spike (Spec 28). Resolves the **first half** of #276; the ONNX/torch-free runtime + real-hardware CPU measurement + default-flip are deliberately split out to a follow-up (spec 30).

## What this ships (Spec 29)

- **Config + opt-in dependency** — `SEARCH_RERANK_ENABLED` (default **false**), `SEARCH_RERANK_POOL_SIZE` (100), `SEARCH_RERANK_TIMEOUT_MS` (5000). `sentence-transformers` moved to an opt-in `rerank` extra, so the **default install + Docker image stay torch-free** (verified: default `uv export` pulls no torch; an AST import-isolation guard fails if torch is imported at module load under `app/`).
- **Reranker module** — `RerankerProtocol` + pure `reorder_by_scores` + `CrossEncoderReranker` (`ms-marco-MiniLM-L-6-v2`, pinned by commit SHA, **safetensors** via `automodel_args`, lazy import, in-code HF offline/telemetry guards).
- **Live bounded path** — when enabled, caps the top-N cosine candidates, scores them **off the event loop** (`asyncio.to_thread` + `asyncio.wait_for`), reorders (tail keeps cosine order), `[:limit]`. **Replaces** the genre heuristic when ON; keeps it as the flag-OFF path. On timeout or any reranker error → **degrades to the heuristic** (no hang, no raise, no PII in logs).
- **Eval harness wiring** — flag-driven reranker in the pytest fixture + `eval_retrieval.py --rerank`, plus an informational wall-time line.

## Results (honest)

The spec gate **passes**: rerank ON reproduces **NDCG@10 = 0.584 (all) / 0.656 (gated)** through the production path (≥ 0.55 floor, ≈ the spike's 0.59).

**But** — the spike's headline **+0.253** was over a *bare* pool. On the **full production pipeline** (Spec 24 rewriter + router already doing the work), the lift collapses to **~+0.024 gated / slightly negative all-cases** (single run, rewriter-confounded, inconclusive). This **validates shipping default-OFF** and makes spec 30's rigorous, isolated, real-hardware measurement essential *before* any default flip — it may well conclude "don't flip." Feeds #268 (LLM selection-quality eval).

## Safety / Council vetoes (all held)

- **Default OFF** — flag is the rollback; OFF = today's exact pipeline (no-op by construction).
- **torch-free default** (Havelock) — opt-in extra + AST guard test.
- **No runtime model download / telemetry** (Angua) — in-code offline guards, SHA + safetensors pinning. (Build-time weight bake + `--network none` verification transfer to spec 30, where the default could flip on.)
- **Safe degradation** (Havelock) — off-loop timeout → heuristic fallback, proven not to block the event loop.

## Tests

TDD throughout. New unit tests for the reranker module, the optional-collaborator wiring, the live bounded path, timeout/error fallback (incl. event-loop-not-blocked), and no-PII logging. Full unit suite green (1137 passed; the 5 skips/failures in a local run were live-Ollama tests with Ollama down — pass in CI). ruff + pyright clean.

## Not in this PR (→ spec 30)

ONNX/onnxruntime torch-free runtime; build-time weight bake + network-isolation verification; real-hardware CPU p95 under concurrency; the default flip. Tracked in the spec's Open Questions.

Related to #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)