### PR TITLE
chore: prune over-engineering — dead scaffolding + 2 deps (#283)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -89,7 +89,7 @@ class Settings(BaseSettings):
     wal_checkpoint_threshold_mb: float = 50.0
 
     # Embedding worker
-    embedding_batch_size: int = 5
+    embedding_batch_size: Annotated[int, Field(ge=1, le=50)] = 5
     embedding_worker_interval_seconds: int = 300
     embedding_max_retries: int = 3
     embedding_cooldown_seconds: int = 300
@@ -184,14 +184,6 @@ class Settings(BaseSettings):
     conversation_ttl_minutes: Annotated[int, Field(ge=1)] = 120
     conversation_max_sessions: Annotated[int, Field(ge=1)] = 100
     conversation_context_budget: Annotated[int, Field(ge=100)] = 6000
-
-    @model_validator(mode="after")
-    def _validate_embedding_batch_size(self) -> Settings:
-        """Reject embedding_batch_size outside the 1–50 range."""
-        if self.embedding_batch_size < 1 or self.embedding_batch_size > 50:
-            msg = "EMBEDDING_BATCH_SIZE must be between 1 and 50"
-            raise ValueError(msg)
-        return self
 
     @model_validator(mode="after")
     def _validate_jellyfin_api_key(self) -> Settings:

--- a/backend/app/middleware/csrf.py
+++ b/backend/app/middleware/csrf.py
@@ -19,11 +19,6 @@ if TYPE_CHECKING:
 _EXEMPT_PATHS = {"/api/auth/login"}
 _STATE_CHANGING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
-_CSRF_REJECT = JSONResponse(
-    status_code=403,
-    content={"detail": "CSRF token missing or invalid"},
-)
-
 
 class CSRFMiddleware(BaseHTTPMiddleware):
     """Validates CSRF token on state-changing requests."""

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,8 +10,6 @@
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@radix-ui/react-dialog": "^1.1.15",
-        "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
         "lucide-react": "^1.7.0",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -5160,18 +5158,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/class-variance-authority": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
-      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "funding": {
-        "url": "https://polar.sh/cva"
-      }
-    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -5275,15 +5261,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/code-block-writer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,8 +18,6 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@radix-ui/react-dialog": "^1.1.15",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
     "next": "16.1.6",
     "react": "19.2.3",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -69,19 +69,6 @@ body {
 @theme inline {
   --font-heading: var(--font-sans);
   --font-sans: var(--font-sans);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -128,20 +115,7 @@ body {
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
   --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
@@ -163,19 +137,6 @@ body {
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {

--- a/frontend/src/components/chat/poster-placeholder.tsx
+++ b/frontend/src/components/chat/poster-placeholder.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Film } from "lucide-react";
 import { cn } from "@/lib/utils";
 

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,60 +1,63 @@
 "use client";
 
 import { Button as ButtonPrimitive } from "@base-ui/react/button";
-import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
-const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-        outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
-        destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
-        icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-);
+const buttonBase =
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4";
+
+const buttonVariant = {
+  default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+  outline:
+    "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+  secondary:
+    "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+  ghost:
+    "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+  destructive:
+    "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+  link: "text-primary underline-offset-4 hover:underline",
+} as const;
+
+const buttonSize = {
+  default:
+    "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+  xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+  sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+  lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+  icon: "size-8",
+  "icon-xs":
+    "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+  "icon-sm":
+    "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+  "icon-lg": "size-9",
+} as const;
 
 function Button({
   className,
   variant = "default",
   size = "default",
   ...props
-}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+}: Omit<ButtonPrimitive.Props, "className"> & {
+  // String-only: every call site passes a string, and merging variant classes
+  // with base-ui's state-function className form is a capability no caller uses.
+  className?: string;
+  variant?: keyof typeof buttonVariant;
+  size?: keyof typeof buttonSize;
+}) {
   return (
     <ButtonPrimitive
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(
+        buttonBase,
+        buttonVariant[variant],
+        buttonSize[size],
+        className
+      )}
       {...props}
     />
   );
 }
 
-export { Button, buttonVariants };
+export { Button };

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -56,19 +56,6 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-action"
-      className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
-      )}
-      {...props}
-    />
-  );
-}
-
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -79,25 +66,4 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-footer"
-      className={cn(
-        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
-        className
-      )}
-      {...props}
-    />
-  );
-}
-
-export {
-  Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
-  CardAction,
-  CardDescription,
-  CardContent,
-};
+export { Card, CardHeader, CardTitle, CardDescription, CardContent };

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -6,9 +6,7 @@ import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const Dialog = DialogPrimitive.Root;
-const DialogTrigger = DialogPrimitive.Trigger;
 const DialogPortal = DialogPrimitive.Portal;
-const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Overlay>,
@@ -93,14 +91,4 @@ const DialogDescription = React.forwardRef<
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
-export {
-  Dialog,
-  DialogPortal,
-  DialogOverlay,
-  DialogClose,
-  DialogTrigger,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-};
+export { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription };

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,5 @@
-import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+// All call sites pass plain class strings (no clsx conditional-object syntax),
+// so twMerge alone covers merge + dedupe — clsx was redundant indirection.
+export const cn = twMerge;


### PR DESCRIPTION
Acts on the ponytail-audit findings in #283. Scope: **over-engineering only**, no behaviour change. Five focused commits; tests + lint green throughout.

## What's cut (~135 lines + 2 frontend deps)

**Group A — dead code / scaffolding**
- `cf1e38b` remove unused `--sidebar-*` / `--chart-[1-5]` CSS custom properties (zero references across 35 components; shadcn-init residue)
- `73a12ee` drop unused `CardAction`/`CardFooter` + `Dialog{Portal,Overlay,Close,Trigger}` exports; make `label.tsx` + `poster-placeholder.tsx` server components (no hooks/browser APIs)
- `4153542` remove unused `_CSRF_REJECT` constant (the inline `JSONResponse` returns are correct — reusing one Starlette Response across requests would be a latent bug)
- `590e722` bound `embedding_batch_size` via `Annotated[int, Field(ge=1, le=50)]`, drop the redundant hand-rolled `@model_validator`

**Group B — dependency removals**
- `c870801` drop `class-variance-authority` (inline button variant/size maps — type-safe via `keyof typeof`, zero external consumers) and `clsx` (`cn = twMerge`; no call site uses the conditional-object form). Verified: tsc clean, **production build succeeds** without either dep, 214 tests pass.

## Deliberately NOT done (with reasoning)

- **Ollama `health()` dedup** (audit Group B): evaluated and skipped. `OllamaChatClient.health()` is unused in prod but has 5 dedicated tests; deduping adds a shared module + couples two *deliberately-separate* clients, deleting removes a symmetric capability. ~10 lines of trivial, stable, tested code — the cure costs more than the duplication.
- **Group C polish** (marginal shrinks): skipped to keep this PR tight on the clear wins.
- **`effective_jellyfin_web_url` / `library/text_builder.py` shim**: kept — one documents a deliberate decision, the other may be an intentional domain boundary (confirm-intent, not reflex-delete).
- **CSRF cookie `split("=")` truncation** (`lib/api/shared.ts`): a *correctness* concern, not over-engineering — routed out of this chore for separate verification, per #283.

## Verification
- Backend: `pyright` 0 errors, `ruff check/format` clean, 1148 unit tests pass.
- Frontend: `tsc` clean, `eslint` clean (2 pre-existing `<img>` warnings, untouched), 214 tests pass, `next build` succeeds.

Closes #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)