### PR TITLE
chore: gitignore Claude Code local config + agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ coverage/
 
 # SDD workflow artifacts — point-in-time, kept locally only
 docs/specs/
+
+# Claude Code — local-only config + agent worktrees (never commit).
+# Scoped (not all of .claude/) so shared config could be committed later if wanted.
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
`.claude/` was untracked but **not** gitignored — one stray `git add .` away from committing `settings.local.json` (personal config) and `.claude/worktrees/` (agent git-worktree checkouts — tens of thousands of files).

Scoped ignore (not blanket `.claude/`) so shared config (`settings.json`, commands, skills) could still be committed later if wanted:

```
.claude/settings.local.json
.claude/worktrees/
```

Verified: `git status` no longer lists `.claude/`; `git check-ignore` confirms both paths; `git add .` no longer stages them. No tracked files affected (nothing under `.claude/` was ever committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)